### PR TITLE
Settings: Add Theme Option & Bundle Dolphin Style Windows Dark Mode

### DIFF
--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -1,5 +1,6 @@
 #include "GUICommon.h"
 
+#include <QApplication>
 #include <QCoreApplication>
 #include <QStringList>
 
@@ -69,4 +70,17 @@ QString getNameFromBase(const Common::MemBase base)
     return QString("");
   }
 }
+
+void changeApplicationStyle(int index)
+{
+  if (index == 0)
+  {
+    QApplication::setStyle(QStringLiteral("fusion"));
+  }
+  else if (index == 1)
+  {
+    QApplication::setStyle(QStringLiteral("windowsvista"));
+  }
+}
+
 } // namespace GUICommon

--- a/Source/GUI/GUICommon.h
+++ b/Source/GUI/GUICommon.h
@@ -14,5 +14,7 @@ extern QStringList g_memBaseNames;
 QString getStringFromType(const Common::MemType type, const size_t length = 0);
 QString getNameFromBase(const Common::MemBase base);
 
+void changeApplicationStyle(int);
+
 extern bool g_valueEditing;
 } // namespace GUICommon

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include <QVBoxLayout>
 #include <string>
 
+#include "GUICommon.h"
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"
 #include "MemCopy/DlgCopy.h"
@@ -29,6 +30,9 @@ MainWindow::MainWindow()
     restoreGeometry(SConfig::getInstance().getMainWindowGeometry());
   if (SConfig::getInstance().getMainWindowState().size())
     restoreState(SConfig::getInstance().getMainWindowState());
+#ifdef _WIN32
+  GUICommon::changeApplicationStyle(SConfig::getInstance().getTheme());
+#endif
 
   m_watcher->restoreWatchModel(SConfig::getInstance().getWatchModel());
 }

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -1,19 +1,22 @@
 #include "DlgSettings.h"
 
+#include <QApplication>
 #include <QAbstractButton>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
 #include <QVBoxLayout>
 
+#include "../GUICommon.h"
 #include "SConfig.h"
 
 DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
 {
   QGroupBox* grbCoreSettings = new QGroupBox("Core settings");
   m_cmbTheme = new QComboBox();
-  m_cmbTheme->addItem("Dark Mode", 0);
-  m_cmbTheme->addItem("Light Mode", 1);
+  m_cmbTheme->addItem("Dark", 0);
+  m_cmbTheme->addItem("Light", 1);
+  connect(m_cmbTheme, QOverload<int>::of(&QComboBox::currentIndexChanged), this, GUICommon::changeApplicationStyle);
 
   QFormLayout* coreSettingsInputLayout = new QFormLayout();
   coreSettingsInputLayout->addRow("Theme", m_cmbTheme);
@@ -113,7 +116,9 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
-  mainLayout->addWidget(grbCoreSettings);
+  #ifdef _WIN32
+    mainLayout->addWidget(grbCoreSettings);
+  #endif
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbViewerSettings);
   mainLayout->addWidget(grbMemorySizeSettings);

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -10,6 +10,16 @@
 
 DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
 {
+  QGroupBox* grbCoreSettings = new QGroupBox("Core settings");
+  m_cmbTheme = new QComboBox();
+  m_cmbTheme->addItem("Dark Mode", 0);
+  m_cmbTheme->addItem("Light Mode", 1);
+
+  QFormLayout* coreSettingsInputLayout = new QFormLayout();
+  coreSettingsInputLayout->addRow("Theme", m_cmbTheme);
+
+  grbCoreSettings->setLayout(coreSettingsInputLayout);
+
   QGroupBox* grbTimerSettings = new QGroupBox("Timer settings");
 
   m_spnWatcherUpdateTimerMs = new QSpinBox();
@@ -50,7 +60,7 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
 
   m_cmbViewerBytesSeparator = new QComboBox();
   m_cmbViewerBytesSeparator->addItem("No separator", 0);
-  m_cmbViewerBytesSeparator->addItem("Separate every bytes", 1);
+  m_cmbViewerBytesSeparator->addItem("Separate every byte", 1);
   m_cmbViewerBytesSeparator->addItem("Separate every 2 bytes", 2);
   m_cmbViewerBytesSeparator->addItem("Separate every 4 bytes", 4);
   m_cmbViewerBytesSeparator->addItem("Separate every 8 bytes", 8);
@@ -103,6 +113,7 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
+  mainLayout->addWidget(grbCoreSettings);
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbViewerSettings);
   mainLayout->addWidget(grbMemorySizeSettings);
@@ -127,6 +138,8 @@ void DlgSettings::loadSettings()
   m_spnFreezeTimerMs->setValue(SConfig::getInstance().getFreezeTimerMs());
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
+  m_cmbTheme->setCurrentIndex(
+      m_cmbTheme->findData(SConfig::getInstance().getTheme()));
   // This erases fractional mebibyte sizes, but nobody should be using those anyway.
   m_sldMEM1Size->setValue(SConfig::getInstance().getMEM1Size() / 1024 / 1024);
   m_sldMEM2Size->setValue(SConfig::getInstance().getMEM2Size() / 1024 / 1024);
@@ -140,6 +153,7 @@ void DlgSettings::saveSettings() const
   SConfig::getInstance().setFreezeTimerMs(m_spnFreezeTimerMs->value());
   SConfig::getInstance().setViewerNbrBytesSeparator(
       m_cmbViewerBytesSeparator->currentData().toInt());
+  SConfig::getInstance().setTheme(m_cmbTheme->currentData().toInt());
   SConfig::getInstance().setMEM1Size(m_sldMEM1Size->value() * 1024 * 1024);
   SConfig::getInstance().setMEM2Size(m_sldMEM2Size->value() * 1024 * 1024);
 }

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -18,6 +18,7 @@ private:
   void loadSettings();
   void saveSettings() const;
 
+  QComboBox* m_cmbTheme;
   QSpinBox* m_spnWatcherUpdateTimerMs;
   QSpinBox* m_spnScannerUpdateTimerMs;
   QSpinBox* m_spnViewerUpdateTimerMs;

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -38,6 +38,11 @@ QByteArray SConfig::getSplitterState() const
   return m_settings->value("mainWindowSettings/splitterState", QByteArray{}).toByteArray();
 }
 
+int SConfig::getTheme() const
+{
+  return m_settings->value("coreSettings/theme", 0).toInt();
+}
+
 int SConfig::getWatcherUpdateTimerMs() const
 {
   return m_settings->value("timerSettings/watcherUpdateTimerMs", 100).toInt();
@@ -91,6 +96,11 @@ void SConfig::setMainWindowState(QByteArray const& state)
 void SConfig::setSplitterState(QByteArray const& state)
 {
   m_settings->setValue("mainWindowSettings/splitterState", state);
+}
+
+void SConfig::setTheme(const int theme)
+{
+  m_settings->setValue("coreSettings/theme", theme);
 }
 
 void SConfig::setWatcherUpdateTimerMs(const int updateTimerMs)

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -18,6 +18,8 @@ public:
 
   QString getWatchModel() const;
 
+  int getTheme() const;
+
   int getWatcherUpdateTimerMs() const;
   int getFreezeTimerMs() const;
   int getScannerUpdateTimerMs() const;
@@ -32,6 +34,8 @@ public:
   void setSplitterState(QByteArray const&);
 
   void setWatchModel(const QString& json);
+
+  void setTheme(const int theme);
 
   void setWatcherUpdateTimerMs(const int watcherUpdateTimerMs);
   void setFreezeTimerMs(const int freezeTimerMs);


### PR DESCRIPTION
- [x] Create preference group Core Settings
- [x] Create UI for setting the theme
- [] ~~Implement Dark Mode overrides (reference Dolphin Dark Mode)~~ While I originally wanted to stick to matching Dolphin, I really don't want to deal with additional licensing. Instead we will use fusion.
- [x] Isolate to Windows builds
- [x] Connect Settings save to actively change the theme

Resolves #69 