### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+
+[*.{h,cpp}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
The `.editorconfig` file overrides the user's formatting settings so that they commit to the style guide of the project. With this, a programmer can keep their preferred settings on (e.g. using tabs instead of spaces), but the IDE will use spaces automatically when working on this project. This works nicely together with clang-format.

Visual Studio has support for this by default, for other IDE's you may need to install a plugin first. Official website: http://editorconfig.org/