### PR TITLE
Improve UX for MemViewer and better code flexibility

### DIFF
--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -44,19 +44,7 @@ MemViewer::~MemViewer()
 
 void MemViewer::initialise()
 {
-#ifdef __linux__
-  setFont(QFont("Monospace", 10));
-#elif _WIN32
-  setFont(QFont("Courier New", 10));
-#endif
-
-  m_charWidthEm = fontMetrics().width(QLatin1Char('M'));
-  m_charHeight = fontMetrics().height();
-  m_hexAreaWidth = VISIBLE_COLS * (m_charWidthEm * 2 + m_charWidthEm / 2);
-  m_hexAreaHeight = VISIBLE_ROWS * m_charHeight;
-  m_rowHeaderWidth = m_charWidthEm * (sizeof(u32) * 2 + 1) + m_charWidthEm / 2;
-  m_hexAsciiSeparatorPosX = m_rowHeaderWidth + m_hexAreaWidth;
-  m_columnHeaderHeight = m_charHeight + m_charWidthEm / 2;
+  updateFontSize(m_memoryFontSize);
   m_curosrRect = new QRect();
   m_updatedRawMemoryData = new char[NUM_BYTES];
   m_lastRawMemoryData = new char[NUM_BYTES];
@@ -176,6 +164,42 @@ void MemViewer::mousePressEvent(QMouseEvent* event)
   m_byteSelectedPosY = clickedPosY;
 
   viewport()->update();
+}
+
+void MemViewer::wheelEvent(QWheelEvent* event)
+{
+  if (event->modifiers().testFlag(Qt::ControlModifier))
+  {
+    if (event->delta() < 0 && m_memoryFontSize > 5)
+      updateFontSize(m_memoryFontSize - 1);
+    else if (event->delta() > 0)
+      updateFontSize(m_memoryFontSize + 1);
+
+    viewport()->update();
+  }
+  else
+  {
+    QAbstractScrollArea::wheelEvent(event);
+  }
+}
+
+void MemViewer::updateFontSize(int newSize)
+{
+  m_memoryFontSize = newSize;
+
+#ifdef __linux__
+  setFont(QFont("Monospace", m_memoryFontSize));
+#elif _WIN32
+  setFont(QFont("Courier New", m_memoryFontSize));
+#endif
+
+  m_charWidthEm = fontMetrics().width(QLatin1Char('M'));
+  m_charHeight = fontMetrics().height();
+  m_hexAreaWidth = VISIBLE_COLS * (m_charWidthEm * 2 + m_charWidthEm / 2);
+  m_hexAreaHeight = VISIBLE_ROWS * m_charHeight;
+  m_rowHeaderWidth = m_charWidthEm * (sizeof(u32) * 2 + 1) + m_charWidthEm / 2;
+  m_hexAsciiSeparatorPosX = m_rowHeaderWidth + m_hexAreaWidth;
+  m_columnHeaderHeight = m_charHeight + m_charWidthEm / 2;
 }
 
 bool MemViewer::handleNaviguationKey(const int key)

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -35,6 +35,7 @@ private:
   void initialise();
 
   void updateFontSize(int newSize);
+  void scrollToSelection();
   bool handleNaviguationKey(const int key);
   bool writeCharacterToSelectedMemory(char byteToWrite);
   void updateMemoryData();
@@ -51,6 +52,9 @@ private:
   void determineMemoryTextRenderProperties(const int rowIndex, const int columnIndex,
                                            bool& drawCarret, QColor& bgColor, QColor& fgColor);
 
+  const int m_numRows = 16;
+  const int m_numColumns = 16; // Should be a multiple of 16, or the header doesn't make much sense
+  const int m_numCells = m_numRows * m_numColumns;
   int m_memoryFontSize = 15;
   int m_byteSelectedPosX = -1;
   int m_byteSelectedPosY = -1;

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -34,7 +34,7 @@ private:
   void initialise();
 
   bool handleNaviguationKey(const int key);
-  bool writeHexCharacterToSelectedMemory(const std::string hexCharToWrite);
+  bool writeCharacterToSelectedMemory(char byteToWrite);
   void updateMemoryData();
   void changeMemoryRegion(const bool isMEM2);
   void renderColumnsHeaderText(QPainter& painter);
@@ -61,6 +61,7 @@ private:
   char* m_updatedRawMemoryData = nullptr;
   char* m_lastRawMemoryData = nullptr;
   int* m_memoryMsElapsedLastChange = nullptr;
+  bool m_editingHex = false;
   bool m_carretBetweenHex = false;
   bool m_disableScrollContentEvent = false;
   bool m_validMemory = false;
@@ -68,6 +69,5 @@ private:
   u32 m_memViewStart = 0;
   u32 m_memViewEnd = 0;
   QRect* m_curosrRect;
-  QList<int> m_hexKeyList;
   QElapsedTimer m_elapsedTimer;
 };

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -19,6 +19,7 @@ public:
   ~MemViewer();
   QSize sizeHint() const override;
   void mousePressEvent(QMouseEvent* event) override;
+  void wheelEvent(QWheelEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
   void paintEvent(QPaintEvent* event) override;
   void scrollContentsBy(int dx, int dy) override;
@@ -33,6 +34,7 @@ signals:
 private:
   void initialise();
 
+  void updateFontSize(int newSize);
   bool handleNaviguationKey(const int key);
   bool writeCharacterToSelectedMemory(char byteToWrite);
   void updateMemoryData();
@@ -49,6 +51,7 @@ private:
   void determineMemoryTextRenderProperties(const int rowIndex, const int columnIndex,
                                            bool& drawCarret, QColor& bgColor, QColor& fgColor);
 
+  int m_memoryFontSize = 15;
   int m_byteSelectedPosX = -1;
   int m_byteSelectedPosY = -1;
   int m_charWidthEm = 0;


### PR DESCRIPTION
I originalle started with the idea to add a "Right-click Hex -> Add To Watch" option, but found a lot of other things that could be improved first 😄

Copied from the commit:
1. Use smaller font
2. The Home and End keys jumps to and selects the first and last byte respectively
3. Fix calculation error when setting scrollbar upon pressing End
4. Always set `m_carretBetweenHex` to false when navigating using the keyboard
5. Fix selection jumping when pressing Left or Right when at the edges of the row
6. Refactor to use defines for number of rows, columns and bytes shown
7. Add support for clicking the ASCII table and typing in it
8. Refactored `writeHexCharacterToSelectedMemory` to be usable for ASCII too
9. Ignore non-left click events (you could middleclick a value to select it)
10. Play system beep when a non-hex character is edited
11. Update selection coords when scrolling

Some notes to clarify:
1. The smaller font is a personal preference, but since the rest of the UI also doesn't use large text anywhere, I found it unnecessary.
2. Previously they only scrolled to the beginning and end, now they select the bytes too
3. When calculating the range of the scroll area, 1 was subtracted to remove the last row, but it should have subtracted the number of visible rows.
4. no comments
5. Easy to reproduce: Select the very last visible byte in the area, and press Right (or the very first and press left, same efffect). The window nicely scrolled down 1 row, but the selection jumped to the top row (or bottom row when going the opposite direction). Now it selects the correct byte.
6. Can be used to easily change the number of rows for example, perhaps useful to save in a variable later, and should it easier to make the window resizable.
7. The only point that really added new code
8. (in my opinion) a easier to read function too.
9. no comments
10. Only tested on Windows, I assume Qt handles it well for all platforms.
11. Srolling down 3 lines will move the selection up 3 lines, easy as that. Has some calculations for page up/down when near the beginning or end.

Before:
![image](https://user-images.githubusercontent.com/9705046/34922856-95850184-f995-11e7-8c2b-a571496d4b61.png)

After (with extra rows just because):
![image](https://user-images.githubusercontent.com/9705046/34922852-8a53f7e8-f995-11e7-9a83-c4f418ef9a70.png)
