### PR TITLE
Add support for localizing strings

### DIFF
--- a/Source/CheatEngineParser/CheatEngineParser.cpp
+++ b/Source/CheatEngineParser/CheatEngineParser.cpp
@@ -287,8 +287,8 @@ void CheatEngineParser::parseCheatEntry(MemWatchTreeNode* node, const bool useDo
 
   if (!isGroup)
   {
-    MemWatchEntry* entry =
-        new MemWatchEntry(label, consoleAddress, type, base, isUnsigned, length, false);
+    MemWatchEntry* entry = new MemWatchEntry(QString::fromStdString(label), consoleAddress, type,
+                                             base, isUnsigned, length, false);
     MemWatchTreeNode* newNode = new MemWatchTreeNode(entry, node, false, "");
     node->appendChild(newNode);
     verifyCheatEntryParsingErrors(currentCheatEntryState, entry, false, useDolphinPointer);
@@ -365,7 +365,7 @@ void CheatEngineParser::verifyCheatEntryParsingErrors(cheatEntryParsingState sta
 QString CheatEngineParser::formatImportedEntryBasicInfo(const MemWatchEntry* entry) const
 {
   QString formatedEntry = "";
-  formatedEntry += "Label: " + QString::fromStdString(entry->getLabel()) + "\n";
+  formatedEntry += "Label: " + entry->getLabel() + "\n";
   formatedEntry +=
       "Type: " + GUICommon::getStringFromType(entry->getType(), entry->getLength()) + "\n";
   std::stringstream ss;

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -1,17 +1,36 @@
 #include "GUICommon.h"
 
+#include <QCoreApplication>
 #include <QStringList>
 
 namespace GUICommon
 {
-QStringList g_memTypeNames = QStringList({"Byte", "2 bytes (Halfword)", "4 bytes (Word)", "Float",
-                                          "Double", "String", "Array of bytes"});
+QStringList g_memTypeNames =
+    QStringList({QCoreApplication::translate("Common", "Byte"),
+                 QCoreApplication::translate("Common", "2 bytes (Halfword)"),
+                 QCoreApplication::translate("Common", "4 bytes (Word)"),
+                 QCoreApplication::translate("Common", "Float"),
+                 QCoreApplication::translate("Common", "Double"),
+                 QCoreApplication::translate("Common", "String"),
+                 QCoreApplication::translate("Common", "Array of bytes")});
 
-QStringList g_memBaseNames = QStringList({"Decimal", "Hexadecimal", "Octal", "Binary"});
+QStringList g_memBaseNames = QStringList({QCoreApplication::translate("Common", "Decimal"),
+                                          QCoreApplication::translate("Common", "Hexadecimal"),
+                                          QCoreApplication::translate("Common", "Octal"),
+                                          QCoreApplication::translate("Common", "Binary")});
 
-QStringList g_memScanFilter = QStringList({"Exact value", "Increased by", "Decreased by", "Between",
-                                           "Bigger than", "Smaller than", "Increased", "Decreased",
-                                           "Changed", "Unchanged", "Unknown initial value"});
+QStringList g_memScanFilter =
+    QStringList({QCoreApplication::translate("Common", "Exact value"),
+                 QCoreApplication::translate("Common", "Increased by"),
+                 QCoreApplication::translate("Common", "Decreased by"),
+                 QCoreApplication::translate("Common", "Between"),
+                 QCoreApplication::translate("Common", "Bigger than"),
+                 QCoreApplication::translate("Common", "Smaller than"),
+                 QCoreApplication::translate("Common", "Increased"),
+                 QCoreApplication::translate("Common", "Decreased"),
+                 QCoreApplication::translate("Common", "Changed"),
+                 QCoreApplication::translate("Common", "Unchanged"),
+                 QCoreApplication::translate("Common", "Unknown initial value")});
 
 bool g_valueEditing = false;
 
@@ -39,13 +58,13 @@ QString getNameFromBase(const Common::MemBase base)
   switch (base)
   {
   case Common::MemBase::base_binary:
-    return QString("binary");
+    return QCoreApplication::translate("Common", "binary");
   case Common::MemBase::base_octal:
-    return QString("octal");
+    return QCoreApplication::translate("Common", "octal");
   case Common::MemBase::base_decimal:
-    return QString("decimal");
+    return QCoreApplication::translate("Common", "decimal");
   case Common::MemBase::base_hexadecimal:
-    return QString("hexadecimal");
+    return QCoreApplication::translate("Common", "hexadecimal");
   default:
     return QString("");
   }

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -30,19 +30,19 @@ MainWindow::~MainWindow()
 
 void MainWindow::makeMenus()
 {
-  m_actOpenWatchList = new QAction("&Open...", this);
-  m_actSaveWatchList = new QAction("&Save", this);
-  m_actSaveAsWatchList = new QAction("&Save as...", this);
-  m_actClearWatchList = new QAction("&Clear the watch list", this);
-  m_actImportFromCT = new QAction("&Import from Cheat Engine's CT file...", this);
-  m_actExportAsCSV = new QAction("&Export as CSV...", this);
+  m_actOpenWatchList = new QAction(tr("&Open..."), this);
+  m_actSaveWatchList = new QAction(tr("&Save"), this);
+  m_actSaveAsWatchList = new QAction(tr("&Save as..."), this);
+  m_actClearWatchList = new QAction(tr("&Clear the watch list"), this);
+  m_actImportFromCT = new QAction(tr("&Import from Cheat Engine's CT file..."), this);
+  m_actExportAsCSV = new QAction(tr("&Export as CSV..."), this);
 
-  m_actViewScanner = new QAction("&Scanner", this);
+  m_actViewScanner = new QAction(tr("&Scanner"), this);
   m_actViewScanner->setCheckable(true);
   m_actViewScanner->setChecked(true);
 
-  m_actQuit = new QAction("&Quit", this);
-  m_actAbout = new QAction("&About", this);
+  m_actQuit = new QAction(tr("&Quit"), this);
+  m_actAbout = new QAction(tr("&About"), this);
   connect(m_actOpenWatchList, &QAction::triggered, this, &MainWindow::onOpenWatchFile);
   connect(m_actSaveWatchList, &QAction::triggered, this, &MainWindow::onSaveWatchFile);
   connect(m_actSaveAsWatchList, &QAction::triggered, this, &MainWindow::onSaveAsWatchFile);
@@ -60,7 +60,7 @@ void MainWindow::makeMenus()
   connect(m_actQuit, &QAction::triggered, this, &MainWindow::onQuit);
   connect(m_actAbout, &QAction::triggered, this, &MainWindow::onAbout);
 
-  m_menuFile = menuBar()->addMenu("&File");
+  m_menuFile = menuBar()->addMenu(tr("&File"));
   m_menuFile->addAction(m_actOpenWatchList);
   m_menuFile->addAction(m_actSaveWatchList);
   m_menuFile->addAction(m_actSaveAsWatchList);
@@ -69,10 +69,10 @@ void MainWindow::makeMenus()
   m_menuFile->addAction(m_actExportAsCSV);
   m_menuFile->addAction(m_actQuit);
 
-  m_menuView = menuBar()->addMenu("&View");
+  m_menuView = menuBar()->addMenu(tr("&View"));
   m_menuView->addAction(m_actViewScanner);
 
-  m_menuHelp = menuBar()->addMenu("&Help");
+  m_menuHelp = menuBar()->addMenu(tr("&Help"));
   m_menuHelp->addAction(m_actAbout);
 }
 
@@ -90,8 +90,8 @@ void MainWindow::initialiseWidgets()
   connect(m_scanner, &MemScanWidget::mustUnhook, this, &MainWindow::onUnhook);
   connect(m_watcher, &MemWatchWidget::mustUnhook, this, &MainWindow::onUnhook);
 
-  m_btnAttempHook = new QPushButton("Hook");
-  m_btnUnhook = new QPushButton("Unhook");
+  m_btnAttempHook = new QPushButton(tr("Hook"));
+  m_btnUnhook = new QPushButton(tr("Unhook"));
   connect(m_btnAttempHook, &QPushButton::clicked, this, &MainWindow::onHookAttempt);
   connect(m_btnUnhook, &QPushButton::clicked, this, &MainWindow::onUnhook);
 
@@ -101,7 +101,7 @@ void MainWindow::initialiseWidgets()
   m_lblMem2Status = new QLabel("");
   m_lblMem2Status->setAlignment(Qt::AlignHCenter);
 
-  m_btnOpenMemViewer = new QPushButton("Open memory viewer");
+  m_btnOpenMemViewer = new QPushButton(tr("Open memory viewer"));
   connect(m_btnOpenMemViewer, &QPushButton::clicked, this, &MainWindow::onOpenMenViewer);
 }
 
@@ -156,7 +156,7 @@ void MainWindow::addSelectedResultsToWatchList(Common::MemType type, size_t leng
   {
     u32 address = m_scanner->getResultListModel()->getResultAddress(i);
     MemWatchEntry* newEntry =
-        new MemWatchEntry("No label", address, type, base, isUnsigned, length);
+        new MemWatchEntry(tr("No label"), address, type, base, isUnsigned, length);
     m_watcher->addWatchEntry(newEntry);
   }
 }
@@ -166,7 +166,8 @@ void MainWindow::addAllResultsToWatchList(Common::MemType type, size_t length, b
 {
   for (auto item : m_scanner->getAllResults())
   {
-    MemWatchEntry* newEntry = new MemWatchEntry("No label", item, type, base, isUnsigned, length);
+    MemWatchEntry* newEntry =
+        new MemWatchEntry(tr("No label"), item, type, base, isUnsigned, length);
     m_watcher->addWatchEntry(newEntry);
   }
 }
@@ -174,7 +175,8 @@ void MainWindow::addAllResultsToWatchList(Common::MemType type, size_t length, b
 void MainWindow::addWatchRequested(u32 address, Common::MemType type, size_t length,
                                    bool isUnsigned, Common::MemBase base)
 {
-  MemWatchEntry* newEntry = new MemWatchEntry("No label", address, type, base, isUnsigned, length);
+  MemWatchEntry* newEntry =
+      new MemWatchEntry(tr("No label"), address, type, base, isUnsigned, length);
   m_watcher->addWatchEntry(newEntry);
 }
 
@@ -193,9 +195,9 @@ void MainWindow::onOpenMemViewerWithAddress(u32 address)
 void MainWindow::updateMem2Status()
 {
   if (DolphinComm::DolphinAccessor::isMEM2Present())
-    m_lblMem2Status->setText("The extended Wii-only memory is present");
+    m_lblMem2Status->setText(tr("The extended Wii-only memory is present"));
   else
-    m_lblMem2Status->setText("The extended Wii-only memory is absent");
+    m_lblMem2Status->setText(tr("The extended Wii-only memory is absent"));
   m_viewer->onMEM2StatusChanged(DolphinComm::DolphinAccessor::isMEM2Present());
 }
 
@@ -206,7 +208,7 @@ void MainWindow::updateDolphinHookingStatus()
   case DolphinComm::DolphinAccessor::DolphinStatus::hooked:
   {
     m_lblDolphinStatus->setText(
-        "Hooked successfully to Dolphin, current start address: " +
+        tr("Hooked successfully to Dolphin, current start address: ") +
         QString::number(DolphinComm::DolphinAccessor::getEmuRAMAddressStart(), 16).toUpper());
     m_scanner->setEnabled(true);
     m_watcher->setEnabled(true);
@@ -217,7 +219,7 @@ void MainWindow::updateDolphinHookingStatus()
   }
   case DolphinComm::DolphinAccessor::DolphinStatus::notRunning:
   {
-    m_lblDolphinStatus->setText("Cannot hook to Dolphin, the process is not running");
+    m_lblDolphinStatus->setText(tr("Cannot hook to Dolphin, the process is not running"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
@@ -228,7 +230,7 @@ void MainWindow::updateDolphinHookingStatus()
   case DolphinComm::DolphinAccessor::DolphinStatus::noEmu:
   {
     m_lblDolphinStatus->setText(
-        "Cannot hook to Dolphin, the process is running, but no emulation has been started");
+        tr("Cannot hook to Dolphin, the process is running, but no emulation has been started"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
@@ -238,7 +240,7 @@ void MainWindow::updateDolphinHookingStatus()
   }
   case DolphinComm::DolphinAccessor::DolphinStatus::unHooked:
   {
-    m_lblDolphinStatus->setText("Unhooked, press \"Hook\" to hook to Dolphin again");
+    m_lblDolphinStatus->setText(tr("Unhooked, press \"Hook\" to hook to Dolphin again"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
@@ -310,11 +312,13 @@ void MainWindow::onExportAsCSV()
 
 void MainWindow::onAbout()
 {
-  QMessageBox::about(this, "About Dolphin memory engine",
-                     "Beta version 0.4\n\nA RAM search made to facilitate research and "
-                     "reverse engineering of GameCube and Wii games using the Dolphin "
-                     "emulator.\n\nThis program is licensed under the MIT license. You "
-                     "should have received a copy of the MIT license along with this program");
+  QString title = tr("About Dolphin memory engine");
+  QString text =
+      "Beta version 0.4\n\n" +
+      tr("A RAM search made to facilitate research and reverse engineering of GameCube and Wii "
+         "games using the Dolphin emulator.\n\nThis program is licensed under the MIT license. You "
+         "should have received a copy of the MIT license along with this program");
+  QMessageBox::about(this, title, text);
 }
 
 void MainWindow::onQuit()

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -42,18 +42,18 @@ void MemScanWidget::initialiseWidgets()
   connect(m_tblResulstList, &QAbstractItemView::doubleClicked, this,
           &MemScanWidget::onResultListDoubleClicked);
 
-  m_btnAddAll = new QPushButton("Add all");
+  m_btnAddAll = new QPushButton(tr("Add all"));
   connect(m_btnAddAll, &QPushButton::clicked, this, &MemScanWidget::onAddAll);
   m_btnAddAll->setEnabled(false);
 
-  m_btnAddSelection = new QPushButton("Add selection");
+  m_btnAddSelection = new QPushButton(tr("Add selection"));
   connect(m_btnAddSelection, &QPushButton::clicked, this, &MemScanWidget::onAddSelection);
   m_btnAddSelection->setEnabled(false);
 
-  m_btnFirstScan = new QPushButton("First scan");
-  m_btnNextScan = new QPushButton("Next scan");
+  m_btnFirstScan = new QPushButton(tr("First scan"));
+  m_btnNextScan = new QPushButton(tr("Next scan"));
   m_btnNextScan->hide();
-  m_btnResetScan = new QPushButton("Reset scan");
+  m_btnResetScan = new QPushButton(tr("Reset scan"));
   m_btnResetScan->hide();
 
   connect(m_btnFirstScan, &QPushButton::clicked, this, &MemScanWidget::onFirstScan);
@@ -79,10 +79,10 @@ void MemScanWidget::initialiseWidgets()
   connect(m_cmbScanFilter, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &MemScanWidget::onScanFilterChanged);
 
-  m_rdbBaseDecimal = new QRadioButton("Decimal");
-  m_rdbBaseHexadecimal = new QRadioButton("Hexadecimal");
-  m_rdbBaseOctal = new QRadioButton("Octal");
-  m_rdbBaseBinary = new QRadioButton("Binary");
+  m_rdbBaseDecimal = new QRadioButton(tr("Decimal"));
+  m_rdbBaseHexadecimal = new QRadioButton(tr("Hexadecimal"));
+  m_rdbBaseOctal = new QRadioButton(tr("Octal"));
+  m_rdbBaseBinary = new QRadioButton(tr("Binary"));
 
   m_btnGroupScanBase = new QButtonGroup(this);
   m_btnGroupScanBase->addButton(m_rdbBaseDecimal, 0);
@@ -91,12 +91,12 @@ void MemScanWidget::initialiseWidgets()
   m_btnGroupScanBase->addButton(m_rdbBaseBinary, 3);
   m_rdbBaseDecimal->setChecked(true);
 
-  m_groupScanBase = new QGroupBox("Base to use");
+  m_groupScanBase = new QGroupBox(tr("Base to use"));
 
-  m_chkSignedScan = new QCheckBox("Signed value scan");
+  m_chkSignedScan = new QCheckBox(tr("Signed value scan"));
   m_chkSignedScan->setChecked(false);
 
-  m_chkEnforceMemAlignement = new QCheckBox("Enforce alignement");
+  m_chkEnforceMemAlignement = new QCheckBox(tr("Enforce alignement"));
   m_chkEnforceMemAlignement->setChecked(true);
 
   m_currentValuesUpdateTimer = new QTimer(this);
@@ -106,7 +106,7 @@ void MemScanWidget::initialiseWidgets()
 
 void MemScanWidget::makeLayouts()
 {
-  QLabel* lblAnd = new QLabel("and");
+  QLabel* lblAnd = new QLabel(tr("and"));
 
   QHBoxLayout* multiAddButtons_layout = new QHBoxLayout();
   multiAddButtons_layout->addWidget(m_btnAddSelection);
@@ -292,9 +292,10 @@ void MemScanWidget::onFirstScan()
   }
   else
   {
+    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
     m_lblResultCount->setText(
-        QString::number(m_memScanner->getResultCount()).append(" result(s) found"));
-    if (m_memScanner->getResultCount() <= 1000 && m_memScanner->getResultCount() != 0)
+        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    if (resultsFound <= 1000 && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
       m_btnAddSelection->setEnabled(true);
@@ -321,9 +322,10 @@ void MemScanWidget::onNextScan()
   }
   else
   {
+    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
     m_lblResultCount->setText(
-        QString::number(m_memScanner->getResultCount()).append(" result(s) found"));
-    if (m_memScanner->getResultCount() <= 1000 && m_memScanner->getResultCount() != 0)
+        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    if (resultsFound <= 1000 && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
       m_btnAddSelection->setEnabled(true);
@@ -365,9 +367,9 @@ void MemScanWidget::handleScannerErrors(const Common::MemOperationReturnCode err
   if (errorCode == Common::MemOperationReturnCode::invalidInput)
   {
     QMessageBox* errorBox =
-        new QMessageBox(QMessageBox::Critical, "Invalid term(s)",
-                        QString("The search term(s) you entered for the type " +
-                                m_cmbScanType->currentText() + " is/are invalid"),
+        new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
+                        tr("The search term(s) you entered for the type %1 is/are invalid")
+                            .arg(m_cmbScanType->currentText()),
                         QMessageBox::Ok, this);
     errorBox->exec();
   }

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -53,11 +53,11 @@ QVariant ResultsListModel::headerData(int section, Qt::Orientation orientation, 
     switch (section)
     {
     case RESULT_COL_ADDRESS:
-      return QString("Address");
+      return tr("Address");
     case RESULT_COL_SCANNED:
-      return QString("Scanned");
+      return tr("Scanned");
     case RESULT_COL_CURRENT:
-      return QString("Current");
+      return tr("Current");
     }
   }
   return QVariant();

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -397,7 +397,7 @@ void MemViewer::renderSeparatorLines(QPainter& painter)
 
 void MemViewer::renderColumnsHeaderText(QPainter& painter)
 {
-  painter.drawText(m_charWidthEm / 2, m_charHeight, " Address");
+  painter.drawText(m_charWidthEm * 1.5f, m_charHeight, tr("Address"));
   int posXHeaderText = m_rowHeaderWidth;
   for (int i = 0; i < m_numColumns; i++)
   {
@@ -409,7 +409,8 @@ void MemViewer::renderColumnsHeaderText(QPainter& painter)
     posXHeaderText += m_charWidthEm * 2 + m_charWidthEm / 2;
   }
 
-  painter.drawText(m_hexAsciiSeparatorPosX + m_charWidthEm / 2, m_charHeight, "  Text (ASCII)  ");
+  painter.drawText(m_hexAsciiSeparatorPosX + m_charWidthEm * 2.5f, m_charHeight, tr("Text (ASCII)"));
+  painter.drawText(0, 0, 0, 0, 0, QString());
 }
 
 void MemViewer::renderRowHeaderText(QPainter& painter, const int rowIndex)

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -23,9 +23,9 @@ void MemViewerWidget::initialiseWidgets()
   m_txtJumpAddress = new QLineEdit(this);
   connect(m_txtJumpAddress, &QLineEdit::textChanged, this,
           &MemViewerWidget::onJumpToAddressTextChanged);
-  m_btnGoToMEM1Start = new QPushButton("Go to the common RAM");
+  m_btnGoToMEM1Start = new QPushButton(tr("Go to the common RAM"));
   connect(m_btnGoToMEM1Start, &QPushButton::clicked, this, &MemViewerWidget::onGoToMEM1Start);
-  m_btnGoToMEM2Start = new QPushButton("Go to the Wii-only RAM");
+  m_btnGoToMEM2Start = new QPushButton(tr("Go to the Wii-only RAM"));
   connect(m_btnGoToMEM2Start, &QPushButton::clicked, this, &MemViewerWidget::onGoToMEM2Start);
   m_memViewer = new MemViewer(this);
   connect(m_memViewer, &MemViewer::memErrorOccured, this, &MemViewerWidget::mustUnhook);
@@ -35,7 +35,7 @@ void MemViewerWidget::initialiseWidgets()
 
 void MemViewerWidget::makeLayouts()
 {
-  QLabel* lblJumpToAddress = new QLabel("Jump to an address: ");
+  QLabel* lblJumpToAddress = new QLabel(tr("Jump to an address: "));
 
   QHBoxLayout* controls_layout = new QHBoxLayout();
   controls_layout->addWidget(lblJumpToAddress);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -168,7 +168,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
       m_lengtWidget->show();
     else
       m_lengtWidget->hide();
-    m_txbLabel->setText(QString::fromStdString(m_entry->getLabel()));
+    m_txbLabel->setText(m_entry->getLabel());
     std::stringstream ssAddress;
     ssAddress << std::hex << std::uppercase << m_entry->getConsoleAddress();
     m_txbAddress->setText(QString::fromStdString(ssAddress.str()));
@@ -284,14 +284,14 @@ void DlgAddWatchEntry::accept()
 {
   if (!validateAndSetAddress())
   {
-    QString errorMsg = QString(
-        "The address you entered is invalid, make sure it is an "
-        "hexadecimal number between 0x80000000 and 0x817FFFFF");
+    QString errorMsg =
+        tr("The address you entered is invalid, make sure it is an "
+           "hexadecimal number between 0x80000000 and 0x817FFFFF");
     if (DolphinComm::DolphinAccessor::isMEM2Present())
-      errorMsg.append(" or between 0x90000000 and 0x93FFFFFF");
+      errorMsg.append(tr(" or between 0x90000000 and 0x93FFFFFF"));
 
-    QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, QString("Invalid address"),
-                                            errorMsg, QMessageBox::Ok, this);
+    QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
+                                            QMessageBox::Ok, this);
     errorBox->exec();
   }
   else
@@ -321,7 +321,7 @@ void DlgAddWatchEntry::accept()
     if (m_txbLabel->text() == "")
       m_entry->setLabel("No label");
     else
-      m_entry->setLabel(m_txbLabel->text().toStdString());
+      m_entry->setLabel(m_txbLabel->text());
     m_entry->setBase(Common::MemBase::base_decimal);
     m_entry->setSignedUnsigned(false);
     setResult(QDialog::Accepted);

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -32,8 +32,8 @@ void DlgChangeType::initialiseWidgets()
 
 void DlgChangeType::makeLayouts()
 {
-  QLabel* lblType = new QLabel(QString("New type: "), this);
-  QLabel* lblLength = new QLabel(QString("Length: "), this);
+  QLabel* lblType = new QLabel(tr("New type: "), this);
+  QLabel* lblLength = new QLabel(tr("Length: "), this);
 
   QWidget* typeSelection = new QWidget(this);
   QHBoxLayout* typeSelectionLayout = new QHBoxLayout;

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -23,18 +23,18 @@ void DlgImportCTFile::initialiseWidgets()
   m_txbFileName->setReadOnly(true);
 
   m_txbCommonBase = new QLineEdit("");
-  m_txbCommonBase->setPlaceholderText("Hex number ex. 7FFF0000");
+  m_txbCommonBase->setPlaceholderText(tr("Hex number ex. 7FFF0000"));
 
   m_widgetAddressMethod = new QWidget();
 
-  m_btnBrowseFiles = new QPushButton("Browse...");
+  m_btnBrowseFiles = new QPushButton(tr("Browse..."));
   connect(m_btnBrowseFiles, &QPushButton::clicked, this, &DlgImportCTFile::onBrowseFiles);
 
   m_groupImportAddressMethod =
-      new QGroupBox("Addresses import method (select the option that describes the table)");
+      new QGroupBox(tr("Addresses import method (select the option that describes the table)"));
 
-  m_rdbUseCommonBase = new QRadioButton("Using an assumed common RAM start address");
-  m_rdbUseDolphinPointers = new QRadioButton("Using an internal Dolphin pointer");
+  m_rdbUseCommonBase = new QRadioButton(tr("Using an assumed common RAM start address"));
+  m_rdbUseDolphinPointers = new QRadioButton(tr("Using an internal Dolphin pointer"));
 
   m_btnGroupImportAddressMethod = new QButtonGroup();
   m_btnGroupImportAddressMethod->addButton(m_rdbUseCommonBase, 0);
@@ -47,7 +47,7 @@ void DlgImportCTFile::initialiseWidgets()
 
 void DlgImportCTFile::makeLayouts()
 {
-  QLabel* lblFileSelect = new QLabel("Select the Cheat Table file to import: ");
+  QLabel* lblFileSelect = new QLabel(tr("Select the Cheat Table file to import: "));
 
   QHBoxLayout* fileSelectInput_layout = new QHBoxLayout();
   fileSelectInput_layout->addWidget(m_txbFileName);
@@ -58,7 +58,7 @@ void DlgImportCTFile::makeLayouts()
   fileSelect_layout->addWidget(lblFileSelect);
   fileSelect_layout->addLayout(fileSelectInput_layout);
 
-  QLabel* lblCommonBaseInput = new QLabel("Enter the assumed start address: ");
+  QLabel* lblCommonBaseInput = new QLabel(tr("Enter the assumed start address: "));
 
   QHBoxLayout* commonBase_layout = new QHBoxLayout();
   commonBase_layout->setContentsMargins(20, 0, 0, 0);
@@ -67,15 +67,15 @@ void DlgImportCTFile::makeLayouts()
 
   m_widgetAddressMethod->setLayout(commonBase_layout);
 
-  QLabel* lblCommonBase = new QLabel(
-      "The table assumes a common RAM start address, every entry\n"
-      "use an address from the address field of the entry and are\n"
-      "offset according to the assumed RAM start address");
+  QLabel* lblCommonBase =
+      new QLabel(tr("The table assumes a common RAM start address, every entry\n"
+                    "use an address from the address field of the entry and are\n"
+                    "offset according to the assumed RAM start address"));
   lblCommonBase->setContentsMargins(20, 0, 0, 0);
-  QLabel* lblDolphinPointer = new QLabel(
-      "Every entry of the table use a Dolphin internal pointer\n"
-      "that points to the start of the RAM and the offset from\n"
-      "the start is in the offset field of the entry");
+  QLabel* lblDolphinPointer =
+      new QLabel(tr("Every entry of the table use a Dolphin internal pointer\n"
+                    "that points to the start of the RAM and the offset from\n"
+                    "the start is in the offset field of the entry"));
   lblDolphinPointer->setContentsMargins(20, 0, 0, 0);
 
   QVBoxLayout* addressImport_layout = new QVBoxLayout();
@@ -126,8 +126,8 @@ void DlgImportCTFile::onAddressImportMethodChanged()
 
 void DlgImportCTFile::onBrowseFiles()
 {
-  QString fileName = QFileDialog::getOpenFileName(this, "Open Cheat Table", QString(),
-                                                  "Cheat Engine's cheat table (*.CT)");
+  QString fileName = QFileDialog::getOpenFileName(this, tr("Open Cheat Table"), QString(),
+                                                  tr("Cheat Engine's cheat table (*.CT)"));
   if (fileName != "")
     m_txbFileName->setText(fileName);
 }
@@ -137,8 +137,8 @@ void DlgImportCTFile::accept()
   if (m_txbFileName->text().isEmpty())
   {
     QMessageBox* errorBox =
-        new QMessageBox(QMessageBox::Critical, "No Cheat Table file provided",
-                        "Please provide a Cheat Table file to import.", QMessageBox::Ok, this);
+        new QMessageBox(QMessageBox::Critical, tr("No Cheat Table file provided"),
+                        tr("Please provide a Cheat Table file to import."), QMessageBox::Ok, this);
     errorBox->exec();
     return;
   }
@@ -147,9 +147,9 @@ void DlgImportCTFile::accept()
     if (m_txbCommonBase->text().isEmpty())
     {
       QMessageBox* errorBox = new QMessageBox(
-          QMessageBox::Critical, "No assumed RAM start address provided",
-          "To use the assumed common start address import method for importing the addresses, "
-          "you need to provide the assumed start address of the table.",
+          QMessageBox::Critical, tr("No assumed RAM start address provided"),
+          tr("To use the assumed common start address import method for importing the addresses, "
+             "you need to provide the assumed start address of the table."),
           QMessageBox::Ok, this);
       errorBox->exec();
       return;
@@ -161,8 +161,8 @@ void DlgImportCTFile::accept()
     if (ss.fail())
     {
       QMessageBox* errorBox = new QMessageBox(
-          QMessageBox::Critical, "The assumed start address provided is invalid",
-          "Please enter a valid hexadecimal number representing the assumed RAM start address.",
+          QMessageBox::Critical, tr("The assumed start address provided is invalid"),
+          tr("Please enter a valid hexadecimal number representing the assumed RAM start address."),
           QMessageBox::Ok, this);
       errorBox->exec();
       return;

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -190,7 +190,7 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
       {
       case WATCH_COL_LABEL:
       {
-        return QString::fromStdString(entry->getLabel());
+        return entry->getLabel();
       }
       case WATCH_COL_TYPE:
       {
@@ -243,7 +243,7 @@ bool MemWatchModel::setData(const QModelIndex& index, const QVariant& value, int
       {
       case WATCH_COL_LABEL:
       {
-        entry->setLabel((value.toString().toStdString()));
+        entry->setLabel(value.toString());
         emit dataChanged(index, index);
         return true;
       }
@@ -351,15 +351,15 @@ QVariant MemWatchModel::headerData(int section, Qt::Orientation orientation, int
     switch (section)
     {
     case WATCH_COL_LABEL:
-      return QString("Name");
+      return tr("Name");
     case WATCH_COL_TYPE:
-      return QString("Type");
+      return tr("Type");
     case WATCH_COL_ADDRESS:
-      return QString("Address");
+      return tr("Address");
     case WATCH_COL_VALUE:
-      return QString("Value");
+      return tr("Value");
     case WATCH_COL_LOCK:
-      return QString("Lock");
+      return tr("Lock");
     }
   }
   return QVariant();
@@ -533,9 +533,8 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
           else if (right->isGroup())
             return false;
 
-          int compareResult = QString::compare(
-              QString::fromStdString(left->getEntry()->getLabel()),
-              QString::fromStdString(right->getEntry()->getLabel()), Qt::CaseInsensitive);
+          int compareResult = QString::compare(left->getEntry()->getLabel(),
+                                               right->getEntry()->getLabel(), Qt::CaseInsensitive);
           return order == Qt::AscendingOrder ? compareResult < 0 : compareResult > 0;
         });
     break;

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -73,10 +73,10 @@ void MemWatchWidget::initialiseWidgets()
   QShortcut* shortcut = new QShortcut(QKeySequence::Delete, m_watchView);
   connect(shortcut, &QShortcut::activated, this, &MemWatchWidget::onDeleteSelection);
 
-  m_btnAddGroup = new QPushButton("Add group", this);
+  m_btnAddGroup = new QPushButton(tr("Add group"), this);
   connect(m_btnAddGroup, &QPushButton::clicked, this, &MemWatchWidget::onAddGroup);
 
-  m_btnAddWatchEntry = new QPushButton("Add watch", this);
+  m_btnAddWatchEntry = new QPushButton(tr("Add watch"), this);
   connect(m_btnAddWatchEntry, &QPushButton::clicked, this, &MemWatchWidget::onAddWatchEntry);
 
   m_updateTimer = new QTimer(this);
@@ -121,8 +121,8 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
 
       if (entry->isBoundToPointer())
       {
-        QMenu* memViewerSubMenu = contextMenu->addMenu("Browse &memory at");
-        QAction* showPointerInViewer = new QAction("The &pointer address...", this);
+        QMenu* memViewerSubMenu = contextMenu->addMenu(tr("Browse &memory at"));
+        QAction* showPointerInViewer = new QAction(tr("The &pointer address..."), this);
         connect(showPointerInViewer, &QAction::triggered, this,
                 [=] { emit goToAddressInViewer(entry->getConsoleAddress()); });
         memViewerSubMenu->addAction(showPointerInViewer);
@@ -131,20 +131,20 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
           std::string strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
           if (strAddressOfPath == "???")
             break;
-          QAction* showAddressOfPathInViewer =
-              new QAction("The pointed address at &level " + QString::number(i + 1) + "...", this);
+          QAction* showAddressOfPathInViewer = new QAction(
+              tr("The pointed address at &level %1...").arg(QString::number(i + 1)), this);
           connect(showAddressOfPathInViewer, &QAction::triggered, this,
                   [=] { emit goToAddressInViewer(entry->getAddressForPointerLevel(i + 1)); });
           memViewerSubMenu->addAction(showAddressOfPathInViewer);
         }
 
-        QAction* showInViewer = new QAction("Browse memory at this &address...", this);
+        QAction* showInViewer = new QAction(tr("Browse memory at this &address..."), this);
         connect(showInViewer, &QAction::triggered, this,
                 [=] { emit goToAddressInViewer(entry->getConsoleAddress()); });
       }
       else
       {
-        QAction* showInViewer = new QAction("Browse memory at this &address...", this);
+        QAction* showInViewer = new QAction(tr("Browse memory at this &address..."), this);
         connect(showInViewer, &QAction::triggered, this,
                 [=] { emit goToAddressInViewer(entry->getConsoleAddress()); });
 
@@ -154,10 +154,10 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       {
         contextMenu->addSeparator();
 
-        QAction* viewDec = new QAction("View as &Decimal", this);
-        QAction* viewHex = new QAction("View as &Hexadecimal", this);
-        QAction* viewOct = new QAction("View as &Octal", this);
-        QAction* viewBin = new QAction("View as &Binary", this);
+        QAction* viewDec = new QAction(tr("View as &Decimal"), this);
+        QAction* viewHex = new QAction(tr("View as &Hexadecimal"), this);
+        QAction* viewOct = new QAction(tr("View as &Octal"), this);
+        QAction* viewBin = new QAction(tr("View as &Binary"), this);
 
         connect(viewDec, &QAction::triggered, m_watchModel, [=] {
           entry->setBase(Common::MemBase::base_decimal);
@@ -188,8 +188,8 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
 
         if (theBase == Common::MemBase::base_decimal)
         {
-          QAction* viewSigned = new QAction("View as &Signed", this);
-          QAction* viewUnsigned = new QAction("View as &Unsigned", this);
+          QAction* viewSigned = new QAction(tr("View as &Signed"), this);
+          QAction* viewUnsigned = new QAction(tr("View as &Unsigned"), this);
 
           connect(viewSigned, &QAction::triggered, m_watchModel, [=] {
             entry->setSignedUnsigned(false);
@@ -226,22 +226,22 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     node = m_watchModel->getRootNode();
   }
 
-  QAction* cut = new QAction("Cu&t", this);
+  QAction* cut = new QAction(tr("Cu&t"), this);
   connect(cut, &QAction::triggered, this, [=] { cutSelectedWatchesToClipBoard(); });
   contextMenu->addAction(cut);
-  QAction* copy = new QAction("&Copy", this);
+  QAction* copy = new QAction(tr("&Copy"), this);
   connect(copy, &QAction::triggered, this, [=] { copySelectedWatchesToClipBoard(); });
   contextMenu->addAction(copy);
 
   if (canPasteInto)
   {
-    QAction* paste = new QAction("&Paste", this);
+    QAction* paste = new QAction(tr("&Paste"), this);
     connect(paste, &QAction::triggered, this, [=] { pasteWatchFromClipBoard(node); });
     contextMenu->addAction(paste);
   }
 
   contextMenu->addSeparator();
-  QAction* deleteSelection = new QAction("&Delete", this);
+  QAction* deleteSelection = new QAction(tr("&Delete"), this);
   connect(deleteSelection, &QAction::triggered, this, [=] { onDeleteSelection(); });
   contextMenu->addAction(deleteSelection);
 
@@ -356,16 +356,17 @@ void MemWatchWidget::onValueWriteError(const QModelIndex& index,
     int typeIndex = static_cast<int>(entry->getType());
     int baseIndex = static_cast<int>(entry->getBase());
 
-    QString errorMsg("The value you entered for the type " +
-                     GUICommon::g_memTypeNames.at(typeIndex));
+    QString errorMsg;
     if (entry->getType() == Common::MemType::type_byteArray)
-      errorMsg +=
-          (" is invalid, you must enter the bytes in hexadecimal with one space between each "
-           "byte");
+      errorMsg = tr("The value you entered for the type %1 is invalid, you must enter the bytes in "
+                    "hexadecimal with one space between each byte")
+                     .arg(GUICommon::g_memTypeNames.at(typeIndex));
     else
-      errorMsg += (" in the base " + GUICommon::g_memBaseNames.at(baseIndex) + " is invalid");
-    QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, QString("Invalid value"),
-                                            errorMsg, QMessageBox::Ok, this);
+      errorMsg = tr("The value you entered for the type %1 in the base %2 is invalid")
+                     .arg(GUICommon::g_memTypeNames.at(typeIndex))
+                     .arg(GUICommon::g_memBaseNames.at(baseIndex));
+    QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid value"), errorMsg,
+                                            QMessageBox::Ok, this);
     errorBox->exec();
     break;
   }

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -10,7 +10,7 @@
 #include "../Common/CommonUtils.h"
 #include "../DolphinProcess/DolphinAccessor.h"
 
-MemWatchEntry::MemWatchEntry(const std::string label, const u32 consoleAddress,
+MemWatchEntry::MemWatchEntry(const QString label, const u32 consoleAddress,
                              const Common::MemType type, const Common::MemBase base,
                              const bool isUnsigned, const size_t length,
                              const bool isBoundToPointer)
@@ -46,7 +46,7 @@ MemWatchEntry::~MemWatchEntry()
   delete[] m_freezeMemory;
 }
 
-std::string MemWatchEntry::getLabel() const
+QString MemWatchEntry::getLabel() const
 {
   return m_label;
 }
@@ -106,7 +106,7 @@ bool MemWatchEntry::isUnsigned() const
   return m_isUnsigned;
 }
 
-void MemWatchEntry::setLabel(const std::string& label)
+void MemWatchEntry::setLabel(const QString& label)
 {
   m_label = label;
 }

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>
+
 #include "../Common/CommonTypes.h"
 #include "../Common/MemoryCommon.h"
 
@@ -10,14 +12,14 @@ class MemWatchEntry
 {
 public:
   MemWatchEntry();
-  MemWatchEntry(const std::string label, const u32 consoleAddress, const Common::MemType type,
+  MemWatchEntry(const QString label, const u32 consoleAddress, const Common::MemType type,
                 const Common::MemBase = Common::MemBase::base_decimal,
                 const bool m_isUnsigned = false, const size_t length = 1,
                 const bool isBoundToPointer = false);
   MemWatchEntry(MemWatchEntry* entry);
   ~MemWatchEntry();
 
-  std::string getLabel() const;
+  QString getLabel() const;
   Common::MemType getType() const;
   u32 getConsoleAddress() const;
   bool isLocked() const;
@@ -29,7 +31,7 @@ public:
   int getPointerOffset(const int index) const;
   std::vector<int> getPointerOffsets() const;
   size_t getPointerLevel() const;
-  void setLabel(const std::string& label);
+  void setLabel(const QString& label);
   void setConsoleAddress(const u32 address);
   void setTypeAndLength(const Common::MemType type, const size_t length = 1);
   void setBase(const Common::MemBase base);
@@ -52,7 +54,7 @@ public:
 private:
   Common::MemOperationReturnCode writeMemoryToRAM(const char* memory, const size_t size);
 
-  std::string m_label;
+  QString m_label;
   u32 m_consoleAddress;
   bool m_lock = false;
   Common::MemType m_type;

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -153,7 +153,7 @@ void MemWatchTreeNode::readFromJson(const QJsonObject& json, MemWatchTreeNode* p
   {
     m_isGroup = false;
     m_entry = new MemWatchEntry();
-    m_entry->setLabel(json["label"].toString().toStdString());
+    m_entry->setLabel(json["label"].toString());
     std::stringstream ss(json["address"].toString().toStdString());
     u32 address = 0;
     ss >> std::hex >> std::uppercase >> address;
@@ -212,7 +212,7 @@ void MemWatchTreeNode::writeToJson(QJsonObject& json) const
     }
     else
     {
-      json["label"] = QString::fromStdString(m_entry->getLabel());
+      json["label"] = m_entry->getLabel();
       std::stringstream ss;
       ss << std::hex << std::uppercase << m_entry->getConsoleAddress();
       json["address"] = QString::fromStdString(ss.str());
@@ -264,7 +264,7 @@ QString MemWatchTreeNode::writeAsCSV() const
       }
     }
     std::string csvLine =
-        m_entry->getLabel() + ";" + ssAddress.str() + ";" +
+        m_entry->getLabel().toStdString() + ";" + ssAddress.str() + ";" +
         GUICommon::getStringFromType(m_entry->getType(), m_entry->getLength()).toStdString() + "\n";
     return QString::fromStdString(csvLine);
   }


### PR DESCRIPTION
This mainly wraps string literals with `tr`, and for global string literals `QCoreApplication::Translate`. This also changes the strings themselves to take arguments using the QString::arg function, instead of appending them manually.

In `MemViewer::renderColumnsHeaderText` you'll see that the calculation has been altered, which has been done to take the spacing in front of the string into account without including it in the string itself.