### PR TITLE
Upgrade to Qt 6.5 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        configuration: [Release] # [Debug, Release]; No need to build Debug, but leaving here if we want it later
+        configuration: [Debug, Release]
 
     steps:
       - name: Checkout code
@@ -55,16 +55,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up CMake
+      - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake
-        shell: bash
-
-      - name: Install Qt 5
-        run: |
-          sudo apt-get update
-           sudo apt install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools qtbase5-private-dev
+          sudo apt install build-essential git cmake ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libevdev-dev libusb-1.0-0-dev libxrandr-dev libxi-dev libpangocairo-1.0-0 qt6-base-private-dev libqt6svg6-dev libbluetooth-dev libasound2-dev libpulse-dev libgl1-mesa-dev libcurl4-openssl-dev
         shell: bash
 
       - name: Install GCC 10 and G++ 10
@@ -90,7 +84,6 @@ jobs:
           cp ./README.md ./Source/build/artifacts/
           cp ./LICENSE ./Source/build/artifacts/
           cp ./Source/build/Dolphin-memory-engine ./Source/build/artifacts/
-          chmod +x ./Source/build/artifacts/Dolphin-memory-engine
         shell: bash
 
       - name: Publish Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt install build-essential git cmake ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libevdev-dev libusb-1.0-0-dev libxrandr-dev libxi-dev libpangocairo-1.0-0 qt6-base-private-dev libqt6svg6-dev libbluetooth-dev libasound2-dev libpulse-dev libgl1-mesa-dev libcurl4-openssl-dev
+          sudo apt install cmake libevdev-dev qt6-base-private-dev libgl1-mesa-dev
         shell: bash
 
       - name: Install GCC 10 and G++ 10

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "Externals/Qt"]
+	path = Externals/Qt
+	url = git@github.com:dolphin-emu/ext-win-qt.git
+	branch = master
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Externals/Qt"]
 	path = Externals/Qt
-	url = git@github.com:dolphin-emu/ext-win-qt.git
+	url = https://github.com/dolphin-emu/ext-win-qt.git
 	branch = master
 	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Externals/Qt"]
-	path = Externals/Qt
-	url = https://github.com/aldelaro5/win-qt5-dolphin-memory-engine.git

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5.0)
+set(CMAKE_CXX_STANDARD 17)
 project(Dolphin-memory-engine)
 
 if(WIN32)
@@ -35,9 +36,9 @@ set(SRCS ${DolphinProcessSrc}
 
 set(CMAKE_INCLUE_CURRENT_DIR ON)
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Gui REQUIRED)
+find_package(Qt6Widgets REQUIRED)
+find_package(Qt6Core REQUIRED)
+find_package(Qt6Gui REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 
@@ -47,32 +48,32 @@ ENDIF(WIN32)
 
 add_executable(Dolphin-memory-engine ${GUI_TYPE} ${SRCS})
 
-target_link_libraries(Dolphin-memory-engine Qt5::Widgets)
-target_link_libraries(Dolphin-memory-engine Qt5::Gui)
-target_link_libraries(Dolphin-memory-engine Qt5::Core)
+target_link_libraries(Dolphin-memory-engine Qt6::Widgets)
+target_link_libraries(Dolphin-memory-engine Qt6::Gui)
+target_link_libraries(Dolphin-memory-engine Qt6::Core)
 
 if(WIN32)
     if($<CONFIG:Debug>)
-        get_target_property(WIDGETDLL Qt5::Widgets IMPORTED_LOCATION_DEBUG)
-		get_target_property(COREDLL Qt5::Widgets IMPORTED_LOCATION_DEBUG)
-		get_target_property(GUIDLL Qt5::Widgets IMPORTED_LOCATION_DEBUG)
+        get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
+		get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
+		get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
     else($<CONFIG:Debug>)
-        get_target_property(WIDGETDLL Qt5::Widgets IMPORTED_LOCATION_RELEASE)
-		get_target_property(COREDLL Qt5::Widgets IMPORTED_LOCATION_RELEASE)
-		get_target_property(GUIDLL Qt5::Widgets IMPORTED_LOCATION_RELEASE)
+        get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
+		get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
+		get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
     endif($<CONFIG:Debug>)
     add_custom_command(
 		TARGET Dolphin-memory-engine POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt5::Widgets>
+			$<TARGET_FILE:Qt6::Widgets>
 			$<TARGET_FILE_DIR:Dolphin-memory-engine>
 		TARGET Dolphin-memory-engine POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt5::Core>
+			$<TARGET_FILE:Qt6::Core>
 			$<TARGET_FILE_DIR:Dolphin-memory-engine>
 		TARGET Dolphin-memory-engine POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt5::Gui>
+			$<TARGET_FILE:Qt6::Gui>
 			$<TARGET_FILE_DIR:Dolphin-memory-engine>
 	)
 endif(WIN32)

--- a/Source/Dolphin-memory-engine.default.props
+++ b/Source/Dolphin-memory-engine.default.props
@@ -12,7 +12,7 @@
     <!-- Root of project -->
     <ProjectRoot>$(SolutionDir)..\</ProjectRoot>
     <!-- Path to Qt build files -->
-    <QTDIR>$(ProjectRoot)Externals\Qt\Qt5.10.0\5.10.0\msvc2017_64\</QTDIR>
+    <QTDIR>$(ProjectRoot)Externals\Qt\Qt6.5.1\x64\</QTDIR>
     <!-- Flags passed to Qt's MOC tool, values dependent on current configuration -->
     <QtMocFlags Condition="'$(Configuration)' == 'Debug'">-DWIN32 -DWIN64 -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB</QtMocFlags>
     <QtMocFlags Condition="'$(Configuration)' == 'Release'">-DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB</QtMocFlags>

--- a/Source/Dolphin-memory-engine.vcxproj
+++ b/Source/Dolphin-memory-engine.vcxproj
@@ -29,6 +29,12 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -51,10 +57,13 @@
       <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
+      <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdc17</LanguageStandard_C>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(QTDIR)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>qtmaind.lib;Qt5Widgetsd.lib;Qt5Cored.lib;Qt5Guid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Qt6Widgetsd.lib;Qt6Cored.lib;Qt6Guid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -69,13 +78,17 @@
       <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_NO_DEBUG;NDEBUG;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp17</LanguageStandard>
+      <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdc17</LanguageStandard_C>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(QTDIR)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>qtmain.lib;Qt5Widgets.lib;Qt5Core.lib;Qt5Gui.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Qt6Widgets.lib;Qt6Core.lib;Qt6Gui.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
+      <EntryPointSymbol Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mainCRTStartup</EntryPointSymbol>
     </Link>
   </ItemDefinitionGroup>
   <!-- Files and target to copy to the output directory -->
@@ -87,9 +100,9 @@
     <DebugSuffix Condition="'$(Configuration)' == 'Debug'">d</DebugSuffix>
   </PropertyGroup>
   <ItemGroup>
-    <FilesToCopy Include="$(QTDIR)bin\Qt5Core$(DebugSuffix).dll" />
-    <FilesToCopy Include="$(QTDIR)bin\Qt5Gui$(DebugSuffix).dll" />
-    <FilesToCopy Include="$(QTDIR)bin\Qt5Widgets$(DebugSuffix).dll" />
+    <FilesToCopy Include="$(QTDIR)bin\Qt6Core$(DebugSuffix).dll" />
+    <FilesToCopy Include="$(QTDIR)bin\Qt6Gui$(DebugSuffix).dll" />
+    <FilesToCopy Include="$(QTDIR)bin\Qt6Widgets$(DebugSuffix).dll" />
     <FilesToCopy Include="$(QTDIR)plugins\platforms\qwindows$(DebugSuffix).dll">
       <SubDir>platforms\</SubDir>
     </FilesToCopy>

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -49,10 +49,10 @@ void MainWindow::makeMenus()
   m_actImportFromCT = new QAction(tr("&Import from Cheat Engine's CT file..."), this);
   m_actExportAsCSV = new QAction(tr("&Export as CSV..."), this);
 
-  m_actOpenWatchList->setShortcut(Qt::Modifier::CTRL + Qt::Key::Key_O);
-  m_actSaveWatchList->setShortcut(Qt::Modifier::CTRL + Qt::Key::Key_S);
-  m_actSaveAsWatchList->setShortcut(Qt::Modifier::CTRL + Qt::Modifier::SHIFT + Qt::Key::Key_S);
-  m_actImportFromCT->setShortcut(Qt::Modifier::CTRL + Qt::Key::Key_I);
+  m_actOpenWatchList->setShortcut(Qt::Modifier::CTRL | Qt::Key::Key_O);
+  m_actSaveWatchList->setShortcut(Qt::Modifier::CTRL | Qt::Key::Key_S);
+  m_actSaveAsWatchList->setShortcut(Qt::Modifier::CTRL | Qt::Modifier::SHIFT | Qt::Key::Key_S);
+  m_actImportFromCT->setShortcut(Qt::Modifier::CTRL | Qt::Key::Key_I);
 
   m_actSettings = new QAction(tr("&Settings"), this);
   m_actCopyMemory = new QAction(tr("&Copy Memory Range"), this);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -4,7 +4,7 @@
 #include <QHeaderView>
 #include <QMessageBox>
 #include <QRadioButton>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <QVBoxLayout>
 #include <sstream>
@@ -216,8 +216,8 @@ QModelIndexList MemScanWidget::getSelectedResults() const
 
 MemScanner::ScanFiter MemScanWidget::getSelectedFilter() const
 {
-  int index =
-      GUICommon::g_memScanFilter.indexOf(QRegExp("^" + m_cmbScanFilter->currentText() + "$"));
+  int index = GUICommon::g_memScanFilter.indexOf(
+      QRegularExpression("^" + m_cmbScanFilter->currentText() + "$"));
   return static_cast<MemScanner::ScanFiter>(index);
 }
 

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -31,7 +31,7 @@ MemViewer::MemViewer(QWidget* parent) : QAbstractScrollArea(parent)
 
   m_elapsedTimer.start();
 
-  m_copyShortcut = new QShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key::Key_C), parent);
+  m_copyShortcut = new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_C), parent);
   connect(m_copyShortcut, &QShortcut::activated, this,
           [=]() { copySelection(Common::MemType::type_byteArray); });
 
@@ -351,9 +351,9 @@ void MemViewer::wheelEvent(QWheelEvent* event)
 {
   if (event->modifiers().testFlag(Qt::ControlModifier))
   {
-    if (event->delta() < 0 && m_memoryFontSize > 5)
+    if (event->angleDelta().y() < 0 && m_memoryFontSize > 5)
       updateFontSize(m_memoryFontSize - 1);
-    else if (event->delta() > 0)
+    else if (event->angleDelta().y() > 0)
       updateFontSize(m_memoryFontSize + 1);
 
     viewport()->update();
@@ -374,7 +374,7 @@ void MemViewer::updateFontSize(int newSize)
   setFont(QFont("Courier New", m_memoryFontSize));
 #endif
 
-  m_charWidthEm = fontMetrics().width(QLatin1Char('M'));
+  m_charWidthEm = fontMetrics().horizontalAdvance(QLatin1Char('M'));
   m_charHeight = fontMetrics().height();
   m_hexAreaWidth = m_numColumns * (m_charWidthEm * 2 + m_charWidthEm / 2);
   m_hexAreaHeight = m_numRows * m_charHeight;

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -41,8 +41,8 @@ void DlgImportCTFile::initialiseWidgets()
   m_btnGroupImportAddressMethod->addButton(m_rdbUseDolphinPointers, 1);
   m_rdbUseCommonBase->setChecked(true);
 
-  connect(m_btnGroupImportAddressMethod, QOverload<int>::of(&QButtonGroup::buttonClicked),
-          [=](int id) { onAddressImportMethodChanged(); });
+  connect(m_btnGroupImportAddressMethod, &QButtonGroup::buttonClicked,
+          this, &DlgImportCTFile::onAddressImportMethodChanged);
 }
 
 void DlgImportCTFile::makeLayouts()

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -73,17 +73,17 @@ void MemWatchWidget::initialiseWidgets()
   connect(deleteWatchShortcut, &QShortcut::activated, this, &MemWatchWidget::onDeleteSelection);
 
   QShortcut* copyWatchShortcut =
-      new QShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key::Key_C), m_watchView);
+      new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_C), m_watchView);
   connect(copyWatchShortcut, &QShortcut::activated, this,
           &MemWatchWidget::copySelectedWatchesToClipBoard);
 
   QShortcut* cutWatchShortcut =
-      new QShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key::Key_X), m_watchView);
+      new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_X), m_watchView);
   connect(cutWatchShortcut, &QShortcut::activated, this,
           &MemWatchWidget::cutSelectedWatchesToClipBoard);
 
   QShortcut* pasteWatchShortcut =
-      new QShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key::Key_V), m_watchView);
+      new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_V), m_watchView);
   connect(pasteWatchShortcut, &QShortcut::activated, this, [=] {
     pasteWatchFromClipBoard(
         m_watchModel->getTreeNodeFromIndex(m_watchView->selectionModel()->currentIndex()),


### PR DESCRIPTION
- [x] Replace Windows Qt submodule with Dolphin external submodule
- [x] Convert Qt5 deprecations to Qt6
- [x] Compiles for Linux
- [x] Compiles for Windows Debug
- [x] Compiles for Windows Release
- [x] Optimize Linux dependencies required
- [x] Fix submodule pull in Windows CI
- [x] ~~Fix QtScaling policy, like how Dolphin did~~ Apparently they rolled back those changes... I may revisit based on feedback.
- [ ] Dark Mode? (Maybe break into its own PR)
- [x] Squash all the wip commits
- [x] Wait for Existing PRs before merging
- [x] Release final Qt 5 version of DME with latest features before Qt 6 upgrade, for those on Win 7 etc.