### PR TITLE
Features: CopyMemoryRange (new View); Search Range; Undo Search

### DIFF
--- a/Source/Dolphin-memory-engine.vcxproj
+++ b/Source/Dolphin-memory-engine.vcxproj
@@ -118,6 +118,7 @@
     <ClInclude Include="**\*.h" Exclude="GUI\**\*.h" />
     <!-- These files don't need to be Moc'ed -->
     <ClInclude Include="GUI\GUICommon.h" />
+    <ClInclude Include="GUI\MemCopy\DlgCopy.h" />
     <ClInclude Include="GUI\MemWatcher\Dialogs\DlgAddWatchEntry.h" />
     <ClInclude Include="GUI\MemWatcher\MemWatchDelegate.h" />
     <ClInclude Include="GUI\MemWatcher\MemWatchTreeNode.h" />

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -10,6 +10,7 @@
 
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"
+#include "MemCopy/DlgCopy.h"
 #include "Settings/DlgSettings.h"
 #include "Settings/SConfig.h"
 
@@ -45,6 +46,7 @@ void MainWindow::makeMenus()
   m_actImportFromCT->setShortcut(Qt::Modifier::CTRL + Qt::Key::Key_I);
 
   m_actSettings = new QAction(tr("&Settings"), this);
+  m_actCopyMemory = new QAction(tr("&Copy Memory Range"), this);
 
   m_actViewScanner = new QAction(tr("&Scanner"), this);
   m_actViewScanner->setCheckable(true);
@@ -60,6 +62,7 @@ void MainWindow::makeMenus()
   connect(m_actExportAsCSV, &QAction::triggered, this, &MainWindow::onExportAsCSV);
 
   connect(m_actSettings, &QAction::triggered, this, &MainWindow::onOpenSettings);
+  connect(m_actCopyMemory, &QAction::triggered, this, &MainWindow::onCopyMemory);
 
   connect(m_actViewScanner, &QAction::toggled, this,
           [=]
@@ -87,6 +90,7 @@ void MainWindow::makeMenus()
 
   m_menuView = menuBar()->addMenu(tr("&View"));
   m_menuView->addAction(m_actViewScanner);
+  m_menuView->addAction(m_actCopyMemory);
 
   m_menuHelp = menuBar()->addMenu(tr("&Help"));
   m_menuHelp->addAction(m_actAbout);
@@ -335,6 +339,13 @@ void MainWindow::onImportFromCT()
 void MainWindow::onExportAsCSV()
 {
   m_watcher->exportWatchListAsCSV();
+}
+
+void MainWindow::onCopyMemory()
+{
+  DlgCopy* dlg = new DlgCopy(this);
+  int dlgResult = dlg->exec();
+  delete dlg;
 }
 
 void MainWindow::onOpenSettings()

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -39,6 +39,7 @@ public:
   void onOpenSettings();
   void onImportFromCT();
   void onExportAsCSV();
+  void onCopyMemory();
   void onAbout();
   void onQuit();
 
@@ -73,4 +74,5 @@ private:
   QAction* m_actSettings;
   QAction* m_actQuit;
   QAction* m_actAbout;
+  QAction* m_actCopyMemory;
 };

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -1,0 +1,305 @@
+#include "DlgCopy.h"
+
+#include "../../DolphinProcess/DolphinAccessor.h"
+#include <QAbstractButton>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <sstream>
+#include <utility>
+#include <qmessagebox.h>
+#include "../../Common/CommonUtils.h"
+
+DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
+{
+  QGroupBox* grbCopySettings = new QGroupBox();
+
+  QVBoxLayout* entireCopyLayout = new QVBoxLayout;
+
+  QFormLayout* copySettingsLayout = new QFormLayout();
+  m_spnWatcherCopyAddress = new QLineEdit();
+  m_spnWatcherCopyAddress->setMaxLength(8);
+  copySettingsLayout->addRow("Base Address", m_spnWatcherCopyAddress);
+
+  m_spnWatcherCopySize = new QLineEdit();
+  copySettingsLayout->addRow("Byte Count", m_spnWatcherCopySize);
+  copySettingsLayout->setLabelAlignment(Qt::AlignRight);
+  entireCopyLayout->addLayout(copySettingsLayout);
+
+  m_cmbViewerBytesSeparator = new QComboBox();
+  m_cmbViewerBytesSeparator->addItem("Byte String", ByteStringFormats::ByteString);
+  m_cmbViewerBytesSeparator->addItem("Byte String (No Spaces)", ByteStringFormats::ByteStringNoSpaces);
+  m_cmbViewerBytesSeparator->addItem("Python Byte String", ByteStringFormats::PythonByteString);
+  m_cmbViewerBytesSeparator->addItem("Python List", ByteStringFormats::PythonList);
+  m_cmbViewerBytesSeparator->addItem("C Array", ByteStringFormats::CArray);
+  copySettingsLayout->addRow("Byte Format", m_cmbViewerBytesSeparator);
+
+  m_spnWatcherCopyOutput = new QTextEdit();
+  m_spnWatcherCopyOutput->setWordWrapMode(QTextOption::WrapMode::WrapAnywhere);
+  copySettingsLayout->addRow("Output", m_spnWatcherCopyOutput);
+  
+  grbCopySettings->setLayout(entireCopyLayout);
+
+  m_buttonsDlg = new QDialogButtonBox(QDialogButtonBox::Apply | QDialogButtonBox::Close);
+  m_buttonsDlg->setStyleSheet("* { button-layout: 2 }");
+
+  connect(m_buttonsDlg, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(m_buttonsDlg, &QDialogButtonBox::clicked, this,
+          [=](QAbstractButton* button)
+          {
+            auto role = m_buttonsDlg->buttonRole(button);
+            if (role == QDialogButtonBox::ApplyRole)
+            {
+              if (DolphinComm::DolphinAccessor::getStatus() !=
+                  DolphinComm::DolphinAccessor::DolphinStatus::hooked)
+              {
+                enablePage(false);
+                return;
+              }
+              copyMemory();
+            }
+            else if (role == QDialogButtonBox::Close)
+            {
+              QDialog::close();
+            }
+          });
+
+  connect(m_cmbViewerBytesSeparator, &QComboBox::currentTextChanged, this,
+      [=](const QString& string)
+      {
+          updateMemoryText();
+      });
+
+  QVBoxLayout* mainLayout = new QVBoxLayout;
+  mainLayout->addWidget(grbCopySettings);
+  mainLayout->addWidget(m_buttonsDlg);
+
+  enablePage(DolphinComm::DolphinAccessor::getStatus() ==
+             DolphinComm::DolphinAccessor::DolphinStatus::hooked);
+
+  setLayout(mainLayout);
+
+  setWindowTitle(tr("Copy Memory Range"));
+
+  setDefaults();
+}
+
+DlgCopy::~DlgCopy()
+{
+  delete m_buttonsDlg;
+}
+
+void DlgCopy::setDefaults()
+{
+  m_spnWatcherCopyAddress->setText("");
+  m_spnWatcherCopySize->setText("");
+  m_cmbViewerBytesSeparator->setCurrentIndex(ByteStringFormats::ByteString);
+}
+
+void DlgCopy::enablePage(bool enable)
+{
+  m_cmbViewerBytesSeparator->setEnabled(enable);
+  m_spnWatcherCopyAddress->setEnabled(enable);
+  m_spnWatcherCopySize->setEnabled(enable);
+  m_spnWatcherCopyOutput->setEnabled(enable);
+  m_buttonsDlg->setEnabled(enable);
+}
+
+bool DlgCopy::copyMemory()
+{
+  u32 address, count;
+  QMessageBox* errorBox;
+
+  if (!hexStringToU32(m_spnWatcherCopyAddress->text().toStdString(), address))
+  {
+    QString errorMsg =
+        tr("The address you entered is invalid, make sure it is an "
+           "hexadecimal number between 0x80000000 and 0x817FFFFF");
+    if (DolphinComm::DolphinAccessor::isMEM2Present())
+      errorMsg.append(tr(" or between 0x90000000 and 0x93FFFFFF"));
+
+    errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
+                                            QMessageBox::Ok, nullptr);
+    errorBox->exec();
+
+    return false;
+  }
+
+  if (!uintStringToU32(m_spnWatcherCopySize->text().toStdString(), count))
+  {
+    if (!hexStringToU32(m_spnWatcherCopySize->text().toStdString(), count))
+    {
+      errorBox = new QMessageBox(
+          QMessageBox::Critical, tr("Invalid value"),
+          tr("Please make sure the byte count is a valid number in base10 or hexadecimal.\n"
+             "i.e. 5, 10, 12, 16, 0x05, 0xf1, 0x100, 0xab12\n"),
+          QMessageBox::Ok, nullptr);
+      errorBox->exec();
+
+      return false;
+    }
+  }
+
+  if (!DolphinComm::DolphinAccessor::isValidConsoleAddress(address) ||
+      !DolphinComm::DolphinAccessor::isValidConsoleAddress(address + count))
+  {
+    errorBox =
+        new QMessageBox(QMessageBox::Critical, tr("Error reading bytes"),
+                        tr("The suggested range of bytes is invalid."), QMessageBox::Ok, nullptr);
+    errorBox->exec();
+
+    return false;
+  }
+    
+  std::vector<char> newData(count);
+  
+  if (!DolphinComm::DolphinAccessor::readFromRAM(
+          Common::dolphinAddrToOffset(address, DolphinComm::DolphinAccessor::isARAMAccessible()),
+          newData.data(), newData.size(), false))
+  {
+    errorBox = new QMessageBox(QMessageBox::Critical, tr("Error reading bytes"),
+                               tr("Dolphin was unable to read the bytes from the suggested range."),
+                               QMessageBox::Ok, nullptr);
+    errorBox->exec();
+
+    return false;
+  }
+  
+  m_Data = newData;
+
+  updateMemoryText();
+
+  return true;
+}
+
+void DlgCopy::updateMemoryText()
+{
+  m_spnWatcherCopyOutput->setText(QString::fromStdString(charToHexString(m_Data.data(), m_Data.size(),
+                      (DlgCopy::ByteStringFormats)m_cmbViewerBytesSeparator->currentIndex())));
+}
+
+bool DlgCopy::isHexString(std::string str)
+{
+  if (str.length() > 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
+  {
+    str = str.substr(2);
+  }
+
+  for (char c : str)
+  {
+    if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+    {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool DlgCopy::hexStringToU32(std::string str, u32& output)
+{
+  // if (str.empty() || str.length() % 2 == 1)
+  if (str.empty())
+    return false;
+
+  if (!isHexString(str))
+    return false;
+
+  std::stringstream ss(str);
+
+  ss >> std::hex;
+  ss >> output;
+
+  return true;
+}
+
+bool DlgCopy::isUnsignedIntegerString(std::string str)
+{
+  for (char c: str)
+  {
+    if (c >= '0' && c <= '9')
+    {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool DlgCopy::uintStringToU32(std::string str, u32& output)
+{
+  if (!isUnsignedIntegerString(str) || str.empty() || str.length() > 10)
+    return false;
+
+  u64 u = std::stoll(str);
+
+  if (u > ULONG_MAX)
+    return false;
+
+  output = (u32)u;
+  return true;
+}
+
+std::string DlgCopy::charToHexString(char* input, size_t count, DlgCopy::ByteStringFormats format)
+{
+  std::stringstream ss;
+  const char convert[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  std::string beforeAll = "";
+  std::string beforeByte = "";
+  std::string betweenBytes = "";
+  std::string afterAll = "";
+  
+  switch (format)
+  {
+  case ByteString:
+    beforeAll = "";
+    beforeByte = "";
+    betweenBytes = " ";
+    afterAll = "";
+    break;
+  case ByteStringNoSpaces:
+    beforeAll = "";
+    beforeByte = "";
+    betweenBytes = "";
+    afterAll = "";
+    break;
+  case PythonByteString:
+    beforeAll = "b\'";
+    beforeByte = "\\x";
+    betweenBytes = "";
+    afterAll = "\'";
+    break;
+  case PythonList:
+    beforeAll = "[ ";
+    beforeByte = "0x";
+    betweenBytes = ", ";
+    afterAll = " ]";
+    break;
+  case CArray:
+    beforeAll = "{ ";
+    beforeByte = "0x";
+    betweenBytes = ", ";
+    afterAll = " }";
+    break;
+  default:
+    return "";
+  }
+  
+  ss << beforeAll;
+
+  for (int i = 0; i < count; i++)
+  {
+    ss << beforeByte << convert[(input[i] >> 4) & 0xf] << convert[input[i] & 0xf];
+    
+    if (i != count - 1)
+    {
+      ss << betweenBytes;
+    }
+  }
+
+  ss << afterAll;
+
+  return ss.str();
+}

--- a/Source/GUI/MemCopy/DlgCopy.h
+++ b/Source/GUI/MemCopy/DlgCopy.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QComboBox>
+#include <QDialog>
+#include <QSpinBox>
+#include <qlineedit.h>
+#include "..\GUICommon.h"
+#include <QDialogButtonBox>
+#include <qtextedit.h>
+
+class DlgCopy : public QDialog
+{
+public:
+  DlgCopy(QWidget* parent = nullptr);
+  ~DlgCopy();
+
+private:
+  enum ByteStringFormats
+  {
+    ByteString = 0,
+    ByteStringNoSpaces = 1,
+    PythonByteString = 2,
+    PythonList = 3,
+    CArray = 4
+  };
+
+  void setDefaults();
+  void enablePage(bool enable);
+  bool copyMemory();
+  void updateMemoryText();
+  
+  static bool hexStringToU32(std::string str, u32& output);
+  static bool isHexString(std::string str);
+  static bool isUnsignedIntegerString(std::string str);
+  static bool uintStringToU32(std::string str, u32& output);
+  static std::string charToHexString(char* input, size_t count, ByteStringFormats format);
+
+  QLineEdit* m_spnWatcherCopyAddress;
+  QLineEdit* m_spnWatcherCopySize;
+  QTextEdit* m_spnWatcherCopyOutput;
+  QComboBox* m_cmbViewerBytesSeparator;
+  QDialogButtonBox* m_buttonsDlg;
+
+  std::vector<char> m_Data;
+};

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -7,7 +7,7 @@
 #include <QRegExp>
 #include <QShortcut>
 #include <QVBoxLayout>
-
+#include <sstream>
 #include "../GUICommon.h"
 
 MemScanWidget::MemScanWidget()
@@ -79,6 +79,16 @@ void MemScanWidget::initialiseWidgets()
   m_txbSearchTerm1 = new QLineEdit();
   m_txbSearchTerm2 = new QLineEdit();
 
+  m_txbSearchRange1 = new QLineEdit();
+  m_txbSearchRange1->setMaxLength(8);
+  m_txbSearchRange1->setPlaceholderText("Search Begin (Optional)");
+  m_txbSearchRange1->setToolTip("Search Range Begin (Optional)");
+
+  m_txbSearchRange2 = new QLineEdit();
+  m_txbSearchRange2->setMaxLength(8);
+  m_txbSearchRange2->setPlaceholderText("Search End (Optional)");
+  m_txbSearchRange2->setToolTip("Search Range End (Optional)");
+
   m_searchTerm2Widget = new QWidget();
 
   m_searchTerm2Widget->hide();
@@ -134,6 +144,10 @@ void MemScanWidget::makeLayouts()
   results_layout->addWidget(m_tblResulstList);
   results_layout->addLayout(multiAddButtons_layout);
 
+  QHBoxLayout* range_layout = new QHBoxLayout();
+  range_layout->addWidget(m_txbSearchRange1);
+  range_layout->addWidget(m_txbSearchRange2);
+
   QHBoxLayout* buttons_layout = new QHBoxLayout();
   buttons_layout->addWidget(m_btnFirstScan);
   buttons_layout->addWidget(m_btnNextScan);
@@ -163,6 +177,7 @@ void MemScanWidget::makeLayouts()
   layout_extraParams->addWidget(m_chkSignedScan);
 
   QVBoxLayout* scannerParams_layout = new QVBoxLayout();
+  scannerParams_layout->addLayout(range_layout);
   scannerParams_layout->addLayout(buttons_layout);
   scannerParams_layout->addWidget(m_cmbScanType);
   scannerParams_layout->addWidget(m_cmbScanFilter);
@@ -297,6 +312,83 @@ void MemScanWidget::onScanMemTypeChanged()
 
 void MemScanWidget::onFirstScan()
 {
+  m_memScanner->resetSearchRange();
+  
+  bool usedCustomBeginning = false;
+  bool usedCustomEnding = false;
+  u32 endAddress;
+  u32 beginAddress;
+
+  if (m_txbSearchRange1->text().size() > 0)
+  {
+    usedCustomBeginning = true;
+    std::stringstream ss;
+    ss << m_txbSearchRange1->text().toStdString();
+    ss >> std::hex;
+    ss >> beginAddress;
+    if (ss.fail())
+    {
+      QMessageBox* errorBox =
+          new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
+                          tr("The term you entered for the Search Range Begin (%1) is invalid")
+                              .arg(m_txbSearchRange1->text()),
+                          QMessageBox::Ok, this);
+      errorBox->exec();
+      return;
+    }
+
+    if (!m_memScanner->setSearchRangeBegin(beginAddress))
+    {
+      QMessageBox* errorBox = new QMessageBox(
+          QMessageBox::Critical, tr("Invalid term(s)"),
+          tr("The term you entered for the Search Range Begin (%1) is an invalid address")
+              .arg(m_txbSearchRange1->text()),
+          QMessageBox::Ok, this);
+      errorBox->exec();
+      return;
+    }
+  }
+
+  if (m_txbSearchRange2->text().size() > 0)
+  {
+    usedCustomEnding = true;
+    std::stringstream ss;
+    ss << m_txbSearchRange2->text().toStdString();
+    ss >> std::hex;
+    ss >> endAddress;
+    if (ss.fail())
+    {
+      QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
+                          tr("The term you entered for the Search Range End (%1) is invalid")
+                              .arg(m_txbSearchRange2->text()),
+                          QMessageBox::Ok, this);
+      errorBox->exec();
+      return;
+    }
+
+    if (!m_memScanner->setSearchRangeEnd(endAddress))
+    {
+      QMessageBox* errorBox = new QMessageBox(
+          QMessageBox::Critical, tr("Invalid term(s)"),
+          tr("The term you entered for the Search Range End (%1) is an invalid address")
+              .arg(m_txbSearchRange2->text()),
+          QMessageBox::Ok, this);
+      errorBox->exec();
+      return;
+    }
+  }
+
+  if (usedCustomBeginning && usedCustomEnding && endAddress < beginAddress)
+  {
+    QMessageBox* errorBox = new QMessageBox(
+        QMessageBox::Critical, tr("Invalid term(s)"),
+        tr("The search range you specified (%1 - %2) is negative")
+                            .arg(m_txbSearchRange1->text(), m_txbSearchRange2->text()),
+        QMessageBox::Ok, this);
+    errorBox->exec();
+    return;
+  }
+
   m_memScanner->setType(static_cast<Common::MemType>(m_cmbScanType->currentIndex()));
   m_memScanner->setIsSigned(m_chkSignedScan->isChecked());
   m_memScanner->setEnforceMemAlignment(m_chkEnforceMemAlignment->isChecked());
@@ -323,6 +415,9 @@ void MemScanWidget::onFirstScan()
     m_btnNextScan->show();
     m_btnResetScan->show();
     m_btnUndoScan->show();
+    m_btnUndoScan->setEnabled(m_memScanner->hasUndo());
+    m_txbSearchRange1->hide();
+    m_txbSearchRange2->hide();
     m_cmbScanType->setDisabled(true);
     m_chkSignedScan->setDisabled(true);
     m_chkEnforceMemAlignment->setDisabled(true);
@@ -351,12 +446,14 @@ void MemScanWidget::onNextScan()
       m_btnAddSelection->setEnabled(true);
       m_btnRemoveSelection->setEnabled(true);
     }
+
+    m_btnUndoScan->setEnabled(m_memScanner->hasUndo());
   }
 }
 
 void MemScanWidget::onUndoScan()
 {
-  if (m_memScanner->getUndoCount() > 0)
+  if (m_memScanner->hasUndo())
   {
     m_memScanner->undoScan();
     
@@ -376,6 +473,8 @@ void MemScanWidget::onUndoScan()
       m_btnRemoveSelection->setEnabled(false);
       m_resultsListModel->updateAfterScannerReset(); 
     }
+
+    m_btnUndoScan->setEnabled(m_memScanner->hasUndo());
   }
   else
   {
@@ -394,6 +493,8 @@ void MemScanWidget::onResetScan()
   m_btnNextScan->hide();
   m_btnResetScan->hide();
   m_btnUndoScan->hide();
+  m_txbSearchRange1->show();
+  m_txbSearchRange2->show();
   m_cmbScanType->setEnabled(true);
   m_chkSignedScan->setEnabled(true);
   m_chkEnforceMemAlignment->setEnabled(true);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -58,12 +58,15 @@ void MemScanWidget::initialiseWidgets()
   m_btnFirstScan = new QPushButton(tr("First scan"));
   m_btnNextScan = new QPushButton(tr("Next scan"));
   m_btnNextScan->hide();
+  m_btnUndoScan = new QPushButton(tr("Undo scan"));
+  m_btnUndoScan->hide();
   m_btnResetScan = new QPushButton(tr("Reset scan"));
   m_btnResetScan->hide();
 
   connect(m_btnFirstScan, &QPushButton::clicked, this, &MemScanWidget::onFirstScan);
   connect(m_btnNextScan, &QPushButton::clicked, this, &MemScanWidget::onNextScan);
   connect(m_btnResetScan, &QPushButton::clicked, this, &MemScanWidget::onResetScan);
+  connect(m_btnUndoScan, &QPushButton::clicked, this, &MemScanWidget::onUndoScan);
 
   QShortcut* scanShortcut = new QShortcut(QKeySequence(Qt::Key::Key_Enter), this);
   connect(scanShortcut, &QShortcut::activated, this, [=] {
@@ -134,6 +137,7 @@ void MemScanWidget::makeLayouts()
   QHBoxLayout* buttons_layout = new QHBoxLayout();
   buttons_layout->addWidget(m_btnFirstScan);
   buttons_layout->addWidget(m_btnNextScan);
+  buttons_layout->addWidget(m_btnUndoScan);
   buttons_layout->addWidget(m_btnResetScan);
 
   QHBoxLayout* searchTerm2_layout = new QHBoxLayout();
@@ -318,6 +322,7 @@ void MemScanWidget::onFirstScan()
     m_btnFirstScan->hide();
     m_btnNextScan->show();
     m_btnResetScan->show();
+    m_btnUndoScan->show();
     m_cmbScanType->setDisabled(true);
     m_chkSignedScan->setDisabled(true);
     m_chkEnforceMemAlignment->setDisabled(true);
@@ -349,6 +354,35 @@ void MemScanWidget::onNextScan()
   }
 }
 
+void MemScanWidget::onUndoScan()
+{
+  if (m_memScanner->getUndoCount() > 0)
+  {
+    m_memScanner->undoScan();
+    
+    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
+    m_lblResultCount->setText(
+        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    if (resultsFound <= 1000 && resultsFound != 0)
+    {
+      m_btnAddAll->setEnabled(true);
+      m_btnAddSelection->setEnabled(true);
+      m_btnRemoveSelection->setEnabled(true);
+    }
+    else
+    {
+      m_btnAddAll->setEnabled(false);
+      m_btnAddSelection->setEnabled(false);
+      m_btnRemoveSelection->setEnabled(false);
+      m_resultsListModel->updateAfterScannerReset(); 
+    }
+  }
+  else
+  {
+    onResetScan();
+  }
+}
+
 void MemScanWidget::onResetScan()
 {
   m_memScanner->reset();
@@ -359,6 +393,7 @@ void MemScanWidget::onResetScan()
   m_btnFirstScan->show();
   m_btnNextScan->hide();
   m_btnResetScan->hide();
+  m_btnUndoScan->hide();
   m_cmbScanType->setEnabled(true);
   m_chkSignedScan->setEnabled(true);
   m_chkEnforceMemAlignment->setEnabled(true);

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -33,6 +33,7 @@ public:
   void handleScannerErrors(const Common::MemOperationReturnCode errorCode);
   void onFirstScan();
   void onNextScan();
+  void onUndoScan();
   void onResetScan();
   void onAddSelection();
   void onRemoveSelection();
@@ -61,6 +62,7 @@ private:
   QPushButton* m_btnFirstScan;
   QPushButton* m_btnNextScan;
   QPushButton* m_btnResetScan;
+  QPushButton* m_btnUndoScan;
   QPushButton* m_btnAddSelection;
   QPushButton* m_btnAddAll;
   QPushButton* m_btnRemoveSelection;

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -59,6 +59,8 @@ private:
 
   MemScanner* m_memScanner;
   ResultsListModel* m_resultsListModel;
+  QLineEdit* m_txbSearchRange1;
+  QLineEdit* m_txbSearchRange2;
   QPushButton* m_btnFirstScan;
   QPushButton* m_btnNextScan;
   QPushButton* m_btnResetScan;

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -238,6 +238,8 @@ Common::MemOperationReturnCode MemScanner::nextScan(const MemScanner::ScanFiter 
 
   std::vector<u32> newerResults = std::vector<u32>();
   bool aramAccessible = DolphinComm::DolphinAccessor::isARAMAccessible();
+  
+  bool wasUninitialized = m_wasUnknownInitialValue;
 
   if (m_wasUnknownInitialValue)
   {
@@ -269,8 +271,6 @@ Common::MemOperationReturnCode MemScanner::nextScan(const MemScanner::ScanFiter 
   }
 
   delete[] noOffset;
-
-  bool wasUninitialized = m_resultsConsoleAddr.size() < newerResults.size();
 
   m_UndoStack.push({m_resultsConsoleAddr, wasUninitialized});
   m_undoCount = m_UndoStack.size();

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <string>
 #include <vector>
+#include <stack>
 
 #include "../Common/CommonTypes.h"
 #include "../Common/CommonUtils.h"
@@ -40,6 +41,7 @@ public:
                                            const std::string& searchTerm2);
   Common::MemOperationReturnCode nextScan(const ScanFiter filter, const std::string& searchTerm1,
                                           const std::string& searchTerm2);
+  bool undoScan();
   void reset();
   inline CompareResult compareMemoryAsNumbers(const char* first, const char* second,
                                               const char* offset, bool offsetInvert,
@@ -129,6 +131,7 @@ public:
 
   std::vector<u32> getResultsConsoleAddr() const;
   size_t getResultCount() const;
+  size_t getUndoCount() const;
   int getTermsNumForFilter(const ScanFiter filter) const;
   Common::MemType getType() const;
   Common::MemBase getBase() const;
@@ -154,8 +157,10 @@ private:
   bool m_enforceMemAlignment = true;
   bool m_memIsSigned = false;
   std::vector<u32> m_resultsConsoleAddr;
-  bool m_wasUnknownInitialValue = false;
   size_t m_resultCount = 0;
+  std::stack<std::vector<u32>> m_UndoStack;
+  size_t m_undoCount = 0;
+  bool m_wasUnknownInitialValue = false;
   char* m_scanRAMCache = nullptr;
   bool m_scanStarted = false;
 };

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -128,9 +128,14 @@ public:
   void setBase(const Common::MemBase base);
   void setEnforceMemAlignment(const bool enforceAlignment);
   void setIsSigned(const bool isSigned);
+  void resetSearchRange();
+  bool setSearchRangeBegin(u32 beginIndex);
+  bool setSearchRangeEnd(u32 endIndex);
+  bool setSearchRange(u32 beginIndex, u32 endIndex);
 
   std::vector<u32> getResultsConsoleAddr() const;
   size_t getResultCount() const;
+  bool hasUndo() const;
   size_t getUndoCount() const;
   int getTermsNumForFilter(const ScanFiter filter) const;
   Common::MemType getType() const;
@@ -151,16 +156,28 @@ private:
                             const u32 consoleOffset) const;
   std::string addSpacesToBytesArrays(const std::string& bytesArray) const;
 
+  bool m_searchInRangeBegin = false;
+  bool m_searchInRangeEnd = false;
+  u32 m_beginSearchRange = 0;
+  u32 m_endSearchRange = 0;
+
   Common::MemType m_memType = Common::MemType::type_byte;
   Common::MemBase m_memBase = Common::MemBase::base_decimal;
   size_t m_memSize;
   bool m_enforceMemAlignment = true;
   bool m_memIsSigned = false;
-  std::vector<u32> m_resultsConsoleAddr;
+
   size_t m_resultCount = 0;
-  std::stack<std::vector<u32>> m_UndoStack;
   size_t m_undoCount = 0;
   bool m_wasUnknownInitialValue = false;
   char* m_scanRAMCache = nullptr;
   bool m_scanStarted = false;
+  
+  struct MemScannerUndoAction
+  {
+    std::vector<u32> data;
+    bool wasUnknownInitialState = false;
+  };
+  std::stack<MemScannerUndoAction> m_UndoStack;
+  std::vector<u32> m_resultsConsoleAddr;
 };


### PR DESCRIPTION
Added a dialog which can be found under the View menu for copying segments of memory into formatted byte strings.
These byte string options are:

- Byte String
- Byte String (No Spaces)
- Python Byte String
- Python Byte List
- C Array

The dialog takes a base address, a count (hex or decimal), and a method for formatting the bytes. Upon clicking 'Apply', the bytes will be shown as a formatted string in the output box. The output only updates when 'Apply' is clicked. If the byte format changes, the old data will be reformatted to the new format.

The boxes are error checked for valid inputs. I created my own error checking functions for valid hex/decimal strings and for hex string->u32 and decimal string -> u32 because I couldn't find a common function for doing so.

This was my first time working with Qt, so let me know if there's a more proper way to work with some of these functions and classes.

I was unsure of the "Moc'ing" that was happening during the build, so I'm not sure if I'm building in a way that conforms to that style. So that may be another thing worth looking at.