### PR TITLE
Bouquet of UI enhancements

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -23,6 +23,11 @@ MainWindow::MainWindow()
   DolphinComm::DolphinAccessor::init();
   makeMemViewer();
   firstHookAttempt();
+
+  if (SConfig::getInstance().getMainWindowGeometry().size())
+    restoreGeometry(SConfig::getInstance().getMainWindowGeometry());
+  if (SConfig::getInstance().getMainWindowState().size())
+    restoreState(SConfig::getInstance().getMainWindowState());
 }
 
 MainWindow::~MainWindow()
@@ -399,6 +404,8 @@ void MainWindow::closeEvent(QCloseEvent* event)
 {
   if (m_watcher->warnIfUnsavedChanges())
   {
+    SConfig::getInstance().setMainWindowGeometry(saveGeometry());
+    SConfig::getInstance().setMainWindowState(saveState());
     m_viewer->close();
     event->accept();
   }

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -17,6 +17,7 @@
 
 MainWindow::MainWindow()
 {
+  setWindowTitle("Dolphin Memory Engine");
   initialiseWidgets();
   makeLayouts();
   makeMenus();
@@ -372,7 +373,7 @@ void MainWindow::onOpenSettings()
 
 void MainWindow::onAbout()
 {
-  QString title = tr("About Dolphin memory engine");
+  QString title = tr("About Dolphin Memory Engine");
   QString text =
       "Beta version 0.6.0\n\n" +
       tr("A RAM search made to facilitate research and reverse engineering of GameCube and Wii "

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -4,6 +4,7 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QShortcut>
+#include <QSplitter>
 #include <QString>
 #include <QVBoxLayout>
 #include <string>
@@ -134,16 +135,24 @@ void MainWindow::makeLayouts()
   QFrame* separatorline = new QFrame();
   separatorline->setFrameShape(QFrame::HLine);
 
+  QSplitter* splitter = new QSplitter(Qt::Vertical);
+  splitter->addWidget(m_scanner);
+  splitter->addWidget(m_watcher);
+
+  if (SConfig::getInstance().getSplitterState().size())
+    splitter->restoreState(SConfig::getInstance().getSplitterState());
+
+  connect(splitter, &QSplitter::splitterMoved,
+          [splitter = splitter]()
+          { SConfig::getInstance().setSplitterState(splitter->saveState()); });
+
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(m_lblDolphinStatus);
   mainLayout->addLayout(dolphinHookButtons_layout);
+  mainLayout->addWidget(m_btnOpenMemViewer);
   mainLayout->addWidget(m_lblMem2Status);
   mainLayout->addWidget(separatorline);
-  mainLayout->addWidget(m_scanner);
-  mainLayout->addSpacing(5);
-  mainLayout->addWidget(m_btnOpenMemViewer);
-  mainLayout->addSpacing(5);
-  mainLayout->addWidget(m_watcher);
+  mainLayout->addWidget(splitter);
 
   QWidget* mainWidget = new QWidget();
   mainWidget->setLayout(mainLayout);

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -29,6 +29,8 @@ MainWindow::MainWindow()
     restoreGeometry(SConfig::getInstance().getMainWindowGeometry());
   if (SConfig::getInstance().getMainWindowState().size())
     restoreState(SConfig::getInstance().getMainWindowState());
+
+  m_watcher->restoreWatchModel(SConfig::getInstance().getWatchModel());
 }
 
 MainWindow::~MainWindow()
@@ -391,6 +393,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 {
   if (m_watcher->warnIfUnsavedChanges())
   {
+    SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
     SConfig::getInstance().setMainWindowGeometry(saveGeometry());
     SConfig::getInstance().setMainWindowState(saveState());
     m_viewer->close();

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -54,10 +54,6 @@ void MainWindow::makeMenus()
   m_actSettings = new QAction(tr("&Settings"), this);
   m_actCopyMemory = new QAction(tr("&Copy Memory Range"), this);
 
-  m_actViewScanner = new QAction(tr("&Scanner"), this);
-  m_actViewScanner->setCheckable(true);
-  m_actViewScanner->setChecked(true);
-
   m_actQuit = new QAction(tr("&Quit"), this);
   m_actAbout = new QAction(tr("&About"), this);
   connect(m_actOpenWatchList, &QAction::triggered, this, &MainWindow::onOpenWatchFile);
@@ -69,15 +65,6 @@ void MainWindow::makeMenus()
 
   connect(m_actSettings, &QAction::triggered, this, &MainWindow::onOpenSettings);
   connect(m_actCopyMemory, &QAction::triggered, this, &MainWindow::onCopyMemory);
-
-  connect(m_actViewScanner, &QAction::toggled, this,
-          [=]
-          {
-            if (m_actViewScanner->isChecked())
-              m_scanner->show();
-            else
-              m_scanner->hide();
-          });
 
   connect(m_actQuit, &QAction::triggered, this, &MainWindow::onQuit);
   connect(m_actAbout, &QAction::triggered, this, &MainWindow::onAbout);
@@ -95,7 +82,6 @@ void MainWindow::makeMenus()
   m_menuEdit->addAction(m_actSettings);
 
   m_menuView = menuBar()->addMenu(tr("&View"));
-  m_menuView->addAction(m_actViewScanner);
   m_menuView->addAction(m_actCopyMemory);
 
   m_menuHelp = menuBar()->addMenu(tr("&Help"));

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -391,16 +391,9 @@ void MainWindow::onQuit()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-  if (m_watcher->warnIfUnsavedChanges())
-  {
-    SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
-    SConfig::getInstance().setMainWindowGeometry(saveGeometry());
-    SConfig::getInstance().setMainWindowState(saveState());
-    m_viewer->close();
-    event->accept();
-  }
-  else
-  {
-    event->ignore();
-  }
+  SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
+  SConfig::getInstance().setMainWindowGeometry(saveGeometry());
+  SConfig::getInstance().setMainWindowState(saveState());
+  m_viewer->close();
+  event->accept();
 }

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -70,7 +70,6 @@ private:
   QAction* m_actClearWatchList;
   QAction* m_actImportFromCT;
   QAction* m_actExportAsCSV;
-  QAction* m_actViewScanner;
   QAction* m_actSettings;
   QAction* m_actQuit;
   QAction* m_actAbout;

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -471,7 +471,7 @@ void MemViewer::addByteIndexAsWatch(int index)
   entry->setConsoleAddress(m_currentFirstAddress + index);
   DlgAddWatchEntry* dlg = new DlgAddWatchEntry(true, entry, this);
   if (dlg->exec() == QDialog::Accepted)
-    emit addWatch(dlg->getEntry());
+    emit addWatch(dlg->stealEntry());
 }
 
 bool MemViewer::handleNaviguationKey(const int key, bool shiftIsHeld)

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -469,7 +469,7 @@ void MemViewer::addByteIndexAsWatch(int index)
 {
   MemWatchEntry* entry = new MemWatchEntry();
   entry->setConsoleAddress(m_currentFirstAddress + index);
-  DlgAddWatchEntry* dlg = new DlgAddWatchEntry(entry);
+  DlgAddWatchEntry* dlg = new DlgAddWatchEntry(true, entry, this);
   if (dlg->exec() == QDialog::Accepted)
     emit addWatch(dlg->getEntry());
 }

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -9,6 +9,7 @@
 
 MemViewerWidget::MemViewerWidget(QWidget* parent, u32 consoleAddress) : QWidget(parent)
 {
+  setWindowTitle("Memory Viewer");
   initialiseWidgets();
   makeLayouts();
 

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -413,7 +413,9 @@ void DlgAddWatchEntry::onIsPointerChanged()
   updatePreview();
 }
 
-MemWatchEntry* DlgAddWatchEntry::getEntry() const
+MemWatchEntry* DlgAddWatchEntry::stealEntry()
 {
-  return m_entry;
+  MemWatchEntry* entry{m_entry};
+  m_entry = nullptr;
+  return entry;
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -10,8 +10,11 @@
 #include "../../../DolphinProcess/DolphinAccessor.h"
 #include "../../GUICommon.h"
 
-DlgAddWatchEntry::DlgAddWatchEntry(MemWatchEntry* entry)
+DlgAddWatchEntry::DlgAddWatchEntry(const bool newEntry, MemWatchEntry* const entry,
+                                   QWidget* const parent)
+    : QDialog(parent)
 {
+  setWindowTitle(newEntry ? "Add Watch" : "Edit Watch");
   initialiseWidgets();
   makeLayouts();
   fillFields(entry);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -41,7 +41,7 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_lblValuePreview->setReadOnly(true);
 
   m_txbAddress = new QLineEdit(this);
-  m_txbAddress->setMaxLength(8);
+  m_txbAddress->setMaxLength(10);
   connect(m_txbAddress, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onAddressChanged);
 
   m_offsetsLayout = new QGridLayout;

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -1,6 +1,7 @@
 #include "DlgAddWatchEntry.h"
 
 #include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QHBoxLayout>
 #include <QMessageBox>
 #include <QVBoxLayout>
@@ -33,7 +34,8 @@ void DlgAddWatchEntry::initialiseWidgets()
   connect(m_chkBoundToPointer, &QCheckBox::stateChanged, this,
           &DlgAddWatchEntry::onIsPointerChanged);
 
-  m_lblValuePreview = new QLabel("", this);
+  m_lblValuePreview = new QLineEdit("", this);
+  m_lblValuePreview->setReadOnly(true);
 
   m_txbAddress = new QLineEdit(this);
   m_txbAddress->setMaxLength(8);
@@ -49,94 +51,64 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_btnRemoveOffset = new QPushButton("Remove offset");
   connect(m_btnRemoveOffset, &QPushButton::clicked, this, &DlgAddWatchEntry::removePointerOffset);
 
-  m_pointerWidget = new QWidget(this);
+  m_pointerWidget = new QGroupBox("Offsets (in hex)", this);
 
   m_txbLabel = new QLineEdit(this);
 
   m_cmbTypes = new QComboBox(this);
   m_cmbTypes->addItems(GUICommon::g_memTypeNames);
 
-  m_lengtWidget = new QWidget;
-
   m_spnLength = new QSpinBox(this);
+  m_spnLength->setPrefix("Length: ");
   m_spnLength->setMinimum(1);
   m_spnLength->setMaximum(9999);
 }
 
 void DlgAddWatchEntry::makeLayouts()
 {
-  QLabel* lblPreview = new QLabel("Value preview: ");
-  QHBoxLayout* preview_layout = new QHBoxLayout;
-  preview_layout->addWidget(lblPreview);
-  preview_layout->addWidget(m_lblValuePreview);
-  preview_layout->addStretch();
-  QWidget* preview_widget = new QWidget();
-  preview_widget->setLayout(preview_layout);
+  QFormLayout* formLayout = new QFormLayout;
+  formLayout->setLabelAlignment(Qt::AlignRight);
+  formLayout->addRow("Preview:", m_lblValuePreview);
+  formLayout->addRow("Address:", m_txbAddress);
+  formLayout->addRow("Label:", m_txbLabel);
 
-  QLabel* lblAddress = new QLabel("Address: ", this);
-
-  QHBoxLayout* layout_addressAndPreview = new QHBoxLayout;
-  layout_addressAndPreview->addWidget(lblAddress);
-  layout_addressAndPreview->addWidget(m_txbAddress);
-  layout_addressAndPreview->addStretch();
-  QWidget* addressWidget = new QWidget(this);
-  addressWidget->setLayout(layout_addressAndPreview);
+  QHBoxLayout* layout_type = new QHBoxLayout;
+  layout_type->setContentsMargins(0, 0, 0, 0);
+  layout_type->addWidget(m_cmbTypes, 1);
+  layout_type->addWidget(m_spnLength);
+  QWidget* widget_type = new QWidget;
+  widget_type->setLayout(layout_type);
+  widget_type->setContentsMargins(0, 0, 0, 0);
+  formLayout->addRow("Type:", widget_type);
 
   QWidget* offsetsWidget = new QWidget();
   offsetsWidget->setLayout(m_offsetsLayout);
-
-  QLabel* lblOffset = new QLabel("Offsets (in hex): ", this);
+  offsetsWidget->setContentsMargins(0, 0, 0, 0);
+  m_offsetsLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout* pointerButtons_layout = new QHBoxLayout;
+  pointerButtons_layout->setContentsMargins(0, 0, 0, 0);
   pointerButtons_layout->addWidget(m_btnAddOffset);
   pointerButtons_layout->addWidget(m_btnRemoveOffset);
   QWidget* pointerButtons_widget = new QWidget();
+  pointerButtons_widget->setContentsMargins(0, 0, 0, 0);
   pointerButtons_widget->setLayout(pointerButtons_layout);
 
   QVBoxLayout* pointerOffset_layout = new QVBoxLayout;
-  pointerOffset_layout->setSpacing(1);
-  pointerOffset_layout->addWidget(lblOffset);
-  pointerOffset_layout->addWidget(offsetsWidget);
   pointerOffset_layout->addWidget(pointerButtons_widget);
+  pointerOffset_layout->addWidget(offsetsWidget);
   pointerOffset_layout->addStretch();
-  pointerOffset_layout->setContentsMargins(0, 0, 0, 0);
   m_pointerWidget->setLayout(pointerOffset_layout);
-
-  QLabel* lblLabel = new QLabel("Label: ", this);
-  QHBoxLayout* layout_label = new QHBoxLayout;
-  layout_label->addWidget(lblLabel);
-  layout_label->addWidget(m_txbLabel);
-  QWidget* labelWidget = new QWidget(this);
-  labelWidget->setLayout(layout_label);
-
-  QLabel* lblType = new QLabel("Type: ", this);
-
-  QHBoxLayout* layout_type = new QHBoxLayout;
-  layout_type->addWidget(lblType);
-  layout_type->addWidget(m_cmbTypes);
-  QWidget* typeWidget = new QWidget(this);
-  typeWidget->setLayout(layout_type);
-
-  QLabel* lblLength = new QLabel(QString("Length: "), this);
-  QHBoxLayout* layout_length = new QHBoxLayout;
-  layout_length->addWidget(lblLength);
-  layout_length->addWidget(m_spnLength);
-  m_lengtWidget->setLayout(layout_length);
 
   QDialogButtonBox* buttonBox =
       new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
   QVBoxLayout* main_layout = new QVBoxLayout;
-  main_layout->setSpacing(1);
-  main_layout->addWidget(preview_widget);
+  main_layout->addLayout(formLayout);
   main_layout->addWidget(m_chkBoundToPointer);
-  main_layout->addWidget(addressWidget);
   main_layout->addWidget(m_pointerWidget);
-  main_layout->addWidget(labelWidget);
-  main_layout->addWidget(typeWidget);
-  main_layout->addWidget(m_lengtWidget);
-  main_layout->addWidget(buttonBox);
   main_layout->addStretch();
+  main_layout->addWidget(buttonBox);
   setLayout(main_layout);
 
   connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgAddWatchEntry::accept);
@@ -151,7 +123,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 
     m_cmbTypes->setCurrentIndex(0);
     m_spnLength->setValue(1);
-    m_lengtWidget->hide();
+    m_spnLength->hide();
     m_lblValuePreview->setText("???");
     m_chkBoundToPointer->setChecked(false);
     m_pointerWidget->hide();
@@ -164,9 +136,9 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     m_cmbTypes->setCurrentIndex(static_cast<int>(m_entry->getType()));
     if (m_entry->getType() == Common::MemType::type_string ||
         m_entry->getType() == Common::MemType::type_byteArray)
-      m_lengtWidget->show();
+      m_spnLength->show();
     else
-      m_lengtWidget->hide();
+      m_spnLength->hide();
     m_txbLabel->setText(m_entry->getLabel());
     std::stringstream ssAddress;
     ssAddress << std::hex << std::uppercase << m_entry->getConsoleAddress();
@@ -296,9 +268,9 @@ void DlgAddWatchEntry::onTypeChange(int index)
 {
   Common::MemType theType = static_cast<Common::MemType>(index);
   if (theType == Common::MemType::type_string || theType == Common::MemType::type_byteArray)
-    m_lengtWidget->show();
+    m_spnLength->show();
   else
-    m_lengtWidget->hide();
+    m_spnLength->hide();
   m_entry->setTypeAndLength(theType, m_spnLength->value());
   if (validateAndSetAddress())
     updatePreview();

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -16,7 +16,7 @@
 class DlgAddWatchEntry : public QDialog
 {
 public:
-  DlgAddWatchEntry(MemWatchEntry* entry);
+  DlgAddWatchEntry(bool newEntry, MemWatchEntry* entry, QWidget* parent);
   ~DlgAddWatchEntry();
   void onTypeChange(int index);
   void accept();

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -24,7 +24,7 @@ public:
   void onIsPointerChanged();
   void onLengthChanged();
   void onOffsetChanged();
-  MemWatchEntry* getEntry() const;
+  MemWatchEntry* stealEntry();
 
 private:
   void initialiseWidgets();

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -4,6 +4,7 @@
 #include <QComboBox>
 #include <QDialog>
 #include <QGridLayout>
+#include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -43,12 +44,11 @@ private:
   QVector<QLabel*> m_addressPath;
   QGridLayout* m_offsetsLayout;
   QCheckBox* m_chkBoundToPointer;
-  QLabel* m_lblValuePreview;
+  QLineEdit* m_lblValuePreview;
   QLineEdit* m_txbLabel;
   QComboBox* m_cmbTypes;
   QSpinBox* m_spnLength;
-  QWidget* m_lengtWidget;
-  QWidget* m_pointerWidget;
+  QGroupBox* m_pointerWidget;
   QPushButton* m_btnAddOffset;
   QPushButton* m_btnRemoveOffset;
 };

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -1,6 +1,7 @@
 #include "DlgChangeType.h"
 
 #include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QVBoxLayout>
@@ -20,9 +21,8 @@ void DlgChangeType::initialiseWidgets()
   m_cmbTypes->addItems(GUICommon::g_memTypeNames);
   m_cmbTypes->setCurrentIndex(m_typeIndex);
 
-  m_lengthSelection = new QWidget;
-
   m_spnLength = new QSpinBox(this);
+  m_spnLength->setPrefix("Length: ");
   m_spnLength->setMinimum(1);
   m_spnLength->setMaximum(9999);
   m_spnLength->setValue(static_cast<int>(m_length));
@@ -33,23 +33,22 @@ void DlgChangeType::initialiseWidgets()
 
 void DlgChangeType::makeLayouts()
 {
-  QLabel* lblType = new QLabel(tr("New type: "), this);
-  QLabel* lblLength = new QLabel(tr("Length: "), this);
+  QHBoxLayout* layout_type = new QHBoxLayout;
+  layout_type->setSpacing(5);
+  layout_type->setContentsMargins(0, 0, 0, 0);
+  layout_type->addWidget(m_cmbTypes, 1);
+  layout_type->addWidget(m_spnLength);
+  QWidget* widget_type = new QWidget;
+  widget_type->setLayout(layout_type);
+  widget_type->setContentsMargins(0, 0, 0, 0);
 
-  QWidget* typeSelection = new QWidget(this);
-  QHBoxLayout* typeSelectionLayout = new QHBoxLayout;
-  typeSelectionLayout->addWidget(lblType);
-  typeSelectionLayout->addWidget(m_cmbTypes);
-  typeSelection->setLayout(typeSelectionLayout);
-
-  QHBoxLayout* lengthSelectionLayout = new QHBoxLayout;
-  lengthSelectionLayout->addWidget(lblLength);
-  lengthSelectionLayout->addWidget(m_spnLength);
-  m_lengthSelection->setLayout(lengthSelectionLayout);
+  QFormLayout* formLayout = new QFormLayout;
+  formLayout->setLabelAlignment(Qt::AlignRight);
+  formLayout->addRow("New type:", widget_type);
 
   Common::MemType theType = static_cast<Common::MemType>(m_typeIndex);
   if (theType != Common::MemType::type_string && theType != Common::MemType::type_byteArray)
-    m_lengthSelection->hide();
+    m_spnLength->hide();
 
   QDialogButtonBox* buttonBox =
       new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -57,11 +56,9 @@ void DlgChangeType::makeLayouts()
   connect(buttonBox, &QDialogButtonBox::rejected, this, &DlgChangeType::reject);
 
   QVBoxLayout* main_layout = new QVBoxLayout;
-
-  main_layout->addWidget(typeSelection);
-  main_layout->addWidget(m_lengthSelection);
+  main_layout->addLayout(formLayout);
+  main_layout->addStretch();
   main_layout->addWidget(buttonBox);
-  main_layout->setSpacing(1);
   setLayout(main_layout);
 }
 
@@ -87,8 +84,8 @@ void DlgChangeType::onTypeChange(int index)
 {
   Common::MemType theType = static_cast<Common::MemType>(index);
   if (theType == Common::MemType::type_string || theType == Common::MemType::type_byteArray)
-    m_lengthSelection->show();
+    m_spnLength->show();
   else
-    m_lengthSelection->hide();
+    m_spnLength->hide();
   adjustSize();
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -11,6 +11,7 @@
 DlgChangeType::DlgChangeType(QWidget* parent, const int typeIndex, const size_t length)
     : QDialog(parent), m_typeIndex(typeIndex), m_length(length)
 {
+  setWindowTitle("Change Type");
   initialiseWidgets();
   makeLayouts();
 }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -786,7 +786,7 @@ bool MemWatchWidget::warnIfUnsavedChanges()
     QMessageBox* questionBox = new QMessageBox(
         QMessageBox::Question, "Unsaved changes",
         "You have unsaved changes in the current watch list, do you want to save them?",
-        QMessageBox::Cancel | QMessageBox::No | QMessageBox::Yes);
+        QMessageBox::Cancel | QMessageBox::No | QMessageBox::Yes, this);
     switch (questionBox->exec())
     {
     case QMessageBox::Cancel:

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -800,3 +800,17 @@ bool MemWatchWidget::warnIfUnsavedChanges()
   }
   return true;
 }
+
+void MemWatchWidget::restoreWatchModel(const QString& json)
+{
+  const QJsonDocument loadDoc(QJsonDocument::fromJson(json.toUtf8()));
+  m_watchModel->loadRootFromJsonRecursive(loadDoc.object());
+}
+
+QString MemWatchWidget::saveWatchModel()
+{
+  QJsonObject root;
+  m_watchModel->writeRootToJsonRecursive(root);
+  QJsonDocument saveDoc(root);
+  return saveDoc.toJson();
+}

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -383,7 +383,7 @@ void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)
     else if (index.column() == MemWatchModel::WATCH_COL_ADDRESS && !node->isGroup())
     {
       MemWatchEntry* entryCopy = new MemWatchEntry(node->getEntry());
-      DlgAddWatchEntry* dlg = new DlgAddWatchEntry(entryCopy);
+      DlgAddWatchEntry* dlg = new DlgAddWatchEntry(false, entryCopy, this);
       if (dlg->exec() == QDialog::Accepted)
       {
         m_watchModel->editEntry(entryCopy, index);
@@ -467,7 +467,7 @@ void MemWatchWidget::onAddGroup()
 
 void MemWatchWidget::onAddWatchEntry()
 {
-  DlgAddWatchEntry* dlg = new DlgAddWatchEntry(nullptr);
+  DlgAddWatchEntry* dlg = new DlgAddWatchEntry(true, nullptr, this);
   if (dlg->exec() == QDialog::Accepted)
     addWatchEntry(dlg->getEntry());
 }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -469,7 +469,7 @@ void MemWatchWidget::onAddWatchEntry()
 {
   DlgAddWatchEntry* dlg = new DlgAddWatchEntry(true, nullptr, this);
   if (dlg->exec() == QDialog::Accepted)
-    addWatchEntry(dlg->getEntry());
+    addWatchEntry(dlg->stealEntry());
 }
 
 void MemWatchWidget::addWatchEntry(MemWatchEntry* entry)

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -62,7 +62,6 @@ void MemWatchWidget::initialiseWidgets()
   connect(m_watchView, &QAbstractItemView::doubleClicked, this,
           &MemWatchWidget::onWatchDoubleClicked);
   m_watchView->setItemDelegate(m_watchDelegate);
-  m_watchView->setSortingEnabled(true);
   m_watchView->setModel(m_watchModel);
 
   m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_LOCK, 50);

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -37,6 +37,8 @@ public:
   QTimer* getUpdateTimer() const;
   QTimer* getFreezeTimer() const;
   bool warnIfUnsavedChanges();
+  void restoreWatchModel(const QString& json);
+  QString saveWatchModel();
 
 signals:
   void mustUnhook();

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -16,6 +16,16 @@ SConfig& SConfig::getInstance()
   return instance;
 }
 
+QByteArray SConfig::getMainWindowGeometry() const
+{
+  return m_settings->value("mainWindowSettings/mainWindowGeometry", QByteArray{}).toByteArray();
+}
+
+QByteArray SConfig::getMainWindowState() const
+{
+  return m_settings->value("mainWindowSettings/mainWindowState", QByteArray{}).toByteArray();
+}
+
 QByteArray SConfig::getSplitterState() const
 {
   return m_settings->value("mainWindowSettings/splitterState", QByteArray{}).toByteArray();
@@ -44,6 +54,16 @@ int SConfig::getViewerUpdateTimerMs() const
 int SConfig::getViewerNbrBytesSeparator() const
 {
   return m_settings->value("viewerSettings/nbrBytesSeparator", 1).toInt();
+}
+
+void SConfig::setMainWindowGeometry(QByteArray const& geometry)
+{
+  m_settings->setValue("mainWindowSettings/mainWindowGeometry", geometry);
+}
+
+void SConfig::setMainWindowState(QByteArray const& state)
+{
+  m_settings->setValue("mainWindowSettings/mainWindowState", state);
 }
 
 void SConfig::setSplitterState(QByteArray const& state)

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -18,6 +18,11 @@ SConfig& SConfig::getInstance()
   return instance;
 }
 
+QString SConfig::getWatchModel() const
+{
+  return m_settings->value("watchModel", QString{}).toString();
+}
+
 QByteArray SConfig::getMainWindowGeometry() const
 {
   return m_settings->value("mainWindowSettings/mainWindowGeometry", QByteArray{}).toByteArray();
@@ -56,6 +61,11 @@ int SConfig::getViewerUpdateTimerMs() const
 int SConfig::getViewerNbrBytesSeparator() const
 {
   return m_settings->value("viewerSettings/nbrBytesSeparator", 1).toInt();
+}
+
+void SConfig::setWatchModel(const QString& json)
+{
+  m_settings->setValue("watchModel", json);
 }
 
 void SConfig::setMainWindowGeometry(QByteArray const& geometry)

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -2,7 +2,9 @@
 
 SConfig::SConfig()
 {
-  m_settings = new QSettings("settings.ini", QSettings::IniFormat);
+  const QString organization{"dolphin-memory-engine"};
+  const QString application{"dolphin-memory-engine"};
+  m_settings = new QSettings(QSettings::IniFormat, QSettings::UserScope, organization, application);
 }
 
 SConfig::~SConfig()

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -16,6 +16,11 @@ SConfig& SConfig::getInstance()
   return instance;
 }
 
+QByteArray SConfig::getSplitterState() const
+{
+  return m_settings->value("mainWindowSettings/splitterState", QByteArray{}).toByteArray();
+}
+
 int SConfig::getWatcherUpdateTimerMs() const
 {
   return m_settings->value("timerSettings/watcherUpdateTimerMs", 100).toInt();
@@ -39,6 +44,11 @@ int SConfig::getViewerUpdateTimerMs() const
 int SConfig::getViewerNbrBytesSeparator() const
 {
   return m_settings->value("viewerSettings/nbrBytesSeparator", 1).toInt();
+}
+
+void SConfig::setSplitterState(QByteArray const& state)
+{
+  m_settings->setValue("mainWindowSettings/splitterState", state);
 }
 
 void SConfig::setWatcherUpdateTimerMs(const int updateTimerMs)

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -10,6 +10,8 @@ public:
   SConfig(SConfig const&) = delete;
   void operator=(SConfig const&) = delete;
 
+  QByteArray getMainWindowGeometry() const;
+  QByteArray getMainWindowState() const;
   QByteArray getSplitterState() const;
 
   int getWatcherUpdateTimerMs() const;
@@ -19,6 +21,8 @@ public:
 
   int getViewerNbrBytesSeparator() const;
 
+  void setMainWindowGeometry(QByteArray const&);
+  void setMainWindowState(QByteArray const&);
   void setSplitterState(QByteArray const&);
 
   void setWatcherUpdateTimerMs(const int watcherUpdateTimerMs);

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QByteArray>
 #include <QSettings>
 
 class SConfig
@@ -9,12 +10,16 @@ public:
   SConfig(SConfig const&) = delete;
   void operator=(SConfig const&) = delete;
 
+  QByteArray getSplitterState() const;
+
   int getWatcherUpdateTimerMs() const;
   int getFreezeTimerMs() const;
   int getScannerUpdateTimerMs() const;
   int getViewerUpdateTimerMs() const;
 
   int getViewerNbrBytesSeparator() const;
+
+  void setSplitterState(QByteArray const&);
 
   void setWatcherUpdateTimerMs(const int watcherUpdateTimerMs);
   void setFreezeTimerMs(const int freezeTimerMs);

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -14,6 +14,8 @@ public:
   QByteArray getMainWindowState() const;
   QByteArray getSplitterState() const;
 
+  QString getWatchModel() const;
+
   int getWatcherUpdateTimerMs() const;
   int getFreezeTimerMs() const;
   int getScannerUpdateTimerMs() const;
@@ -24,6 +26,8 @@ public:
   void setMainWindowGeometry(QByteArray const&);
   void setMainWindowState(QByteArray const&);
   void setSplitterState(QByteArray const&);
+
+  void setWatchModel(const QString& json);
 
   void setWatcherUpdateTimerMs(const int watcherUpdateTimerMs);
   void setFreezeTimerMs(const int freezeTimerMs);


### PR DESCRIPTION
A number improvements to the UI:

- Add splitter in main window to allow resizing:

<img src="https://user-images.githubusercontent.com/1853278/174156367-33d1fc08-dd73-4a2a-ad7e-ce7b6dc3d72f.gif" width="480"/>

- Store window state and window geometry in settings file. State is restored on startup.
- Provide a window title to all dialogs (**Add Watch**, **Edit Watch**, **Memory Viewer**, **Dolphin Memory Engine**, ...).
- Rework **Add Watch** dialog with a proper form layout:

![image](https://user-images.githubusercontent.com/1853278/174156810-046c9185-461e-4efa-b53e-a33d94187477.png)

- Memory watch list is now saved as part of the settings; list is restored on startup.
- Support for memory addresses that start with the `0x` prefix.
- Rows in the memory watch table are no longer sortable: users could mistakenly reordered their curated list.

Bug fixes:

- Crash involving a double deallocation in `DlgAddWatchEntry`.