### PR TITLE
Fix remaining memory leaks

### DIFF
--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -28,6 +28,12 @@ void DolphinAccessor::init()
   }
 }
 
+void DolphinAccessor::free()
+{
+    delete m_instance;
+    delete[] m_updatedRAMCache;
+}
+
 void DolphinAccessor::hook()
 {
   init();

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -19,6 +19,7 @@ public:
   };
 
   static void init();
+  static void free();
   static void hook();
   static void unHook();
   static bool readFromRAM(const u32 offset, char* buffer, const size_t size, const bool withBSwap);

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -24,8 +24,8 @@ MainWindow::MainWindow()
 MainWindow::~MainWindow()
 {
   delete m_viewer;
-  delete m_scanner;
   delete m_watcher;
+  DolphinComm::DolphinAccessor::free();
 }
 
 void MainWindow::makeMenus()
@@ -78,7 +78,7 @@ void MainWindow::makeMenus()
 
 void MainWindow::initialiseWidgets()
 {
-  m_scanner = new MemScanWidget(this);
+  m_scanner = new MemScanWidget();
   connect(m_scanner, &MemScanWidget::requestAddWatchEntry, this, &MainWindow::addWatchRequested);
   connect(m_scanner, &MemScanWidget::requestAddAllResultsToWatchList, this,
           &MainWindow::addAllResultsToWatchList);
@@ -114,20 +114,20 @@ void MainWindow::makeLayouts()
   QFrame* separatorline = new QFrame();
   separatorline->setFrameShape(QFrame::HLine);
 
-  QVBoxLayout* main_layout = new QVBoxLayout;
-  main_layout->addWidget(m_lblDolphinStatus);
-  main_layout->addLayout(dolphinHookButtons_layout);
-  main_layout->addWidget(m_lblMem2Status);
-  main_layout->addWidget(separatorline);
-  main_layout->addWidget(m_scanner);
-  main_layout->addSpacing(5);
-  main_layout->addWidget(m_btnOpenMemViewer);
-  main_layout->addSpacing(5);
-  main_layout->addWidget(m_watcher);
+  QVBoxLayout* mainLayout = new QVBoxLayout;
+  mainLayout->addWidget(m_lblDolphinStatus);
+  mainLayout->addLayout(dolphinHookButtons_layout);
+  mainLayout->addWidget(m_lblMem2Status);
+  mainLayout->addWidget(separatorline);
+  mainLayout->addWidget(m_scanner);
+  mainLayout->addSpacing(5);
+  mainLayout->addWidget(m_btnOpenMemViewer);
+  mainLayout->addSpacing(5);
+  mainLayout->addWidget(m_watcher);
 
-  QWidget* main_widget = new QWidget(this);
-  main_widget->setLayout(main_layout);
-  setCentralWidget(main_widget);
+  QWidget* mainWidget = new QWidget();
+  mainWidget->setLayout(mainLayout);
+  setCentralWidget(mainWidget);
 
   setMinimumWidth(800);
 }

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -9,7 +9,7 @@
 
 #include "../GUICommon.h"
 
-MemScanWidget::MemScanWidget(QWidget* parent) : QWidget(parent)
+MemScanWidget::MemScanWidget()
 {
   initialiseWidgets();
   makeLayouts();

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -19,7 +19,7 @@ class MemScanWidget : public QWidget
   Q_OBJECT
 
 public:
-  MemScanWidget(QWidget* parent);
+  MemScanWidget();
   ~MemScanWidget();
 
   ResultsListModel* getResultListModel() const;


### PR DESCRIPTION
This fixes the following issues:
- The instance and the ram buffer from the `DolpingAccessor` class were not freed on exit. It's an annoying thing that comes with static singletones. I'd suggest refactoring this to something smarter or simpler in the future.
- Qt makes use of the composite design pattern, which means it doesn't require you to set parents or delete widgets manually. The parent/child relation is set when widgets are added to layouts or when setting one as the central widget. I've removed any manual setting of parents for those calls.

As additional change, I've renamed `main_layout` and `main_widget` to not use camelCase, like the rest of the document.