### PR TITLE
Add Clang-Format check in GitHub Action.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: 🔦 Lint
+
+on: [push, pull_request]
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-22.04
+    name: Clang-Format Check
+    steps:
+      - uses: actions/checkout@v4
+      - uses: RafikFarhad/clang-format-github-action@v4
+        with:
+          style: "file"
+          sources: "Source/**/*.h,Source/**/*.cpp"

--- a/Source/Common/CommonUtils.h
+++ b/Source/Common/CommonUtils.h
@@ -5,17 +5,15 @@
 #elif _WIN32
 #include <stdlib.h>
 #elif __APPLE__
-#define bswap_16(value) \
-((((value) & 0xff) << 8) | ((value) >> 8))
+#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
 
-#define bswap_32(value) \
-(((uint32_t)bswap_16((uint16_t)((value) & 0xffff)) << 16) | \
-(uint32_t)bswap_16((uint16_t)((value) >> 16)))
+#define bswap_32(value)                                                                            \
+  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \
+   (uint32_t)bswap_16((uint16_t)((value) >> 16)))
 
-#define bswap_64(value) \
-(((uint64_t)bswap_32((uint32_t)((value) & 0xffffffff)) \
-<< 32) | \
-(uint64_t)bswap_32((uint32_t)((value) >> 32)))
+#define bswap_64(value)                                                                            \
+  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) |                                    \
+   (uint64_t)bswap_32((uint32_t)((value) >> 32)))
 #endif
 
 #include "CommonTypes.h"

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.h
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.h
@@ -2,25 +2,24 @@
 
 #pragma once
 
-#include "../IDolphinProcess.h"
 #include <mach/mach.h>
+#include "../IDolphinProcess.h"
 
 namespace DolphinComm
 {
 class MacDolphinProcess : public IDolphinProcess
 {
 public:
-  MacDolphinProcess()
-  {
-  }
+  MacDolphinProcess() {}
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
   bool readFromRAM(const u32 offset, char* buffer, size_t size, const bool withBSwap) override;
   bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
                   const bool withBSwap) override;
+
 private:
   task_t m_task;
   task_t m_currentTask;
 };
-} // namespace DolphinComm
+}  // namespace DolphinComm
 #endif

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -8,6 +8,7 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QFontDatabase>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -15,7 +16,6 @@
 #include <QPainter>
 #include <QRegularExpression>
 #include <QScrollBar>
-#include <QFontDatabase>
 
 #include "../../Common/CommonUtils.h"
 #include "../../DolphinProcess/DolphinAccessor.h"

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -285,10 +285,12 @@ void DlgAddWatchEntry::accept()
   {
     QString errorMsg = tr("The address you entered is invalid, make sure it is an "
                           "hexadecimal number between 0x%1 and 0x%2")
-                           .arg(Common::MEM1_START, 8, 16).arg(Common::GetMEM1End() - 1, 8, 16);
+                           .arg(Common::MEM1_START, 8, 16)
+                           .arg(Common::GetMEM1End() - 1, 8, 16);
     if (DolphinComm::DolphinAccessor::isMEM2Present())
-      errorMsg.append(
-          tr(" or between 0x%1 and 0x%2").arg(Common::MEM2_START, 8, 16).arg(Common::GetMEM2End() - 1, 8, 16));
+      errorMsg.append(tr(" or between 0x%1 and 0x%2")
+                          .arg(Common::MEM2_START, 8, 16)
+                          .arg(Common::GetMEM2End() - 1, 8, 16));
     QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
                                             QMessageBox::Ok, this);
     errorBox->exec();

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -411,7 +411,8 @@ void MemWatchWidget::onDataEdited(const QModelIndex& index, const QVariant& valu
       if (selectedIndex.column() != MemWatchModel::WATCH_COL_VALUE)
         continue;
 
-      MemWatchTreeNode* const selectedNode{static_cast<MemWatchTreeNode*>(selectedIndex.internalPointer())};
+      MemWatchTreeNode* const selectedNode{
+          static_cast<MemWatchTreeNode*>(selectedIndex.internalPointer())};
       if (selectedNode->isGroup())
         continue;
       MemWatchEntry* const selectedEntry{selectedNode->getEntry()};

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -261,7 +261,7 @@ Common::MemOperationReturnCode MemWatchEntry::readMemoryFromRAM()
     m_isValidPointer = true;
   }
 
-  if(!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
+  if (!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
     return Common::MemOperationReturnCode::OK;
 
   if (DolphinComm::DolphinAccessor::readFromRAM(
@@ -306,7 +306,7 @@ Common::MemOperationReturnCode MemWatchEntry::writeMemoryToRAM(const char* memor
     m_isValidPointer = true;
   }
 
-  if(!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
+  if (!DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
     return Common::MemOperationReturnCode::OK;
 
   if (DolphinComm::DolphinAccessor::writeToRAM(
@@ -320,7 +320,7 @@ Common::MemOperationReturnCode MemWatchEntry::writeMemoryToRAM(const char* memor
 std::string MemWatchEntry::getStringFromMemory() const
 {
   if ((m_boundToPointer && !m_isValidPointer) ||
-    !DolphinComm::DolphinAccessor::isValidConsoleAddress(m_consoleAddress))
+      !DolphinComm::DolphinAccessor::isValidConsoleAddress(m_consoleAddress))
     return "???";
   return Common::formatMemoryToString(m_memory, m_type, m_length, m_base, m_isUnsigned);
 }


### PR DESCRIPTION
C++ source files have been re-formatted via Clang-Format, as a number of files had been overlooked in recent commits and were not compliant with the `.clang-format` file.

A **Lint** GitHub Action has been added to ensure no further regression.