### PR TITLE
Support for multiple value edits.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -227,6 +227,12 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
 
 bool MemWatchModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
+  return editData(index, value, role, true);
+}
+
+bool MemWatchModel::editData(const QModelIndex& index, const QVariant& value, const int role,
+                             const bool emitEdit)
+{
   if (!index.isValid())
     return false;
 
@@ -257,6 +263,8 @@ bool MemWatchModel::setData(const QModelIndex& index, const QVariant& value, int
           return false;
         }
         emit dataChanged(index, index);
+        if (emitEdit)
+          emit dataEdited(index, value, role);
         return true;
       }
       default:

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -66,7 +66,10 @@ public:
   bool hasAnyNodes() const;
   MemWatchTreeNode* getRootNode() const;
   MemWatchTreeNode* getTreeNodeFromIndex(const QModelIndex& index) const;
+  bool editData(const QModelIndex& index, const QVariant& value, int role, bool emitEdit = false);
+
 signals:
+  void dataEdited(const QModelIndex& index, const QVariant& value, int role);
   void writeFailed(const QModelIndex& index, Common::MemOperationReturnCode writeReturn);
   void readFailed();
   void dropSucceeded();

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -16,6 +16,7 @@ public:
   ~MemWatchWidget();
 
   void onMemWatchContextMenuRequested(const QPoint& pos);
+  void onDataEdited(const QModelIndex& index, const QVariant& value, int role);
   void onValueWriteError(const QModelIndex& index, Common::MemOperationReturnCode writeReturn);
   void onWatchDoubleClicked(const QModelIndex& index);
   void onAddGroup();


### PR DESCRIPTION
When multiple watch entries are selected, and an edit is applied to one of the values, the new value is set in all addresses (provided the watch entry has the same type).

To edit a value without losing the multi selection, `F2` can be pressed while the focus is set on a value cell.

Fixes #48.