### PR TITLE
 Bugfix: 'Add selection' adds wrong addresses

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -157,7 +157,7 @@ void MainWindow::addSelectedResultsToWatchList(Common::MemType type, size_t leng
   QModelIndexList selection = m_scanner->getSelectedResults();
   for (int i = 0; i < selection.count(); i++)
   {
-    u32 address = m_scanner->getResultListModel()->getResultAddress(i);
+    u32 address = m_scanner->getResultListModel()->getResultAddress(selection.at(i).row());
     MemWatchEntry* newEntry =
         new MemWatchEntry(tr("No label"), address, type, base, isUnsigned, length);
     m_watcher->addWatchEntry(newEntry);


### PR DESCRIPTION
Fixed minor oversight with addSelectedResultsToWatchList:
It was adding index 0 to num of selected regardless of what items were selected.