### PR TITLE
Add auto-hooking mechanism.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -63,6 +63,7 @@ void MainWindow::makeMenus()
   m_actHook = new QAction(tr("&Hook"), this);
   m_actUnhook = new QAction(tr("&Unhook"), this);
 
+  m_actMemoryViewer = new QAction(tr("&Memory Viewer"), this);
   m_actCopyMemory = new QAction(tr("&Copy Memory Range"), this);
 
   m_actQuit = new QAction(tr("&Quit"), this);
@@ -79,6 +80,7 @@ void MainWindow::makeMenus()
   connect(m_actHook, &QAction::triggered, this, &MainWindow::onHookAttempt);
   connect(m_actUnhook, &QAction::triggered, this, &MainWindow::onUnhook);
 
+  connect(m_actMemoryViewer, &QAction::triggered, this, &MainWindow::onOpenMenViewer);
   connect(m_actCopyMemory, &QAction::triggered, this, &MainWindow::onCopyMemory);
 
   connect(m_actQuit, &QAction::triggered, this, &MainWindow::onQuit);
@@ -101,6 +103,7 @@ void MainWindow::makeMenus()
   m_menuDolphin->addAction(m_actUnhook);
 
   m_menuView = menuBar()->addMenu(tr("&View"));
+  m_menuView->addAction(m_actMemoryViewer);
   m_menuView->addAction(m_actCopyMemory);
 
   m_menuHelp = menuBar()->addMenu(tr("&Help"));
@@ -128,9 +131,6 @@ void MainWindow::initialiseWidgets()
 
   m_lblMem2Status = new QLabel("");
   m_lblMem2Status->setAlignment(Qt::AlignHCenter);
-
-  m_btnOpenMemViewer = new QPushButton(tr("Open memory viewer"));
-  connect(m_btnOpenMemViewer, &QPushButton::clicked, this, &MainWindow::onOpenMenViewer);
 }
 
 void MainWindow::makeLayouts()
@@ -151,7 +151,6 @@ void MainWindow::makeLayouts()
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(m_lblDolphinStatus);
-  mainLayout->addWidget(m_btnOpenMemViewer);
   mainLayout->addWidget(m_lblMem2Status);
   mainLayout->addWidget(separatorline);
   mainLayout->addWidget(splitter);
@@ -255,7 +254,7 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setEnabled(true);
     m_watcher->setEnabled(true);
     m_copier->setEnabled(true);
-    m_btnOpenMemViewer->setEnabled(true);
+    m_actMemoryViewer->setEnabled(true);
     m_actCopyMemory->setEnabled(true);
     m_actHook->setEnabled(false);
     m_actUnhook->setEnabled(true);
@@ -267,7 +266,7 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
-    m_btnOpenMemViewer->setDisabled(true);
+    m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);
@@ -280,7 +279,7 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
-    m_btnOpenMemViewer->setDisabled(true);
+    m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);
@@ -292,7 +291,7 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
-    m_btnOpenMemViewer->setDisabled(true);
+    m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -36,6 +36,7 @@ MainWindow::MainWindow()
 #endif
 
   m_watcher->restoreWatchModel(SConfig::getInstance().getWatchModel());
+  m_actAutoHook->setChecked(SConfig::getInstance().getAutoHook());
 
   onHookAttempt();
 }
@@ -438,6 +439,7 @@ void MainWindow::onQuit()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+  SConfig::getInstance().setAutoHook(m_actAutoHook->isChecked());
   SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
   SConfig::getInstance().setMainWindowGeometry(saveGeometry());
   SConfig::getInstance().setMainWindowState(saveState());

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -12,7 +12,6 @@
 #include "GUICommon.h"
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"
-#include "MemCopy/DlgCopy.h"
 #include "Settings/DlgSettings.h"
 #include "Settings/SConfig.h"
 
@@ -39,6 +38,7 @@ MainWindow::MainWindow()
 
 MainWindow::~MainWindow()
 {
+  delete m_copier;
   delete m_viewer;
   delete m_watcher;
   DolphinComm::DolphinAccessor::free();
@@ -120,6 +120,8 @@ void MainWindow::initialiseWidgets()
 
   connect(m_scanner, &MemScanWidget::mustUnhook, this, &MainWindow::onUnhook);
   connect(m_watcher, &MemWatchWidget::mustUnhook, this, &MainWindow::onUnhook);
+
+  m_copier = new DlgCopy(this);
 
   m_lblDolphinStatus = new QLabel("");
   m_lblDolphinStatus->setAlignment(Qt::AlignHCenter);
@@ -252,7 +254,9 @@ void MainWindow::updateDolphinHookingStatus()
         QString::number(DolphinComm::DolphinAccessor::getEmuRAMAddressStart(), 16).toUpper());
     m_scanner->setEnabled(true);
     m_watcher->setEnabled(true);
+    m_copier->setEnabled(true);
     m_btnOpenMemViewer->setEnabled(true);
+    m_actCopyMemory->setEnabled(true);
     m_actHook->setEnabled(false);
     m_actUnhook->setEnabled(true);
     break;
@@ -262,7 +266,9 @@ void MainWindow::updateDolphinHookingStatus()
     m_lblDolphinStatus->setText(tr("Cannot hook to Dolphin, the process is not running"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
+    m_copier->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
+    m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);
     break;
@@ -273,7 +279,9 @@ void MainWindow::updateDolphinHookingStatus()
         tr("Cannot hook to Dolphin, the process is running, but no emulation has been started"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
+    m_copier->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
+    m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);
     break;
@@ -283,7 +291,9 @@ void MainWindow::updateDolphinHookingStatus()
     m_lblDolphinStatus->setText(tr("Unhooked, press \"Hook\" to hook to Dolphin again"));
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
+    m_copier->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
+    m_actCopyMemory->setDisabled(true);
     m_actHook->setEnabled(true);
     m_actUnhook->setEnabled(false);
     break;
@@ -352,9 +362,8 @@ void MainWindow::onExportAsCSV()
 
 void MainWindow::onCopyMemory()
 {
-  DlgCopy* dlg = new DlgCopy(this);
-  int dlgResult = dlg->exec();
-  delete dlg;
+  m_copier->show();
+  m_copier->raise();
 }
 
 void MainWindow::onOpenSettings()

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -59,6 +59,10 @@ void MainWindow::makeMenus()
   m_actImportFromCT->setShortcut(Qt::Modifier::CTRL | Qt::Key::Key_I);
 
   m_actSettings = new QAction(tr("&Settings"), this);
+
+  m_actHook = new QAction(tr("&Hook"), this);
+  m_actUnhook = new QAction(tr("&Unhook"), this);
+
   m_actCopyMemory = new QAction(tr("&Copy Memory Range"), this);
 
   m_actQuit = new QAction(tr("&Quit"), this);
@@ -71,6 +75,10 @@ void MainWindow::makeMenus()
   connect(m_actExportAsCSV, &QAction::triggered, this, &MainWindow::onExportAsCSV);
 
   connect(m_actSettings, &QAction::triggered, this, &MainWindow::onOpenSettings);
+
+  connect(m_actHook, &QAction::triggered, this, &MainWindow::onHookAttempt);
+  connect(m_actUnhook, &QAction::triggered, this, &MainWindow::onUnhook);
+
   connect(m_actCopyMemory, &QAction::triggered, this, &MainWindow::onCopyMemory);
 
   connect(m_actQuit, &QAction::triggered, this, &MainWindow::onQuit);
@@ -87,6 +95,10 @@ void MainWindow::makeMenus()
 
   m_menuEdit = menuBar()->addMenu(tr("&Edit"));
   m_menuEdit->addAction(m_actSettings);
+
+  m_menuDolphin = menuBar()->addMenu(tr("&Dolphin"));
+  m_menuDolphin->addAction(m_actHook);
+  m_menuDolphin->addAction(m_actUnhook);
 
   m_menuView = menuBar()->addMenu(tr("&View"));
   m_menuView->addAction(m_actCopyMemory);
@@ -109,11 +121,6 @@ void MainWindow::initialiseWidgets()
   connect(m_scanner, &MemScanWidget::mustUnhook, this, &MainWindow::onUnhook);
   connect(m_watcher, &MemWatchWidget::mustUnhook, this, &MainWindow::onUnhook);
 
-  m_btnAttempHook = new QPushButton(tr("Hook"));
-  m_btnUnhook = new QPushButton(tr("Unhook"));
-  connect(m_btnAttempHook, &QPushButton::clicked, this, &MainWindow::onHookAttempt);
-  connect(m_btnUnhook, &QPushButton::clicked, this, &MainWindow::onUnhook);
-
   m_lblDolphinStatus = new QLabel("");
   m_lblDolphinStatus->setAlignment(Qt::AlignHCenter);
 
@@ -126,10 +133,6 @@ void MainWindow::initialiseWidgets()
 
 void MainWindow::makeLayouts()
 {
-  QHBoxLayout* dolphinHookButtons_layout = new QHBoxLayout();
-  dolphinHookButtons_layout->addWidget(m_btnAttempHook);
-  dolphinHookButtons_layout->addWidget(m_btnUnhook);
-
   QFrame* separatorline = new QFrame();
   separatorline->setFrameShape(QFrame::HLine);
 
@@ -146,7 +149,6 @@ void MainWindow::makeLayouts()
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(m_lblDolphinStatus);
-  mainLayout->addLayout(dolphinHookButtons_layout);
   mainLayout->addWidget(m_btnOpenMemViewer);
   mainLayout->addWidget(m_lblMem2Status);
   mainLayout->addWidget(separatorline);
@@ -251,8 +253,8 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setEnabled(true);
     m_watcher->setEnabled(true);
     m_btnOpenMemViewer->setEnabled(true);
-    m_btnAttempHook->hide();
-    m_btnUnhook->show();
+    m_actHook->setEnabled(false);
+    m_actUnhook->setEnabled(true);
     break;
   }
   case DolphinComm::DolphinAccessor::DolphinStatus::notRunning:
@@ -261,8 +263,8 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
-    m_btnAttempHook->show();
-    m_btnUnhook->hide();
+    m_actHook->setEnabled(true);
+    m_actUnhook->setEnabled(false);
     break;
   }
   case DolphinComm::DolphinAccessor::DolphinStatus::noEmu:
@@ -272,8 +274,8 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
-    m_btnAttempHook->show();
-    m_btnUnhook->hide();
+    m_actHook->setEnabled(true);
+    m_actUnhook->setEnabled(false);
     break;
   }
   case DolphinComm::DolphinAccessor::DolphinStatus::unHooked:
@@ -282,8 +284,8 @@ void MainWindow::updateDolphinHookingStatus()
     m_scanner->setDisabled(true);
     m_watcher->setDisabled(true);
     m_btnOpenMemViewer->setDisabled(true);
-    m_btnAttempHook->show();
-    m_btnUnhook->hide();
+    m_actHook->setEnabled(true);
+    m_actUnhook->setEnabled(false);
     break;
   }
   }

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -55,13 +55,12 @@ private:
   MemViewerWidget* m_viewer;
 
   QLabel* m_lblDolphinStatus;
-  QPushButton* m_btnAttempHook;
-  QPushButton* m_btnUnhook;
   QLabel* m_lblMem2Status;
   QPushButton* m_btnOpenMemViewer;
 
   QMenu* m_menuFile;
   QMenu* m_menuEdit;
+  QMenu* m_menuDolphin;
   QMenu* m_menuView;
   QMenu* m_menuHelp;
   QAction* m_actOpenWatchList;
@@ -71,6 +70,8 @@ private:
   QAction* m_actImportFromCT;
   QAction* m_actExportAsCSV;
   QAction* m_actSettings;
+  QAction* m_actHook;
+  QAction* m_actUnhook;
   QAction* m_actQuit;
   QAction* m_actAbout;
   QAction* m_actCopyMemory;

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -58,7 +58,6 @@ private:
 
   QLabel* m_lblDolphinStatus;
   QLabel* m_lblMem2Status;
-  QPushButton* m_btnOpenMemViewer;
 
   QMenu* m_menuFile;
   QMenu* m_menuEdit;
@@ -74,7 +73,8 @@ private:
   QAction* m_actSettings;
   QAction* m_actHook;
   QAction* m_actUnhook;
+  QAction* m_actMemoryViewer;
+  QAction* m_actCopyMemory;
   QAction* m_actQuit;
   QAction* m_actAbout;
-  QAction* m_actCopyMemory;
 };

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -4,6 +4,7 @@
 #include <QCloseEvent>
 #include <QMainWindow>
 #include <QMenu>
+#include <QTimer>
 
 #include "../Common/CommonTypes.h"
 #include "../Common/MemoryCommon.h"
@@ -29,6 +30,8 @@ public:
   void updateDolphinHookingStatus();
   void onHookAttempt();
   void onUnhook();
+  void onAutoHookToggled(bool checked);
+  void onHookIfNotHooked();
   void onOpenMenViewer();
   void onOpenMemViewerWithAddress(u32 address);
   void updateMem2Status();
@@ -49,12 +52,13 @@ private:
   void initialiseWidgets();
   void makeLayouts();
   void makeMemViewer();
-  void firstHookAttempt();
 
   MemWatchWidget* m_watcher;
   MemScanWidget* m_scanner;
   MemViewerWidget* m_viewer;
   DlgCopy* m_copier;
+
+  QTimer m_autoHookTimer;
 
   QLabel* m_lblDolphinStatus;
   QLabel* m_lblMem2Status;
@@ -71,6 +75,7 @@ private:
   QAction* m_actImportFromCT;
   QAction* m_actExportAsCSV;
   QAction* m_actSettings;
+  QAction* m_actAutoHook;
   QAction* m_actHook;
   QAction* m_actUnhook;
   QAction* m_actMemoryViewer;

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -7,6 +7,7 @@
 
 #include "../Common/CommonTypes.h"
 #include "../Common/MemoryCommon.h"
+#include "MemCopy/DlgCopy.h"
 #include "MemScanner/MemScanWidget.h"
 #include "MemViewer/MemViewerWidget.h"
 #include "MemWatcher/MemWatchWidget.h"
@@ -53,6 +54,7 @@ private:
   MemWatchWidget* m_watcher;
   MemScanWidget* m_scanner;
   MemViewerWidget* m_viewer;
+  DlgCopy* m_copier;
 
   QLabel* m_lblDolphinStatus;
   QLabel* m_lblMem2Status;

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -45,25 +45,17 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   m_buttonsDlg->setStyleSheet("* { button-layout: 2 }");
 
   connect(m_buttonsDlg, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  connect(m_buttonsDlg, &QDialogButtonBox::clicked, this,
-          [=](QAbstractButton* button)
-          {
-            auto role = m_buttonsDlg->buttonRole(button);
-            if (role == QDialogButtonBox::ApplyRole)
-            {
-              if (DolphinComm::DolphinAccessor::getStatus() !=
-                  DolphinComm::DolphinAccessor::DolphinStatus::hooked)
-              {
-                enablePage(false);
-                return;
-              }
-              copyMemory();
-            }
-            else if (role == QDialogButtonBox::Close)
-            {
-              QDialog::close();
-            }
-          });
+  connect(m_buttonsDlg, &QDialogButtonBox::clicked, this, [this](QAbstractButton* const button) {
+    const auto role = m_buttonsDlg->buttonRole(button);
+    if (role == QDialogButtonBox::ApplyRole)
+    {
+      copyMemory();
+    }
+    else if (role == QDialogButtonBox::RejectRole)
+    {
+      hide();
+    }
+  });
 
   connect(m_cmbViewerBytesSeparator, &QComboBox::currentTextChanged, this,
       [=](const QString& string)
@@ -74,9 +66,6 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCopySettings);
   mainLayout->addWidget(m_buttonsDlg);
-
-  enablePage(DolphinComm::DolphinAccessor::getStatus() ==
-             DolphinComm::DolphinAccessor::DolphinStatus::hooked);
 
   setLayout(mainLayout);
 
@@ -95,15 +84,6 @@ void DlgCopy::setDefaults()
   m_spnWatcherCopyAddress->setText("");
   m_spnWatcherCopySize->setText("");
   m_cmbViewerBytesSeparator->setCurrentIndex(ByteStringFormats::ByteString);
-}
-
-void DlgCopy::enablePage(bool enable)
-{
-  m_cmbViewerBytesSeparator->setEnabled(enable);
-  m_spnWatcherCopyAddress->setEnabled(enable);
-  m_spnWatcherCopySize->setEnabled(enable);
-  m_spnWatcherCopyOutput->setEnabled(enable);
-  m_buttonsDlg->setEnabled(enable);
 }
 
 bool DlgCopy::copyMemory()

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -23,6 +23,11 @@ QString SConfig::getWatchModel() const
   return m_settings->value("watchModel", QString{}).toString();
 }
 
+bool SConfig::getAutoHook() const
+{
+  return m_settings->value("autoHook", true).toBool();
+}
+
 QByteArray SConfig::getMainWindowGeometry() const
 {
   return m_settings->value("mainWindowSettings/mainWindowGeometry", QByteArray{}).toByteArray();
@@ -81,6 +86,11 @@ u32 SConfig::getMEM2Size() const
 void SConfig::setWatchModel(const QString& json)
 {
   m_settings->setValue("watchModel", json);
+}
+
+void SConfig::setAutoHook(const bool enabled)
+{
+  m_settings->setValue("autoHook", enabled);
 }
 
 void SConfig::setMainWindowGeometry(QByteArray const& geometry)

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -17,6 +17,7 @@ public:
   QByteArray getSplitterState() const;
 
   QString getWatchModel() const;
+  bool getAutoHook() const;
 
   int getTheme() const;
 
@@ -34,6 +35,7 @@ public:
   void setSplitterState(QByteArray const&);
 
   void setWatchModel(const QString& json);
+  void setAutoHook(bool enabled);
 
   void setTheme(const int theme);
 


### PR DESCRIPTION
- The **Hook** and **Unhook** buttons have been moved to the new **Dolphin** top-bar menu.
- A new **Auto-hook** checkable menu action (checked by default) has been added to the menu too.

![Dolphin Memory Engine - Auto-hooking Mechanism](https://github.com/aldelaro5/Dolphin-memory-engine/assets/1853278/54d85547-580c-4d0e-bcf7-32bf376b54f0)

Bonus:
- The **Open memory viewer** button has been moved to the existing **View** top-bar menu.
- The **Copy Memory Range** dialog is now created only once on startup, and its enable state is synced with hooked state. Its associated menu action in the **View** menu is now enabled/disabled too.