### PR TITLE
Save splitter state when scanner is collapsed via shortcut.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -446,6 +446,8 @@ void MainWindow::onScannerActionToggled(const bool checked)
   }
 
   m_splitter->setSizes(sizes);
+
+  SConfig::getInstance().setSplitterState(m_splitter->saveState());
 }
 
 void MainWindow::onOpenSettings()


### PR DESCRIPTION
Follow-up to 038eac02ca6b22ecc63, where the functionality was introduced.

It was overlooked that, when the splitter is changed programmatically (as part of toggling the **View > Scanner** action), the `splitterMoved` signal is not emited, and the splitter's state is not stored.