### PR TITLE
Store count in MIME data as `int` during drag & drop actions in the watch table.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -425,7 +425,7 @@ QMimeData* MemWatchModel::mimeData(const QModelIndexList& indexes) const
   MemWatchTreeNode* leastDeepNode = getLeastDeepNodeFromList(nodes);
   std::memcpy(&leastDeepPointer, &leastDeepNode, sizeof(MemWatchTreeNode*));
   stream << leastDeepPointer;
-  stream << nodes.count();
+  stream << static_cast<int>(nodes.count());
   foreach (MemWatchTreeNode* node, nodes)
   {
     qulonglong pointer = 0;


### PR DESCRIPTION
Since Qt 6, functions such as `QList<T>::count()` now return a 64-bit integer; until Qt 5, the return type was a 32-bit integer.

This caused a type mismatch in the drag & drop functionality, where the type declared by Qt was used in `MemWatchModel::mimeData()`, but then `int` was explicitly used in `MemWatchModel::dropMimeData()`.

Now `int` is used explicitly in both cases.

Fixes #87.