### PR TITLE
AppVeyor Build System

### DIFF
--- a/Source/Dolphin-memory-engine.vcxproj
+++ b/Source/Dolphin-memory-engine.vcxproj
@@ -130,8 +130,8 @@
   <ItemGroup>
     <!-- All files except for GUICommon need to be Moc'ed -->
     <CustomBuild Include="GUI\**\*.h" Exclude="@(ClInclude)">
-      <Command>"$(QTDIR)bin\moc.exe" "%(FullPath)" -o ".\GeneratedFiles\$(Configuration)\moc_%(Filename).cpp" $(QtMocFlags) "-I." "-I$(QTDIR)include" "-I$(OutDir)GeneratedFiles\$(ConfigurationName)\." "-I$(QTDIR)include\QtCore" "-I$(QTDIR)include\QtGui" "-I$(QTDIR)include\QtWidgets"</Command>
       <Message>Moc'ing %(Filename)%(Extension)...</Message>
+      <Command>"$(QTDIR)bin\moc.exe" "%(FullPath)" -o ".\GeneratedFiles\$(Configuration)\moc_%(Filename).cpp" $(QtMocFlags) "-I." "-I$(QTDIR)include" "-I$(OutDir)GeneratedFiles\$(ConfigurationName)\." "-I$(QTDIR)include\QtCore" "-I$(QTDIR)include\QtGui" "-I$(QTDIR)include\QtWidgets"</Command>
       <Outputs>.\GeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <AdditionalInputs>$(QTDIR)bin\moc.exe;%(FullPath)</AdditionalInputs>
     </CustomBuild>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+version: 0.4.0.{build}
+image: Visual Studio 2017
+configuration:
+- Debug
+- Release
+platform: x64
+install:
+- cmd: git submodule update --init
+build:
+  project: Source\Dolphin-memory-engine.sln
+  verbosity: normal
+artifacts:
+- path: Source\bin\$(configuration)\
+  name: $(configuration) build


### PR DESCRIPTION
[AppVeyor](https://www.appveyor.com/) is a continuous integration service/build system, which can be used for free for Open Source projects. It only provides VMs for Windows builds, for Linux or other platforms you'll have to use something another CI, like [Travis](https://travis-ci.org/). AppVeyor can also be used to perform unit tests, which might be desirable to add later on (QTest seems interesting).

The file `appveyor.yml` contains the settings for AppVeyor to run. I've set it up to build both the Debug and Release configurations using MSVC 2017, and when successful, it'll create an archieve with the output (executable, DLLs and symbols). Those files should run out-of-the-box.

Before AppVeyor will build this repository, the project has to be added to first. I can only do this for my own fork, so you'll have to do that first. You can log in with your GitHub account, then click Add Project and select this repository. It should only take a minute.

AppVeyor's integration with Github will show a green checkmark for branches and pull requests that build successfully, and a red cross when the build fails.

Optionally you can add a build badge to the readme, which shows the state of the latest build.

About versioning: AppVeyor increases the build number for every commit and pull request for tracked branches, writing it as 4.0.{build} (with the current configuration). That number will eventually get pretty high. When you make a new release, and move on to 4.1 for example, you may want to reset this to 1 again.