### PR TITLE
feature: add Copy+Paste at current index

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -26,7 +26,7 @@ public:
   void openWatchFile();
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
-  void pasteWatchFromClipBoard(MemWatchTreeNode* node);
+  void pasteWatchFromClipBoard(MemWatchTreeNode* node, int row);
   void saveWatchFile();
   void saveAsWatchFile();
   void clearWatchList();


### PR DESCRIPTION
This is a feature my group has been wanting for a while. Finally got around to implementing it.
Super helpful when dealing with large DMWs as a group and cleaning up organization within DME.

Before:
- Using Ctrl+V would paste copied entry(ies) to the bottom of the DMW, no matter what
- Right-clicking a group or empty space allowed for "Paste" action via ContextMenu. Either adding to end of group or end of DMW, respectively.

After:
- Supports pasting entries to one element below currently selected item
- Enabled ContextMenu->Paste-ing on any element, following same behavior as keyboard 
- If a group is selected, append to end of group (just like ContextMenu->Paste behavior prior to PR)
- If no element is selected place at end of DMW

Misc:
- Removed 'canPasteInto' bool
- Modified signature of pasteWatchFromClipBoard to include an int (row)
- If null (empty list) assumes rootNode is safe and places element at end of rootNode
- Additional counter 'numberIterated' used to copy/paste collections of content in same order

Video demo of new behavior if my descriptions are not clear:
https://streamable.com/aroqh