### PR TITLE
Simplify user-facing references to the Wii's extended memory segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ The compiled binaries should be appear in the directory named `build`.
 
 
 ## General usage
-First, open Dolphin and start a game, then run this program. Make sure that it reports that the Wii-only extra memory is present for Wii games and absent for GameCube games.
+First, open Dolphin and start a game, then run this program. Make sure that it reports that the memory type matches the system being emulated; Wii for Wii games and GameCube for GameCube games.
 
->_Exclusive to the Wii, this is an extra region of memory added as part of the enhancements from the earlier GameCube hardware. Consequently, the presence of this extra memory affects what is considered a valid watch address, as well as what areas of memory the scanner will look though._
+>_Added as part of the enhancements from the earlier GameCube hardware, the Wii has an extra region of memory onboard. Consequently, the presence of this extra memory affects what is a valid watch address and therefore what regions of memory the scanner will look though._
 
 If the hooking process is successful, the UI should be enabled, otherwise, you will need to click the hook button before the program can be of any use.
 

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -193,9 +193,9 @@ void MainWindow::onOpenMemViewerWithAddress(u32 address)
 void MainWindow::updateMem2Status()
 {
   if (DolphinComm::DolphinAccessor::isMEM2Present())
-    m_lblMem2Status->setText("The extended Wii-only memory is present");
+    m_lblMem2Status->setText("Memory type: Wii");
   else
-    m_lblMem2Status->setText("The extended Wii-only memory is absent");
+    m_lblMem2Status->setText("Memory type: GameCube");
   m_viewer->onMEM2StatusChanged(DolphinComm::DolphinAccessor::isMEM2Present());
 }
 


### PR DESCRIPTION
> “Regardless, I don't think I did a good job on that paragraph. I already have an idea for a much better rewrite.” — Me, on my previous pull request #9  

So here's part two to my idea for a better rewrite as I mentioned to @aldelaro5 before. “Wii-only extra memory” is a mouthful and kinda awkward, so I sought to come up with a better solution on how to refer to it.

Then there's how it's represented in the GUI. The two states are currently presented with longer strings of text that are only 7.69% different; _way_ too easy to misread in my opinion. And so I also set out to improve that situation too.

My end result is this proposal to start calling it the active “memory type”. This makes things short and sweet, but also differentiates the GUI representation much more. Take a look and compare them for yourself:

**Before:**
```
The extended Wii-only memory is present
The extended Wii-only memory is absent
```

**After:**
```
Memory type: Wii
Memory type: GameCube
```

This way the user's attention is drawn more towards the information we want to convey and they are much more unlikely to misread and confuse which state is active. The change also helps streamline the topic of MEM2's presence (or lack thereof) in discussion and consequently in documentation as well.

Instead of saying “make sure the Wii-only extra memory isn't there when you're doing GameCube stuff” one can just say “make sure the memory type matches what you're working with”, _if it's even necessary to tell someone that._ The change should also make it much more intuitive.