### PR TITLE
Specify `Release` build type for Linux build in GitHub Action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,11 +72,8 @@ jobs:
 
       - name: Build
         run: |
-          cd Source
-          mkdir build
-          cd build
-          cmake ..
-          make
+          cmake Source -B Source/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build Source/build --parallel
         shell: bash
         
       - name: Copy LICENSE, README, Prepare Artifacts


### PR DESCRIPTION
Now `-O3 -DNDEBUG` are passed in to the compiler.

Additionally, generator-agnostic commands are now used, as opposed to invoking `make` directly. Also, the build is now done in parallel.