### PR TITLE
Fix right side widgets being cut off

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -128,8 +128,6 @@ void MainWindow::makeLayouts()
   QWidget* main_widget = new QWidget(this);
   main_widget->setLayout(main_layout);
   setCentralWidget(main_widget);
-
-  setMinimumWidth(800);
 }
 
 void MainWindow::makeMemViewer()


### PR DESCRIPTION
This fixes the right side being cut off when resizing the window, as seen in this image:

![image](https://user-images.githubusercontent.com/9705046/35761232-b848ed7a-0886-11e8-9f18-1eb07e63e792.png)