### PR TITLE
Enable support for SVG images in AppImage.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt install cmake libevdev-dev qt6-base-private-dev libgl1-mesa-dev libfuse2
+          sudo apt install cmake libevdev-dev qt6-base-private-dev libqt6svg6 libgl1-mesa-dev libfuse2
         shell: bash
 
       - name: Install GCC 10 and G++ 10


### PR DESCRIPTION
The `libqt6svg6` was not installed in the GitHub Action; the dependency was not bundled in the AppImage.