### PR TITLE
Add null pointer checks in `DolphinAccessor`.

### DIFF
--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -67,38 +67,38 @@ DolphinAccessor::DolphinStatus DolphinAccessor::getStatus()
 bool DolphinAccessor::readFromRAM(const u32 offset, char* buffer, const size_t size,
                                   const bool withBSwap)
 {
-  return m_instance->readFromRAM(offset, buffer, size, withBSwap);
+  return m_instance ? m_instance->readFromRAM(offset, buffer, size, withBSwap) : false;
 }
 
 bool DolphinAccessor::writeToRAM(const u32 offset, const char* buffer, const size_t size,
                                  const bool withBSwap)
 {
-  return m_instance->writeToRAM(offset, buffer, size, withBSwap);
+  return m_instance ? m_instance->writeToRAM(offset, buffer, size, withBSwap) : false;
 }
 
 int DolphinAccessor::getPID()
 {
-  return m_instance->getPID();
+  return m_instance ? m_instance->getPID() : -1;
 }
 
 u64 DolphinAccessor::getEmuRAMAddressStart()
 {
-  return m_instance->getEmuRAMAddressStart();
+  return m_instance ? m_instance->getEmuRAMAddressStart() : 0;
 }
 
 bool DolphinAccessor::isARAMAccessible()
 {
-  return m_instance->isARAMAccessible();
+  return m_instance ? m_instance->isARAMAccessible() : false;
 }
 
 u64 DolphinAccessor::getARAMAddressStart()
 {
-  return m_instance->getARAMAddressStart();
+  return m_instance ? m_instance->getARAMAddressStart() : 0;
 }
 
 bool DolphinAccessor::isMEM2Present()
 {
-  return m_instance->isMEM2Present();
+  return m_instance ? m_instance->isMEM2Present() : false;
 }
 
 bool DolphinAccessor::isValidConsoleAddress(const u32 address)


### PR DESCRIPTION
Prevents crash in `DolphinAccessor` when dereferencing a pointer that can be null.

Reproduction steps:
- Launch Dolphin.
- Load any game (tested with Mario Kart: Double Dash!! on Linux).
- Launch the Dolphin Memory Engine, and hook to Dolphin.
- Make a first scan, and narrow it down to a few entries (few enough to get the entries show up in the ephemeral memory watch table).
- Close Dolphin.
- Dolphin Memory Engine would crash with:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00005593f5fe39bc in DolphinComm::IDolphinProcess::isARAMAccessible() const ()
[Current thread is 1 (Thread 0x7fe38fb31fc0 (LWP 12969))]
(gdb) bt
#0  0x00005593f5fe39bc in DolphinComm::IDolphinProcess::isARAMAccessible() const ()
#1  0x00005593f5fe3522 in DolphinComm::DolphinAccessor::isARAMAccessible() ()
#2  0x00005593f5ff1a88 in MemScanner::getFormattedScannedValueAt[abi:cxx11](int) const ()
#3  0x00005593f601d13e in ResultsListModel::data(QModelIndex const&, int) const ()
#4  0x00007fe38ffca980 in QStyledItemDelegate::initStyleOption(QStyleOptionViewItem*, QModelIndex const&) const () at /apps/Qt/5.15.2/gcc_64/lib/libQt5Widgets.so.5
#5  0x00007fe38ffc9bb9 in QStyledItemDelegate::paint(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) const () at /apps/Qt/5.15.2/gcc_64/lib/libQt5Widgets.so.5
#6  0x00007fe38fff136a in QTableViewPrivate::drawCell(QPainter*, QStyleOptionViewItem const&, QModelIndex const&) () at /apps/Qt/5.15.2/gcc_64/lib/libQt5Widgets.so.5
#7  0x00007fe38fff9ba0 in QTableView::paintEvent(QPaintEvent*) () at /apps/Qt/5.15.2/gcc_64/lib/libQt5Widgets.so.5
```