### PR TITLE
Add setting for configuring the threshold to show scanned values in table.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -98,6 +98,8 @@ void MainWindow::makeMenus()
 void MainWindow::initialiseWidgets()
 {
   m_scanner = new MemScanWidget();
+  m_scanner->setShowThreshold(
+      static_cast<size_t>(SConfig::getInstance().getScannerShowThreshold()));
   connect(m_scanner, &MemScanWidget::requestAddWatchEntry, this, &MainWindow::addWatchRequested);
   connect(m_scanner, &MemScanWidget::requestAddAllResultsToWatchList, this,
           &MainWindow::addAllResultsToWatchList);
@@ -374,6 +376,8 @@ void MainWindow::onOpenSettings()
       m_watcher->getFreezeTimer()->start(SConfig::getInstance().getFreezeTimerMs());
       m_viewer->getUpdateTimer()->start(SConfig::getInstance().getViewerUpdateTimerMs());
     }
+    m_scanner->setShowThreshold(
+        static_cast<size_t>(SConfig::getInstance().getScannerShowThreshold()));
   }
 }
 

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -405,7 +405,7 @@ void MemScanWidget::onFirstScan()
     int resultsFound = static_cast<int>(m_memScanner->getResultCount());
     m_lblResultCount->setText(
         tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
-    if (resultsFound <= 1000 && resultsFound != 0)
+    if (resultsFound <= m_showThreshold && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
       m_btnAddSelection->setEnabled(true);
@@ -440,7 +440,7 @@ void MemScanWidget::onNextScan()
     int resultsFound = static_cast<int>(m_memScanner->getResultCount());
     m_lblResultCount->setText(
         tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
-    if (resultsFound <= 1000 && resultsFound != 0)
+    if (resultsFound <= m_showThreshold && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
       m_btnAddSelection->setEnabled(true);
@@ -548,7 +548,7 @@ void MemScanWidget::handleScannerErrors(const Common::MemOperationReturnCode err
 
 void MemScanWidget::onCurrentValuesUpdateTimer()
 {
-  if (m_memScanner->getResultCount() > 0 && m_memScanner->getResultCount() <= 1000)
+  if (m_memScanner->getResultCount() > 0 && m_memScanner->getResultCount() <= m_showThreshold)
   {
     Common::MemOperationReturnCode updateReturn = m_resultsListModel->updateScannerCurrentCache();
     if (updateReturn != Common::MemOperationReturnCode::OK)
@@ -559,6 +559,15 @@ void MemScanWidget::onCurrentValuesUpdateTimer()
 QTimer* MemScanWidget::getUpdateTimer() const
 {
   return m_currentValuesUpdateTimer;
+}
+
+void MemScanWidget::setShowThreshold(const size_t showThreshold)
+{
+  m_showThreshold = showThreshold;
+  if (m_resultsListModel)
+  {
+    m_resultsListModel->setShowThreshold(showThreshold);
+  }
 }
 
 void MemScanWidget::onResultListDoubleClicked(const QModelIndex& index)

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -39,6 +39,7 @@ public:
   void onRemoveSelection();
   void onAddAll();
   QTimer* getUpdateTimer() const;
+  void setShowThreshold(size_t showThreshold);
 
 signals:
   void requestAddWatchEntry(u32 address, Common::MemType type, size_t length, bool isUnsigned,
@@ -85,4 +86,5 @@ private:
   QGroupBox* m_groupScanBase;
   QTableView* m_tblResulstList;
   bool m_variableLengthType;
+  size_t m_showThreshold{};
 };

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -16,7 +16,7 @@ int ResultsListModel::columnCount(const QModelIndex& parent) const
 
 int ResultsListModel::rowCount(const QModelIndex& parent) const
 {
-  if (m_scanner->getResultCount() > 1000)
+  if (m_scanner->getResultCount() > m_showThreshold)
     return 0;
   return static_cast<int>(m_scanner->getResultCount());
 }
@@ -84,4 +84,13 @@ Common::MemOperationReturnCode ResultsListModel::updateScannerCurrentCache()
 void ResultsListModel::updateAfterScannerReset()
 {
   emit layoutChanged();
+}
+
+void ResultsListModel::setShowThreshold(const size_t showThreshold)
+{
+  m_showThreshold = showThreshold;
+  if (showThreshold < m_scanner->getResultCount())
+  {
+    emit layoutChanged();
+  }
 }

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -30,7 +30,9 @@ public:
   u32 getResultAddress(const int row) const;
   Common::MemOperationReturnCode updateScannerCurrentCache();
   void updateAfterScannerReset();
+  void setShowThreshold(size_t showThreshold);
 
 private:
   MemScanner* m_scanner;
+  size_t m_showThreshold{};
 };

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -59,6 +59,15 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
 
   grbTimerSettings->setLayout(timerSettingsLayout);
 
+  QGroupBox* grbScannerSettings = new QGroupBox("Scanner settings");
+
+  m_spnScannerShowThreshold = new QSpinBox(this);
+  m_spnScannerShowThreshold->setMinimum(1);
+  m_spnScannerShowThreshold->setMaximum(100000);
+
+  QFormLayout* scannerSettingsInputLayout = new QFormLayout(grbScannerSettings);
+  scannerSettingsInputLayout->addRow("Show Threshold", m_spnScannerShowThreshold);
+
   QGroupBox* grbViewerSettings = new QGroupBox("Viewer settings");
 
   m_cmbViewerBytesSeparator = new QComboBox();
@@ -120,6 +129,7 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
     mainLayout->addWidget(grbCoreSettings);
   #endif
   mainLayout->addWidget(grbTimerSettings);
+  mainLayout->addWidget(grbScannerSettings);
   mainLayout->addWidget(grbViewerSettings);
   mainLayout->addWidget(grbMemorySizeSettings);
   mainLayout->addWidget(m_buttonsDlg);
@@ -141,6 +151,7 @@ void DlgSettings::loadSettings()
   m_spnScannerUpdateTimerMs->setValue(SConfig::getInstance().getScannerUpdateTimerMs());
   m_spnViewerUpdateTimerMs->setValue(SConfig::getInstance().getViewerUpdateTimerMs());
   m_spnFreezeTimerMs->setValue(SConfig::getInstance().getFreezeTimerMs());
+  m_spnScannerShowThreshold->setValue(SConfig::getInstance().getScannerShowThreshold());
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
   m_cmbTheme->setCurrentIndex(
@@ -156,6 +167,7 @@ void DlgSettings::saveSettings() const
   SConfig::getInstance().setScannerUpdateTimerMs(m_spnScannerUpdateTimerMs->value());
   SConfig::getInstance().setViewerUpdateTimerMs(m_spnViewerUpdateTimerMs->value());
   SConfig::getInstance().setFreezeTimerMs(m_spnFreezeTimerMs->value());
+  SConfig::getInstance().setScannerShowThreshold(m_spnScannerShowThreshold->value());
   SConfig::getInstance().setViewerNbrBytesSeparator(
       m_cmbViewerBytesSeparator->currentData().toInt());
   SConfig::getInstance().setTheme(m_cmbTheme->currentData().toInt());

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -23,6 +23,7 @@ private:
   QSpinBox* m_spnScannerUpdateTimerMs;
   QSpinBox* m_spnViewerUpdateTimerMs;
   QSpinBox* m_spnFreezeTimerMs;
+  QSpinBox* m_spnScannerShowThreshold;
   QComboBox* m_cmbViewerBytesSeparator;
   QDialogButtonBox* m_buttonsDlg;
   QSlider* m_sldMEM1Size;

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -63,6 +63,11 @@ int SConfig::getViewerUpdateTimerMs() const
   return m_settings->value("timerSettings/viewerUpdateTimerMs", 100).toInt();
 }
 
+int SConfig::getScannerShowThreshold() const
+{
+  return m_settings->value("scannerSettings/scannerShowThreshold", 1000).toInt();
+}
+
 int SConfig::getViewerNbrBytesSeparator() const
 {
   return m_settings->value("viewerSettings/nbrBytesSeparator", 1).toInt();
@@ -121,6 +126,11 @@ void SConfig::setScannerUpdateTimerMs(const int scannerUpdateTimerMs)
 void SConfig::setViewerUpdateTimerMs(const int viewerUpdateTimerMs)
 {
   m_settings->setValue("timerSettings/viewerUpdateTimerMs", viewerUpdateTimerMs);
+}
+
+void SConfig::setScannerShowThreshold(const int scannerShowThreshold)
+{
+  m_settings->setValue("scannerSettings/scannerShowThreshold", scannerShowThreshold);
 }
 
 void SConfig::setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator)

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -24,6 +24,7 @@ public:
   int getFreezeTimerMs() const;
   int getScannerUpdateTimerMs() const;
   int getViewerUpdateTimerMs() const;
+  int getScannerShowThreshold() const;
   u32 getMEM1Size() const;
   u32 getMEM2Size() const;
 
@@ -41,6 +42,7 @@ public:
   void setFreezeTimerMs(const int freezeTimerMs);
   void setScannerUpdateTimerMs(const int scannerUpdateTimerMs);
   void setViewerUpdateTimerMs(const int viewerUpdateTimerMs);
+  void setScannerShowThreshold(int scannerShowThreshold);
   void setMEM1Size(const u32 mem1SizeReal);
   void setMEM2Size(const u32 mem2SizeReal);
 


### PR DESCRIPTION
The default value is still 1000. More powerful systems can handle more rows in the table. For example, 10000 rows is a good number for modern hardware.