### PR TITLE
Apply Qt coding conventions to includes

### DIFF
--- a/Source/CheatEngineParser/CheatEngineParser.h
+++ b/Source/CheatEngineParser/CheatEngineParser.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QFile>
-#include <QString>
-#include <QXmlStreamReader>
+#include <QtCore/QFile>
+#include <QtCore/QString>
+#include <QtCore/QXmlStreamReader>
 
 #include "../MemoryWatch/MemWatchTreeNode.h"
 

--- a/Source/Dolphin-memory-engine.vcxproj
+++ b/Source/Dolphin-memory-engine.vcxproj
@@ -50,7 +50,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QTDIR)include</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -68,7 +68,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(QTDIR)include</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_NO_DEBUG;NDEBUG;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -80,7 +80,6 @@
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-
   <!-- Files and target to copy to the output directory -->
   <PropertyGroup>
     <!--
@@ -102,10 +101,9 @@
   </ItemGroup>
   <Target Name="CopyDlls" AfterTargets="Build">
     <Message Importance="High" Text="Copying required files for $(Configuration)..." />
-    <Message Importance="High" Text="Copying '%(FilesToCopy.FullPath)' -> '$(OutDir)%(FilesToCopy.SubDir)%(Filename)%(Extension)'." />
+    <Message Importance="High" Text="Copying '%(FilesToCopy.FullPath)' -&gt; '$(OutDir)%(FilesToCopy.SubDir)%(Filename)%(Extension)'." />
     <Copy SourceFiles="@(FilesToCopy)" DestinationFiles="$(OutDir)%(FilesToCopy.SubDir)%(Filename)%(Extension)" />
   </Target>
-
   <!-- Files -->
   <ItemGroup>
     <ClCompile Include="**\*.cpp" Exclude="GeneratedFiles\**\*.cpp" />
@@ -130,7 +128,7 @@
   <ItemGroup>
     <!-- All files except for GUICommon need to be Moc'ed -->
     <CustomBuild Include="GUI\**\*.h" Exclude="@(ClInclude)">
-      <Command>"$(QTDIR)bin\moc.exe" "%(FullPath)" -o ".\GeneratedFiles\$(Configuration)\moc_%(Filename).cpp" $(QtMocFlags) "-I." "-I$(QTDIR)include" "-I$(OutDir)GeneratedFiles\$(ConfigurationName)\." "-I$(QTDIR)include\QtCore" "-I$(QTDIR)include\QtGui" "-I$(QTDIR)include\QtWidgets"</Command>
+      <Command>"$(QTDIR)bin\moc.exe" "%(FullPath)" -o ".\GeneratedFiles\$(Configuration)\moc_%(Filename).cpp" $(QtMocFlags) "-I." "-I$(QTDIR)include" "-I$(OutDir)GeneratedFiles\$(ConfigurationName)\."</Command>
       <Message>Moc'ing %(Filename)%(Extension)...</Message>
       <Outputs>.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <AdditionalInputs>$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -1,6 +1,6 @@
 #include "GUICommon.h"
 
-#include <QStringList>
+#include <QtCore/QStringList>
 
 namespace GUICommon
 {

--- a/Source/GUI/GUICommon.h
+++ b/Source/GUI/GUICommon.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QString>
-#include <QStringList>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
 
 #include "../Common/MemoryCommon.h"
 

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -1,12 +1,13 @@
 #include "MainWindow.h"
 
-#include <QHBoxLayout>
-#include <QMenuBar>
-#include <QMessageBox>
-#include <QShortcut>
-#include <QString>
-#include <QVBoxLayout>
 #include <string>
+
+#include <QtCore/QString>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QMenuBar>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QShortcut>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QAction>
-#include <QCloseEvent>
-#include <QMainWindow>
-#include <QMenu>
+#include <QtGui/QCloseEvent>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QMenu>
 
 #include "../Common/CommonTypes.h"
 #include "../Common/MemoryCommon.h"

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -1,11 +1,11 @@
 #include "MemScanWidget.h"
 
-#include <QHBoxLayout>
-#include <QHeaderView>
-#include <QMessageBox>
-#include <QRadioButton>
-#include <QRegExp>
-#include <QVBoxLayout>
+#include <QtCore/QRegExp>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../GUICommon.h"
 

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <QButtonGroup>
-#include <QCheckBox>
-#include <QComboBox>
-#include <QGroupBox>
-#include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QRadioButton>
-#include <QTableView>
-#include <QTimer>
-#include <QWidget>
+#include <QtCore/QTimer>
+#include <QtWidgets/QButtonGroup>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QRadioButton>
+#include <QtWidgets/QTableView>
+#include <QtWidgets/QWidget>
 
 #include "ResultsListModel.h"
 

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QAbstractTableModel>
+#include <QtCore/QAbstractTableModel>
 
 #include "../../MemoryScanner/MemoryScanner.h"
 

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -6,10 +6,10 @@
 #include <iomanip>
 #include <sstream>
 
-#include <QApplication>
-#include <QMouseEvent>
-#include <QPainter>
-#include <QScrollBar>
+#include <QtGui/QMouseEvent>
+#include <QtGui/QPainter>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QScrollBar>
 
 #include "../../Common/CommonUtils.h"
 #include "../../DolphinProcess/DolphinAccessor.h"

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QAbstractScrollArea>
-#include <QColor>
-#include <QElapsedTimer>
-#include <QList>
-#include <QRect>
-#include <QTimer>
-#include <QWidget>
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QList>
+#include <QtCore/QRect>
+#include <QtCore/QTimer>
+#include <QtGui/QColor>
+#include <QtWidgets/QAbstractScrollArea>
+#include <QtWidgets/QWidget>
 
 #include "../../Common/CommonTypes.h"
 

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -2,8 +2,8 @@
 
 #include <sstream>
 
-#include <QLabel>
-#include <QVBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../../DolphinProcess/DolphinAccessor.h"
 

--- a/Source/GUI/MemViewer/MemViewerWidget.h
+++ b/Source/GUI/MemViewer/MemViewerWidget.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QLineEdit>
-#include <QPushButton>
-#include <QWidget>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QWidget>
 
 #include "MemViewer.h"
 

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -1,10 +1,11 @@
 #include "DlgAddWatchEntry.h"
 
-#include <QDialogButtonBox>
-#include <QHBoxLayout>
-#include <QMessageBox>
-#include <QVBoxLayout>
 #include <sstream>
+
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../../../DolphinProcess/DolphinAccessor.h"
 #include "../../GUICommon.h"

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <QCheckBox>
-#include <QComboBox>
-#include <QDialog>
-#include <QGridLayout>
-#include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QSpinBox>
-#include <QVector>
+#include <QtCore/QVector>
+#include <QtWidgets/QCheckBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QGridLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QSpinBox>
 
 #include "../../../MemoryWatch/MemWatchEntry.h"
 

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -1,9 +1,9 @@
 #include "DlgChangeType.h"
 
-#include <QDialogButtonBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QVBoxLayout>
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../../GUICommon.h"
 

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QComboBox>
-#include <QDialog>
-#include <QSpinBox>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QSpinBox>
 
 class DlgChangeType : public QDialog
 {

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -2,11 +2,11 @@
 
 #include <sstream>
 
-#include <QDialogButtonBox>
-#include <QFileDialog>
-#include <QHBoxLayout>
-#include <QMessageBox>
-#include <QVBoxLayout>
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QVBoxLayout>
 
 DlgImportCTFile::DlgImportCTFile(QWidget* parent)
 {

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
@@ -1,10 +1,10 @@
-#include <QButtonGroup>
-#include <QDialog>
-#include <QGroupBox>
-#include <QLabel>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QRadioButton>
+#include <QtWidgets/QButtonGroup>
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QGroupBox>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QRadioButton>
 
 #include "../../../Common/CommonTypes.h"
 

--- a/Source/GUI/MemWatcher/MemWatchDelegate.cpp
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.cpp
@@ -1,6 +1,6 @@
 #include "MemWatchDelegate.h"
 
-#include <QLineEdit>
+#include <QtWidgets/QLineEdit>
 
 #include "../../MemoryWatch/MemWatchTreeNode.h"
 #include "../GUICommon.h"

--- a/Source/GUI/MemWatcher/MemWatchDelegate.h
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QStyledItemDelegate>
+#include <QtWidgets/QStyledItemDelegate>
 
 class MemWatchDelegate : public QStyledItemDelegate
 {

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1,10 +1,11 @@
 #include "MemWatchModel.h"
 
-#include <QDataStream>
-#include <QMimeData>
 #include <cstring>
 #include <limits>
 #include <sstream>
+
+#include <QtCore/QDataStream>
+#include <QtCore/QMimeData>
 
 #include "../../CheatEngineParser/CheatEngineParser.h"
 #include "../GUICommon.h"

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QAbstractItemModel>
-#include <QFile>
-#include <QJsonObject>
+#include <QtCore/QAbstractItemModel>
+#include <QtCore/QFile>
+#include <QtCore/QJsonObject>
 
 #include "../../MemoryWatch/MemWatchEntry.h"
 #include "../../MemoryWatch/MemWatchTreeNode.h"

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -1,25 +1,26 @@
 #include "MemWatchWidget.h"
 
-#include <QAction>
-#include <QApplication>
-#include <QByteArray>
-#include <QClipboard>
-#include <QFile>
-#include <QFileDialog>
-#include <QHBoxLayout>
-#include <QHeaderView>
-#include <QIODevice>
-#include <QInputDialog>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QMenu>
-#include <QMessageBox>
-#include <QShortcut>
-#include <QSignalMapper>
-#include <QString>
-#include <QTextStream>
-#include <QVBoxLayout>
 #include <string>
+
+#include <QtCore/QByteArray>
+#include <QtCore/QFile>
+#include <QtCore/QIODevice>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QSignalMapper>
+#include <QtCore/QString>
+#include <QtCore/QTextStream>
+#include <QtGui/QClipboard>
+#include <QtWidgets/QAction>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QShortcut>
+#include <QtWidgets/QVBoxLayout>
 
 #include "../../Common/MemoryCommon.h"
 #include "../../MemoryWatch/MemWatchEntry.h"

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QPushButton>
-#include <QTimer>
-#include <QTreeView>
+#include <QtCore/QTimer>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QTreeView>
 
 #include "MemWatchDelegate.h"
 #include "MemWatchModel.h"

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -1,8 +1,8 @@
 #include "MemWatchTreeNode.h"
 
-#include <QJsonArray>
-
 #include <sstream>
+
+#include <QtCore/QJsonArray>
 
 #include "../GUI/GUICommon.h"
 

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QJsonObject>
-#include <QString>
-#include <QVector>
+#include <QtCore/QJsonObject>
+#include <QtCore/QString>
+#include <QtCore/QVector>
 
 #include "MemWatchEntry.h"
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,4 +1,4 @@
-#include <QApplication>
+#include <QtWidgets/QApplication>
 
 #include "GUI/MainWindow.h"
 


### PR DESCRIPTION
Following https://wiki.qt.io/Qt_Coding_Style and https://wiki.qt.io/Coding_Conventions

One important thing noted in the second page:

> The library prefix is necessary for Mac OS X frameworks and is very convenient for non-qmake projects.

From a quick look it doesn't look like the CMakeList.txt file has to be updated, but I currently don't have a Linux machine or VM available to confirm this.