### PR TITLE
Added support for dolphin-emu-nogui

### DIFF
--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -115,7 +115,8 @@ bool LinuxDolphinProcess::findPID()
     std::string line;
     aCmdLineFile.open("/proc/" + std::string(directoryEntry->d_name) + "/comm");
     getline(aCmdLineFile, line);
-    if (line == "dolphin-emu" || line == "dolphin-emu-qt2" || line == "dolphin-emu-wx")
+    if (line == "dolphin-emu" || line == "dolphin-emu-qt2" || line == "dolphin-emu-wx" ||
+        line == "dolphin-emu-nog")
       m_PID = aPID;
 
     aCmdLineFile.close();


### PR DESCRIPTION
Tiny change that adds dolphin-emu-nog as a search target for running dolphin processes, tested by running dolphin-emu-nogui and could correctly hook into and read from memory.