### PR TITLE
Remove MFP casts from connect calls

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -50,7 +50,7 @@ void MainWindow::makeMenus()
   connect(m_actImportFromCT, &QAction::triggered, this, &MainWindow::onImportFromCT);
   connect(m_actExportAsCSV, &QAction::triggered, this, &MainWindow::onExportAsCSV);
 
-  connect(m_actViewScanner, static_cast<void (QAction::*)(bool)>(&QAction::toggled), this, [=] {
+  connect(m_actViewScanner, &QAction::toggled, this, [=] {
     if (m_actViewScanner->isChecked())
       m_scanner->show();
     else
@@ -79,30 +79,11 @@ void MainWindow::makeMenus()
 void MainWindow::initialiseWidgets()
 {
   m_scanner = new MemScanWidget(this);
-  connect(m_scanner,
-          static_cast<void (MemScanWidget::*)(u32 address, Common::MemType type, size_t length,
-                                              bool isUnsigned, Common::MemBase base)>(
-              &MemScanWidget::requestAddWatchEntry),
-          this,
-          static_cast<void (MainWindow::*)(u32 address, Common::MemType type, size_t length,
-                                           bool isUnsigned, Common::MemBase base)>(
-              &MainWindow::addWatchRequested));
-  connect(m_scanner,
-          static_cast<void (MemScanWidget::*)(Common::MemType type, size_t length, bool isUnsigned,
-                                              Common::MemBase base)>(
-              &MemScanWidget::requestAddAllResultsToWatchList),
-          this,
-          static_cast<void (MainWindow::*)(Common::MemType type, size_t length, bool isUnsigned,
-                                           Common::MemBase base)>(
-              &MainWindow::addAllResultsToWatchList));
-  connect(m_scanner,
-          static_cast<void (MemScanWidget::*)(Common::MemType type, size_t length, bool isUnsigned,
-                                              Common::MemBase base)>(
-              &MemScanWidget::requestAddSelectedResultsToWatchList),
-          this,
-          static_cast<void (MainWindow::*)(Common::MemType type, size_t length, bool isUnsigned,
-                                           Common::MemBase base)>(
-              &MainWindow::addSelectedResultsToWatchList));
+  connect(m_scanner, &MemScanWidget::requestAddWatchEntry, this, &MainWindow::addWatchRequested);
+  connect(m_scanner, &MemScanWidget::requestAddAllResultsToWatchList, this,
+          &MainWindow::addAllResultsToWatchList);
+  connect(m_scanner, &MemScanWidget::requestAddSelectedResultsToWatchList, this,
+          &MainWindow::addSelectedResultsToWatchList);
 
   m_watcher = new MemWatchWidget(this);
 
@@ -111,10 +92,8 @@ void MainWindow::initialiseWidgets()
 
   m_btnAttempHook = new QPushButton("Hook");
   m_btnUnhook = new QPushButton("Unhook");
-  connect(m_btnAttempHook, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MainWindow::onHookAttempt);
-  connect(m_btnUnhook, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MainWindow::onUnhook);
+  connect(m_btnAttempHook, &QPushButton::clicked, this, &MainWindow::onHookAttempt);
+  connect(m_btnUnhook, &QPushButton::clicked, this, &MainWindow::onUnhook);
 
   m_lblDolphinStatus = new QLabel("");
   m_lblDolphinStatus->setAlignment(Qt::AlignHCenter);
@@ -123,8 +102,7 @@ void MainWindow::initialiseWidgets()
   m_lblMem2Status->setAlignment(Qt::AlignHCenter);
 
   m_btnOpenMemViewer = new QPushButton("Open memory viewer");
-  connect(m_btnOpenMemViewer, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MainWindow::onOpenMenViewer);
+  connect(m_btnOpenMemViewer, &QPushButton::clicked, this, &MainWindow::onOpenMenViewer);
 }
 
 void MainWindow::makeLayouts()
@@ -158,9 +136,8 @@ void MainWindow::makeMemViewer()
 {
   m_viewer = new MemViewerWidget(nullptr, Common::MEM1_START);
   connect(m_viewer, &MemViewerWidget::mustUnhook, this, &MainWindow::onUnhook);
-  connect(m_watcher,
-          static_cast<void (MemWatchWidget::*)(u32)>(&MemWatchWidget::goToAddressInViewer), this,
-          static_cast<void (MainWindow::*)(u32)>(&MainWindow::onOpenMemViewerWithAddress));
+  connect(m_watcher, &MemWatchWidget::goToAddressInViewer, this,
+          &MainWindow::onOpenMemViewerWithAddress);
 }
 
 void MainWindow::firstHookAttempt()

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -39,21 +39,15 @@ void MemScanWidget::initialiseWidgets()
   m_tblResulstList->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_tblResulstList->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_tblResulstList->setMinimumWidth(385);
-  connect(m_tblResulstList,
-          static_cast<void (QAbstractItemView::*)(const QModelIndex&)>(
-              &QAbstractItemView::doubleClicked),
-          this,
-          static_cast<void (MemScanWidget::*)(const QModelIndex&)>(
-              &MemScanWidget::onResultListDoubleClicked));
+  connect(m_tblResulstList, &QAbstractItemView::doubleClicked, this,
+          &MemScanWidget::onResultListDoubleClicked);
 
   m_btnAddAll = new QPushButton("Add all");
-  connect(m_btnAddAll, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemScanWidget::onAddAll);
+  connect(m_btnAddAll, &QPushButton::clicked, this, &MemScanWidget::onAddAll);
   m_btnAddAll->setEnabled(false);
 
   m_btnAddSelection = new QPushButton("Add selection");
-  connect(m_btnAddSelection, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemScanWidget::onAddSelection);
+  connect(m_btnAddSelection, &QPushButton::clicked, this, &MemScanWidget::onAddSelection);
   m_btnAddSelection->setEnabled(false);
 
   m_btnFirstScan = new QPushButton("First scan");
@@ -62,12 +56,9 @@ void MemScanWidget::initialiseWidgets()
   m_btnResetScan = new QPushButton("Reset scan");
   m_btnResetScan->hide();
 
-  connect(m_btnFirstScan, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemScanWidget::onFirstScan);
-  connect(m_btnNextScan, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemScanWidget::onNextScan);
-  connect(m_btnResetScan, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemScanWidget::onResetScan);
+  connect(m_btnFirstScan, &QPushButton::clicked, this, &MemScanWidget::onFirstScan);
+  connect(m_btnNextScan, &QPushButton::clicked, this, &MemScanWidget::onNextScan);
+  connect(m_btnResetScan, &QPushButton::clicked, this, &MemScanWidget::onResetScan);
 
   m_txbSearchTerm1 = new QLineEdit();
   m_txbSearchTerm2 = new QLineEdit();
@@ -79,14 +70,14 @@ void MemScanWidget::initialiseWidgets()
   m_cmbScanType = new QComboBox();
   m_cmbScanType->addItems(GUICommon::g_memTypeNames);
   m_cmbScanType->setCurrentIndex(0);
-  connect(m_cmbScanType, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          this, &MemScanWidget::onScanMemTypeChanged);
+  connect(m_cmbScanType, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &MemScanWidget::onScanMemTypeChanged);
   m_variableLengthType = false;
 
   m_cmbScanFilter = new QComboBox();
   updateScanFilterChoices();
-  connect(m_cmbScanFilter, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          this, &MemScanWidget::onScanFilterChanged);
+  connect(m_cmbScanFilter, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &MemScanWidget::onScanFilterChanged);
 
   m_rdbBaseDecimal = new QRadioButton("Decimal");
   m_rdbBaseHexadecimal = new QRadioButton("Hexadecimal");

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -24,11 +24,9 @@ void MemViewerWidget::initialiseWidgets()
   connect(m_txtJumpAddress, &QLineEdit::textChanged, this,
           &MemViewerWidget::onJumpToAddressTextChanged);
   m_btnGoToMEM1Start = new QPushButton("Go to the common RAM");
-  connect(m_btnGoToMEM1Start, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemViewerWidget::onGoToMEM1Start);
+  connect(m_btnGoToMEM1Start, &QPushButton::clicked, this, &MemViewerWidget::onGoToMEM1Start);
   m_btnGoToMEM2Start = new QPushButton("Go to the Wii-only RAM");
-  connect(m_btnGoToMEM2Start, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemViewerWidget::onGoToMEM2Start);
+  connect(m_btnGoToMEM2Start, &QPushButton::clicked, this, &MemViewerWidget::onGoToMEM2Start);
   m_memViewer = new MemViewer(this);
   connect(m_memViewer, &MemViewer::memErrorOccured, this, &MemViewerWidget::mustUnhook);
   m_updateMemoryTimer = new QTimer(this);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -16,9 +16,9 @@ DlgAddWatchEntry::DlgAddWatchEntry(MemWatchEntry* entry)
   fillFields(entry);
 
   // These are connected at the end to avoid triggering the events when initialising.
-  connect(m_cmbTypes, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_cmbTypes, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &DlgAddWatchEntry::onTypeChange);
-  connect(m_spnLength, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+  connect(m_spnLength, QOverload<int>::of(&QSpinBox::valueChanged), this,
           &DlgAddWatchEntry::onLengthChanged);
 }
 
@@ -30,27 +30,24 @@ DlgAddWatchEntry::~DlgAddWatchEntry()
 void DlgAddWatchEntry::initialiseWidgets()
 {
   m_chkBoundToPointer = new QCheckBox("This is a pointer", this);
-  connect(m_chkBoundToPointer, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
-          this, &DlgAddWatchEntry::onIsPointerChanged);
+  connect(m_chkBoundToPointer, &QCheckBox::stateChanged, this,
+          &DlgAddWatchEntry::onIsPointerChanged);
 
   m_lblValuePreview = new QLabel("", this);
 
   m_txbAddress = new QLineEdit(this);
   m_txbAddress->setMaxLength(8);
-  connect(m_txbAddress, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textEdited),
-          this, &DlgAddWatchEntry::onAddressChanged);
+  connect(m_txbAddress, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onAddressChanged);
 
   m_offsetsLayout = new QGridLayout;
 
   m_offsets = QVector<QLineEdit*>();
 
   m_btnAddOffset = new QPushButton("Add offset");
-  connect(m_btnAddOffset, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &DlgAddWatchEntry::addPointerOffset);
+  connect(m_btnAddOffset, &QPushButton::clicked, this, &DlgAddWatchEntry::addPointerOffset);
 
   m_btnRemoveOffset = new QPushButton("Remove offset");
-  connect(m_btnRemoveOffset, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &DlgAddWatchEntry::removePointerOffset);
+  connect(m_btnRemoveOffset, &QPushButton::clicked, this, &DlgAddWatchEntry::removePointerOffset);
 
   m_pointerWidget = new QWidget(this);
 
@@ -188,8 +185,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
         txbOffset->setFixedWidth(100);
         txbOffset->setMaxLength(7);
         txbOffset->setText(QString::fromStdString(ss.str()));
-        connect(txbOffset, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textEdited),
-                this, &DlgAddWatchEntry::onOffsetChanged);
+        connect(txbOffset, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onOffsetChanged);
         m_offsets.append(txbOffset);
         QLabel* lblAddressOfPath = new QLabel();
         lblAddressOfPath->setText(
@@ -224,8 +220,7 @@ void DlgAddWatchEntry::addPointerOffset()
   m_offsetsLayout->addWidget(txbOffset, level, 1);
   m_offsetsLayout->addWidget(lblAddressOfPath, level, 2);
   m_entry->addOffset(0);
-  connect(txbOffset, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textEdited), this,
-          &DlgAddWatchEntry::onOffsetChanged);
+  connect(txbOffset, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onOffsetChanged);
   if (m_entry->getPointerLevel() > 1)
     m_btnRemoveOffset->setEnabled(true);
   else

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -26,7 +26,7 @@ void DlgChangeType::initialiseWidgets()
   m_spnLength->setMinimum(1);
   m_spnLength->setValue(static_cast<int>(m_length));
 
-  connect(m_cmbTypes, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+  connect(m_cmbTypes, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &DlgChangeType::onTypeChange);
 }
 

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -28,8 +28,7 @@ void DlgImportCTFile::initialiseWidgets()
   m_widgetAddressMethod = new QWidget();
 
   m_btnBrowseFiles = new QPushButton("Browse...");
-  connect(m_btnBrowseFiles, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &DlgImportCTFile::onBrowseFiles);
+  connect(m_btnBrowseFiles, &QPushButton::clicked, this, &DlgImportCTFile::onBrowseFiles);
 
   m_groupImportAddressMethod =
       new QGroupBox("Addresses import method (select the option that describes the table)");

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -43,12 +43,7 @@ MemWatchWidget::~MemWatchWidget()
 void MemWatchWidget::initialiseWidgets()
 {
   m_watchModel = new MemWatchModel(this);
-  connect(m_watchModel,
-          static_cast<void (MemWatchModel::*)(const QModelIndex&, Common::MemOperationReturnCode)>(
-              &MemWatchModel::writeFailed),
-          this,
-          static_cast<void (MemWatchWidget::*)(const QModelIndex&, Common::MemOperationReturnCode)>(
-              &MemWatchWidget::onValueWriteError));
+  connect(m_watchModel, &MemWatchModel::writeFailed, this, &MemWatchWidget::onValueWriteError);
   connect(m_watchModel, &MemWatchModel::dropSucceeded, this, &MemWatchWidget::onDropSucceeded);
   connect(m_watchModel, &MemWatchModel::readFailed, this, &MemWatchWidget::mustUnhook);
 
@@ -62,16 +57,10 @@ void MemWatchWidget::initialiseWidgets()
   m_watchView->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_watchView->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_watchView->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(m_watchView,
-          static_cast<void (QWidget::*)(const QPoint&)>(&QWidget::customContextMenuRequested), this,
-          static_cast<void (MemWatchWidget::*)(const QPoint&)>(
-              &MemWatchWidget::onMemWatchContextMenuRequested));
-  connect(m_watchView,
-          static_cast<void (QAbstractItemView::*)(const QModelIndex&)>(
-              &QAbstractItemView::doubleClicked),
-          this,
-          static_cast<void (MemWatchWidget::*)(const QModelIndex&)>(
-              &MemWatchWidget::onWatchDoubleClicked));
+  connect(m_watchView, &QWidget::customContextMenuRequested, this,
+          &MemWatchWidget::onMemWatchContextMenuRequested);
+  connect(m_watchView, &QAbstractItemView::doubleClicked, this,
+          &MemWatchWidget::onWatchDoubleClicked);
   m_watchView->setItemDelegate(m_watchDelegate);
   m_watchView->setSortingEnabled(true);
   m_watchView->setModel(m_watchModel);
@@ -85,12 +74,10 @@ void MemWatchWidget::initialiseWidgets()
   connect(shortcut, &QShortcut::activated, this, &MemWatchWidget::onDeleteSelection);
 
   m_btnAddGroup = new QPushButton("Add group", this);
-  connect(m_btnAddGroup, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemWatchWidget::onAddGroup);
+  connect(m_btnAddGroup, &QPushButton::clicked, this, &MemWatchWidget::onAddGroup);
 
   m_btnAddWatchEntry = new QPushButton("Add watch", this);
-  connect(m_btnAddWatchEntry, static_cast<void (QPushButton::*)(bool)>(&QPushButton::clicked), this,
-          &MemWatchWidget::onAddWatchEntry);
+  connect(m_btnAddWatchEntry, &QPushButton::clicked, this, &MemWatchWidget::onAddWatchEntry);
 
   m_updateTimer = new QTimer(this);
   connect(m_updateTimer, &QTimer::timeout, m_watchModel, &MemWatchModel::onUpdateTimer);


### PR DESCRIPTION
The static_casts are bloating the code, making it unnecessarily hard to read. The templated connect functions from Qt are smart enough to find the correct MFP.

Only when a signal has multiple overloaded possiblilities, the compiler can't select one, but for this Qt has a helper class `QOverload<>`, in which you only have to provide the argument types to let it pick the correct one. Using this rids the code of the return type and duplicated class name you see in static_cast.

C++14 has an even more elegant solution, but I'm not sure if VS2015 supports this, and it would only remove the `::of` part.