### PR TITLE
increase maximum string length to 9999

### DIFF
--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -60,6 +60,7 @@ void DlgAddWatchEntry::initialiseWidgets()
 
   m_spnLength = new QSpinBox(this);
   m_spnLength->setMinimum(1);
+  m_spnLength->setMaximum(9999);
 }
 
 void DlgAddWatchEntry::makeLayouts()


### PR DESCRIPTION
one line addition
Changed max string length from 99 to 9999

A game I have been working on has many strings far over the 99 limit.
Setting the max to an arbitrary higher limit will prevent others from running into this limitation.