### PR TITLE
Remove primary cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ Source/*.tlog
 Source/*.VC.opendb
 Source/*.VC.db
 Source/.vs/
-Source/.vscode/
+.vscode/
 .idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ Source/*.tlog
 Source/*.VC.opendb
 Source/*.VC.db
 Source/.vs/
+Source/.vscode/
 .vscode/
 .idea/*

--- a/Source/Common/CommonUtils.h
+++ b/Source/Common/CommonUtils.h
@@ -143,4 +143,4 @@ inline u32 cacheIndexToOffset(u32 cacheIndex, bool considerAram)
   }
   return cacheIndex;
 }
-} // namespace Common
+}  // namespace Common

--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -548,4 +548,4 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
     break;
   }
 }
-} // namespace Common
+}  // namespace Common

--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -42,7 +42,7 @@ enum class MemBase
   base_hexadecimal,
   base_octal,
   base_binary,
-  base_none // Placeholder when the base doesn't matter (ie. string)
+  base_none  // Placeholder when the base doesn't matter (ie. string)
 };
 
 enum class MemOperationReturnCode
@@ -63,4 +63,4 @@ char* formatStringToMemory(MemOperationReturnCode& returnCode, size_t& actualLen
 std::string formatMemoryToString(const char* memory, const MemType type, const size_t length,
                                  const MemBase base, const bool isUnsigned,
                                  const bool withBSwap = false);
-} // namespace Common
+}  // namespace Common

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -31,18 +31,15 @@ public:
   static bool isARAMAccessible();
   static u64 getARAMAddressStart();
   static bool isMEM2Present();
-  static char* getRAMCache();
-  static size_t getRAMCacheSize();
-  static Common::MemOperationReturnCode updateRAMCache();
-  static std::string getFormattedValueFromCache(const u32 ramIndex, Common::MemType memType,
-                                                size_t memSize, Common::MemBase memBase,
-                                                bool memIsUnsigned);
-  static void copyRawMemoryFromCache(char* dest, const u32 consoleAddress, const size_t byteCount);
+  static size_t getRAMTotalSize();
+  static Common::MemOperationReturnCode readEntireRAM(char* buffer);
+  static std::string getFormattedValueFromMemory(const u32 ramIndex, Common::MemType memType,
+                                                 size_t memSize, Common::MemBase memBase,
+                                                 bool memIsUnsigned);
   static bool isValidConsoleAddress(const u32 address);
 
 private:
   static IDolphinProcess* m_instance;
   static DolphinStatus m_status;
-  static char* m_updatedRAMCache;
 };
-} // namespace DolphinComm
+}  // namespace DolphinComm

--- a/Source/DolphinProcess/IDolphinProcess.h
+++ b/Source/DolphinProcess/IDolphinProcess.h
@@ -10,9 +10,7 @@ namespace DolphinComm
 class IDolphinProcess
 {
 public:
-  virtual ~IDolphinProcess()
-  {
-  }
+  virtual ~IDolphinProcess() {}
   virtual bool findPID() = 0;
   virtual bool obtainEmuRAMInformations() = 0;
   virtual bool readFromRAM(const u32 offset, char* buffer, const size_t size,
@@ -20,30 +18,12 @@ public:
   virtual bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
                           const bool withBSwap) = 0;
 
-  int getPID() const
-  {
-    return m_PID;
-  };
-  u64 getEmuRAMAddressStart() const
-  {
-    return m_emuRAMAddressStart;
-  };
-  bool isMEM2Present() const
-  {
-    return m_MEM2Present;
-  };
-  bool isARAMAccessible() const
-  {
-    return m_ARAMAccessible;
-  };
-  u64 getARAMAddressStart() const
-  {
-    return m_emuARAMAdressStart;
-  };
-  u64 getMEM2AddressStart() const
-  {
-    return m_MEM2AddressStart;
-  };
+  int getPID() const { return m_PID; };
+  u64 getEmuRAMAddressStart() const { return m_emuRAMAddressStart; };
+  bool isMEM2Present() const { return m_MEM2Present; };
+  bool isARAMAccessible() const { return m_ARAMAccessible; };
+  u64 getARAMAddressStart() const { return m_emuARAMAdressStart; };
+  u64 getMEM2AddressStart() const { return m_MEM2AddressStart; };
   u64 getMEM1ToMEM2Distance() const
   {
     if (!m_MEM2Present)
@@ -59,4 +39,4 @@ protected:
   bool m_ARAMAccessible = false;
   bool m_MEM2Present = false;
 };
-} // namespace DolphinComm
+}  // namespace DolphinComm

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -265,5 +265,5 @@ bool LinuxDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const
 
   return true;
 }
-} // namespace DolphinComm
+}  // namespace DolphinComm
 #endif

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -106,6 +106,7 @@ bool LinuxDolphinProcess::findPID()
   if (directoryPointer == nullptr)
     return false;
 
+  m_PID = -1;
   struct dirent* directoryEntry = nullptr;
   while (m_PID == -1 && (directoryEntry = readdir(directoryPointer)))
   {

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.h
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.h
@@ -13,14 +13,12 @@ namespace DolphinComm
 class LinuxDolphinProcess : public IDolphinProcess
 {
 public:
-  LinuxDolphinProcess()
-  {
-  }
+  LinuxDolphinProcess() {}
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
   bool readFromRAM(const u32 offset, char* buffer, size_t size, const bool withBSwap) override;
   bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
                   const bool withBSwap) override;
 };
-} // namespace DolphinComm
+}  // namespace DolphinComm
 #endif

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -242,5 +242,5 @@ bool WindowsDolphinProcess::writeToRAM(const u32 offset, const char* buffer, con
   delete[] bufferCopy;
   return (bResult && nread == size);
 }
-} // namespace DolphinComm
+}  // namespace DolphinComm
 #endif

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -18,6 +18,7 @@ bool WindowsDolphinProcess::findPID()
 
   HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
 
+  m_PID = -1;
   if (Process32First(snapshot, &entry) == TRUE)
   {
     do

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.h
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.h
@@ -11,9 +11,7 @@ namespace DolphinComm
 class WindowsDolphinProcess : public IDolphinProcess
 {
 public:
-  WindowsDolphinProcess()
-  {
-  }
+  WindowsDolphinProcess() {}
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
   bool readFromRAM(const u32 offset, char* buffer, const size_t size,
@@ -24,5 +22,5 @@ public:
 private:
   HANDLE m_hDolphin;
 };
-} // namespace DolphinComm
+}  // namespace DolphinComm
 #endif

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -83,4 +83,4 @@ void changeApplicationStyle(int index)
   }
 }
 
-} // namespace GUICommon
+}  // namespace GUICommon

--- a/Source/GUI/GUICommon.h
+++ b/Source/GUI/GUICommon.h
@@ -17,4 +17,4 @@ QString getNameFromBase(const Common::MemBase base);
 void changeApplicationStyle(int);
 
 extern bool g_valueEditing;
-} // namespace GUICommon
+}  // namespace GUICommon

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -10,9 +10,9 @@
 #include <QVBoxLayout>
 #include <string>
 
-#include "GUICommon.h"
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"
+#include "GUICommon.h"
 #include "Settings/DlgSettings.h"
 #include "Settings/SConfig.h"
 
@@ -159,9 +159,9 @@ void MainWindow::makeLayouts()
   if (SConfig::getInstance().getSplitterState().size())
     splitter->restoreState(SConfig::getInstance().getSplitterState());
 
-  connect(splitter, &QSplitter::splitterMoved,
-          [splitter = splitter]()
-          { SConfig::getInstance().setSplitterState(splitter->saveState()); });
+  connect(splitter, &QSplitter::splitterMoved, [splitter = splitter]() {
+    SConfig::getInstance().setSplitterState(splitter->saveState());
+  });
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(m_lblDolphinStatus);
@@ -427,9 +427,11 @@ void MainWindow::onAbout()
       tr("A RAM search made to facilitate research and reverse engineering of GameCube and Wii "
          "games using the Dolphin emulator.") +
       "<br>" +
-      tr("<a href=\"https://github.com/aldelaro5/dolphin-memory-engine\">Visit the project page</a> to learn more and check for updates.") +
+      tr("<a href=\"https://github.com/aldelaro5/dolphin-memory-engine\">Visit the project "
+         "page</a> to learn more and check for updates.") +
       "<br><br>" +
-      tr("This program is licensed under the MIT license. You should have received a copy of the MIT license along with this program.");
+      tr("This program is licensed under the MIT license. You should have received a copy of the "
+         "MIT license along with this program.");
 
   QMessageBox aboutBox;
   aboutBox.setWindowTitle(title);

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -1,15 +1,15 @@
 #include "DlgCopy.h"
 
-#include "../../DolphinProcess/DolphinAccessor.h"
 #include <QAbstractButton>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <qmessagebox.h>
 #include <sstream>
 #include <utility>
-#include <qmessagebox.h>
 #include "../../Common/CommonUtils.h"
+#include "../../DolphinProcess/DolphinAccessor.h"
 
 DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
 {
@@ -29,7 +29,8 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
 
   m_cmbViewerBytesSeparator = new QComboBox();
   m_cmbViewerBytesSeparator->addItem("Byte String", ByteStringFormats::ByteString);
-  m_cmbViewerBytesSeparator->addItem("Byte String (No Spaces)", ByteStringFormats::ByteStringNoSpaces);
+  m_cmbViewerBytesSeparator->addItem("Byte String (No Spaces)",
+                                     ByteStringFormats::ByteStringNoSpaces);
   m_cmbViewerBytesSeparator->addItem("Python Byte String", ByteStringFormats::PythonByteString);
   m_cmbViewerBytesSeparator->addItem("Python List", ByteStringFormats::PythonList);
   m_cmbViewerBytesSeparator->addItem("C Array", ByteStringFormats::CArray);
@@ -38,7 +39,7 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   m_spnWatcherCopyOutput = new QTextEdit();
   m_spnWatcherCopyOutput->setWordWrapMode(QTextOption::WrapMode::WrapAnywhere);
   copySettingsLayout->addRow("Output", m_spnWatcherCopyOutput);
-  
+
   grbCopySettings->setLayout(entireCopyLayout);
 
   m_buttonsDlg = new QDialogButtonBox(QDialogButtonBox::Apply | QDialogButtonBox::Close);
@@ -58,10 +59,7 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   });
 
   connect(m_cmbViewerBytesSeparator, &QComboBox::currentTextChanged, this,
-      [=](const QString& string)
-      {
-          updateMemoryText();
-      });
+          [=](const QString& string) { updateMemoryText(); });
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCopySettings);
@@ -101,7 +99,7 @@ bool DlgCopy::copyMemory()
           tr(" or between 0x%08X and 0x%08X").arg(Common::MEM2_START, Common::GetMEM2End() - 1));
 
     errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
-                                            QMessageBox::Ok, nullptr);
+                               QMessageBox::Ok, nullptr);
     errorBox->exec();
 
     return false;
@@ -132,9 +130,9 @@ bool DlgCopy::copyMemory()
 
     return false;
   }
-    
+
   std::vector<char> newData(count);
-  
+
   if (!DolphinComm::DolphinAccessor::readFromRAM(
           Common::dolphinAddrToOffset(address, DolphinComm::DolphinAccessor::isARAMAccessible()),
           newData.data(), newData.size(), false))
@@ -146,7 +144,7 @@ bool DlgCopy::copyMemory()
 
     return false;
   }
-  
+
   m_Data = newData;
 
   updateMemoryText();
@@ -156,7 +154,8 @@ bool DlgCopy::copyMemory()
 
 void DlgCopy::updateMemoryText()
 {
-  m_spnWatcherCopyOutput->setText(QString::fromStdString(charToHexString(m_Data.data(), m_Data.size(),
+  m_spnWatcherCopyOutput->setText(QString::fromStdString(
+      charToHexString(m_Data.data(), m_Data.size(),
                       (DlgCopy::ByteStringFormats)m_cmbViewerBytesSeparator->currentIndex())));
 }
 
@@ -197,7 +196,7 @@ bool DlgCopy::hexStringToU32(std::string str, u32& output)
 
 bool DlgCopy::isUnsignedIntegerString(std::string str)
 {
-  for (char c: str)
+  for (char c : str)
   {
     if (c >= '0' && c <= '9')
     {
@@ -231,7 +230,7 @@ std::string DlgCopy::charToHexString(char* input, size_t count, DlgCopy::ByteStr
   std::string beforeByte = "";
   std::string betweenBytes = "";
   std::string afterAll = "";
-  
+
   switch (format)
   {
   case ByteString:
@@ -267,13 +266,13 @@ std::string DlgCopy::charToHexString(char* input, size_t count, DlgCopy::ByteStr
   default:
     return "";
   }
-  
+
   ss << beforeAll;
 
   for (int i = 0; i < count; i++)
   {
     ss << beforeByte << convert[(input[i] >> 4) & 0xf] << convert[input[i] & 0xf];
-    
+
     if (i != count - 1)
     {
       ss << betweenBytes;

--- a/Source/GUI/MemCopy/DlgCopy.h
+++ b/Source/GUI/MemCopy/DlgCopy.h
@@ -2,9 +2,9 @@
 
 #include <QComboBox>
 #include <QDialog>
+#include <QDialogButtonBox>
 #include <QSpinBox>
 #include <qlineedit.h>
-#include <QDialogButtonBox>
 #include <qtextedit.h>
 
 #include "../GUICommon.h"
@@ -29,7 +29,7 @@ private:
   void enablePage(bool enable);
   bool copyMemory();
   void updateMemoryText();
-  
+
   static bool hexStringToU32(std::string str, u32& output);
   static bool isHexString(std::string str);
   static bool isUnsignedIntegerString(std::string str);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -313,7 +313,7 @@ void MemScanWidget::onScanMemTypeChanged()
 void MemScanWidget::onFirstScan()
 {
   m_memScanner->resetSearchRange();
-  
+
   bool usedCustomBeginning = false;
   bool usedCustomEnding = false;
   u32 endAddress;
@@ -358,7 +358,8 @@ void MemScanWidget::onFirstScan()
     ss >> endAddress;
     if (ss.fail())
     {
-      QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
+      QMessageBox* errorBox =
+          new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
                           tr("The term you entered for the Search Range End (%1) is invalid")
                               .arg(m_txbSearchRange2->text()),
                           QMessageBox::Ok, this);
@@ -380,11 +381,11 @@ void MemScanWidget::onFirstScan()
 
   if (usedCustomBeginning && usedCustomEnding && endAddress < beginAddress)
   {
-    QMessageBox* errorBox = new QMessageBox(
-        QMessageBox::Critical, tr("Invalid term(s)"),
-        tr("The search range you specified (%1 - %2) is negative")
+    QMessageBox* errorBox =
+        new QMessageBox(QMessageBox::Critical, tr("Invalid term(s)"),
+                        tr("The search range you specified (%1 - %2) is negative")
                             .arg(m_txbSearchRange1->text(), m_txbSearchRange2->text()),
-        QMessageBox::Ok, this);
+                        QMessageBox::Ok, this);
     errorBox->exec();
     return;
   }
@@ -456,7 +457,7 @@ void MemScanWidget::onUndoScan()
   if (m_memScanner->hasUndo())
   {
     m_memScanner->undoScan();
-    
+
     int resultsFound = static_cast<int>(m_memScanner->getResultCount());
     m_lblResultCount->setText(
         tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
@@ -471,7 +472,7 @@ void MemScanWidget::onUndoScan()
       m_btnAddAll->setEnabled(false);
       m_btnAddSelection->setEnabled(false);
       m_btnRemoveSelection->setEnabled(false);
-      m_resultsListModel->updateAfterScannerReset(); 
+      m_resultsListModel->updateAfterScannerReset();
     }
 
     m_btnUndoScan->setEnabled(m_memScanner->hasUndo());
@@ -550,9 +551,7 @@ void MemScanWidget::onCurrentValuesUpdateTimer()
 {
   if (m_memScanner->getResultCount() > 0 && m_memScanner->getResultCount() <= m_showThreshold)
   {
-    Common::MemOperationReturnCode updateReturn = m_resultsListModel->updateScannerCurrentCache();
-    if (updateReturn != Common::MemOperationReturnCode::OK)
-      handleScannerErrors(updateReturn);
+    m_resultsListModel->updateScanner();
   }
 }
 

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -73,12 +73,9 @@ QVariant ResultsListModel::headerData(int section, Qt::Orientation orientation, 
   return QVariant();
 }
 
-Common::MemOperationReturnCode ResultsListModel::updateScannerCurrentCache()
+void ResultsListModel::updateScanner()
 {
-  Common::MemOperationReturnCode updateReturn = m_scanner->updateCurrentRAMCache();
-  if (updateReturn == Common::MemOperationReturnCode::OK)
-    emit layoutChanged();
-  return updateReturn;
+  emit layoutChanged();
 }
 
 void ResultsListModel::updateAfterScannerReset()

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -28,7 +28,7 @@ public:
   bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
   u32 getResultAddress(const int row) const;
-  Common::MemOperationReturnCode updateScannerCurrentCache();
+  void updateScanner();
   void updateAfterScannerReset();
   void setShowThreshold(size_t showThreshold);
 

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -85,7 +85,7 @@ private:
                                            bool& drawCarret, QColor& bgColor, QColor& fgColor);
 
   const int m_numRows = 16;
-  const int m_numColumns = 16; // Should be a multiple of 16, or the header doesn't make much sense
+  const int m_numColumns = 16;  // Should be a multiple of 16, or the header doesn't make much sense
   const int m_numCells = m_numRows * m_numColumns;
   int m_memoryFontSize = 15;
   int m_StartBytesSelectionPosX = 0;

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -284,12 +284,11 @@ void DlgAddWatchEntry::accept()
   if (!validateAndSetAddress())
   {
     QString errorMsg = tr("The address you entered is invalid, make sure it is an "
-                          "hexadecimal number between 0x%08X and 0x%08X")
-                           .arg(Common::MEM1_START, Common::GetMEM1End() - 1);
+                          "hexadecimal number between 0x%1 and 0x%2")
+                           .arg(Common::MEM1_START, 8, 16).arg(Common::GetMEM1End() - 1, 8, 16);
     if (DolphinComm::DolphinAccessor::isMEM2Present())
       errorMsg.append(
-          tr(" or between 0x%08X and 0x%08X").arg(Common::MEM2_START, Common::GetMEM2End() - 1));
-
+          tr(" or between 0x%1 and 0x%2").arg(Common::MEM2_START, 8, 16).arg(Common::GetMEM2End() - 1, 8, 16));
     QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
                                             QMessageBox::Ok, this);
     errorBox->exec();

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -41,8 +41,8 @@ void DlgImportCTFile::initialiseWidgets()
   m_btnGroupImportAddressMethod->addButton(m_rdbUseDolphinPointers, 1);
   m_rdbUseCommonBase->setChecked(true);
 
-  connect(m_btnGroupImportAddressMethod, &QButtonGroup::buttonClicked,
-          this, &DlgImportCTFile::onAddressImportMethodChanged);
+  connect(m_btnGroupImportAddressMethod, &QButtonGroup::buttonClicked, this,
+          &DlgImportCTFile::onAddressImportMethodChanged);
 }
 
 void DlgImportCTFile::makeLayouts()

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -566,8 +566,8 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
                 u32 leftAddress = left->getEntry()->getConsoleAddress();
                 u32 rightAddress = right->getEntry()->getConsoleAddress();
 
-                return order == Qt::AscendingOrder ? leftAddress < rightAddress
-                                                   : leftAddress > rightAddress;
+                return order == Qt::AscendingOrder ? leftAddress < rightAddress :
+                                                     leftAddress > rightAddress;
               });
     break;
   }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -175,18 +175,14 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
         QAction* viewOct = new QAction(tr("View as &Octal"), this);
         QAction* viewBin = new QAction(tr("View as &Binary"), this);
 
-        connect(viewDec, &QAction::triggered, m_watchModel, [=] {
-          setSelectedWatchesBase(entry, Common::MemBase::base_decimal);
-        });
-        connect(viewHex, &QAction::triggered, m_watchModel, [=] {
-          setSelectedWatchesBase(entry, Common::MemBase::base_hexadecimal);
-        });
-        connect(viewOct, &QAction::triggered, m_watchModel, [=] {
-          setSelectedWatchesBase(entry, Common::MemBase::base_octal);
-        });
-        connect(viewBin, &QAction::triggered, m_watchModel, [=] {
-          setSelectedWatchesBase(entry, Common::MemBase::base_binary);
-        });
+        connect(viewDec, &QAction::triggered, m_watchModel,
+                [=] { setSelectedWatchesBase(entry, Common::MemBase::base_decimal); });
+        connect(viewHex, &QAction::triggered, m_watchModel,
+                [=] { setSelectedWatchesBase(entry, Common::MemBase::base_hexadecimal); });
+        connect(viewOct, &QAction::triggered, m_watchModel,
+                [=] { setSelectedWatchesBase(entry, Common::MemBase::base_octal); });
+        connect(viewBin, &QAction::triggered, m_watchModel,
+                [=] { setSelectedWatchesBase(entry, Common::MemBase::base_binary); });
 
         contextMenu->addAction(viewDec);
         contextMenu->addAction(viewHex);

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -1,7 +1,7 @@
 #include "DlgSettings.h"
 
-#include <QApplication>
 #include <QAbstractButton>
+#include <QApplication>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QLabel>
@@ -16,7 +16,8 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   m_cmbTheme = new QComboBox();
   m_cmbTheme->addItem("Dark", 0);
   m_cmbTheme->addItem("Light", 1);
-  connect(m_cmbTheme, QOverload<int>::of(&QComboBox::currentIndexChanged), this, GUICommon::changeApplicationStyle);
+  connect(m_cmbTheme, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          GUICommon::changeApplicationStyle);
 
   QFormLayout* coreSettingsInputLayout = new QFormLayout();
   coreSettingsInputLayout->addRow("Theme", m_cmbTheme);
@@ -102,12 +103,12 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   m_lblMEM2Size = new QLabel();
   m_sldMEM1Size = new QSlider(Qt::Horizontal);
   m_sldMEM2Size = new QSlider(Qt::Horizontal);
-  connect(m_sldMEM1Size, &QSlider::valueChanged,
-          [this](int slider_value)
-          { m_lblMEM1Size->setText(tr("%1 MB (MEM1)").arg(QString::number(slider_value))); });
-  connect(m_sldMEM2Size, &QSlider::valueChanged,
-          [this](int slider_value)
-          { m_lblMEM2Size->setText(tr("%1 MB (MEM2)").arg(QString::number(slider_value))); });
+  connect(m_sldMEM1Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM1Size->setText(tr("%1 MB (MEM1)").arg(QString::number(slider_value)));
+  });
+  connect(m_sldMEM2Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM2Size->setText(tr("%1 MB (MEM2)").arg(QString::number(slider_value)));
+  });
   m_sldMEM1Size->setRange(24, 64);
   m_sldMEM2Size->setRange(64, 128);
 
@@ -125,9 +126,9 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
-  #ifdef _WIN32
-    mainLayout->addWidget(grbCoreSettings);
-  #endif
+#ifdef _WIN32
+  mainLayout->addWidget(grbCoreSettings);
+#endif
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbScannerSettings);
   mainLayout->addWidget(grbViewerSettings);
@@ -154,8 +155,7 @@ void DlgSettings::loadSettings()
   m_spnScannerShowThreshold->setValue(SConfig::getInstance().getScannerShowThreshold());
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
-  m_cmbTheme->setCurrentIndex(
-      m_cmbTheme->findData(SConfig::getInstance().getTheme()));
+  m_cmbTheme->setCurrentIndex(m_cmbTheme->findData(SConfig::getInstance().getTheme()));
   // This erases fractional mebibyte sizes, but nobody should be using those anyway.
   m_sldMEM1Size->setValue(SConfig::getInstance().getMEM1Size() / 1024 / 1024);
   m_sldMEM2Size->setValue(SConfig::getInstance().getMEM2Size() / 1024 / 1024);

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cstring>
+#include <stack>
 #include <string>
 #include <vector>
-#include <stack>
 
 #include "../Common/CommonTypes.h"
 #include "../Common/CommonUtils.h"
@@ -143,7 +143,6 @@ public:
   size_t getLength() const;
   bool getIsUnsigned() const;
   std::string getFormattedScannedValueAt(const int index) const;
-  Common::MemOperationReturnCode updateCurrentRAMCache();
   std::string getFormattedCurrentValueAt(int index) const;
   void removeResultAt(int index);
   bool typeSupportsAdditionalOptions(const Common::MemType type) const;
@@ -172,7 +171,7 @@ private:
   bool m_wasUnknownInitialValue = false;
   char* m_scanRAMCache = nullptr;
   bool m_scanStarted = false;
-  
+
   struct MemScannerUndoAction
   {
     std::vector<u32> data;

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -261,6 +261,9 @@ Common::MemOperationReturnCode MemWatchEntry::readMemoryFromRAM()
     m_isValidPointer = true;
   }
 
+  if(!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
+    return Common::MemOperationReturnCode::OK;
+
   if (DolphinComm::DolphinAccessor::readFromRAM(
           Common::dolphinAddrToOffset(realConsoleAddress,
                                       DolphinComm::DolphinAccessor::isARAMAccessible()),
@@ -303,6 +306,9 @@ Common::MemOperationReturnCode MemWatchEntry::writeMemoryToRAM(const char* memor
     m_isValidPointer = true;
   }
 
+  if(!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
+    return Common::MemOperationReturnCode::OK;
+
   if (DolphinComm::DolphinAccessor::writeToRAM(
           Common::dolphinAddrToOffset(realConsoleAddress,
                                       DolphinComm::DolphinAccessor::isARAMAccessible()),
@@ -313,7 +319,8 @@ Common::MemOperationReturnCode MemWatchEntry::writeMemoryToRAM(const char* memor
 
 std::string MemWatchEntry::getStringFromMemory() const
 {
-  if (m_boundToPointer && !m_isValidPointer)
+  if ((m_boundToPointer && !m_isValidPointer) ||
+    !DolphinComm::DolphinAccessor::isValidConsoleAddress(m_consoleAddress))
     return "???";
   return Common::formatMemoryToString(m_memory, m_type, m_length, m_base, m_isUnsigned);
 }


### PR DESCRIPTION
Removing the primary cache yields a very significant performance improvement on all platforms (90% reduction in memory usage, CPU usage is no longer 100%). The cache does not seem to serve any actual purpose. Memory viewer GUI is now much more usable on Windows, though there remains some sluggishness due to the high memory refresh rate.

Also fixed a crash bug in `DlgAddWatchEntry.cpp`, an unhooking bug that occurred when MEM2 memory watches were still present while loading a game without MEM2, and a bug that prevented DME from discovering Dolphin when closed and relaunched.