### PR TITLE
Configure CMake to install Qt6Svg.dll and qsvg.dll in build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt install cmake libevdev-dev qt6-base-private-dev libqt6svg6 libgl1-mesa-dev libfuse2
+          sudo apt install cmake libevdev-dev qt6-base-private-dev libqt6svg6 libqt6svg6-dev libgl1-mesa-dev libfuse2
         shell: bash
 
       - name: Install GCC 10 and G++ 10

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -66,26 +66,26 @@ if(WIN32)
     set_target_properties(dolphin-memory-engine PROPERTIES OUTPUT_NAME DolphinMemoryEngine)
     if($<CONFIG:Debug>)
         get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
-		get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
-		get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
+        get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
+        get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
     else($<CONFIG:Debug>)
         get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
-		get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
-		get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
+        get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
+        get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
     endif($<CONFIG:Debug>)
     add_custom_command(
-		TARGET dolphin-memory-engine POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt6::Widgets>
-			$<TARGET_FILE_DIR:dolphin-memory-engine>
-		TARGET dolphin-memory-engine POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt6::Core>
-			$<TARGET_FILE_DIR:dolphin-memory-engine>
-		TARGET dolphin-memory-engine POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different
-			$<TARGET_FILE:Qt6::Gui>
-			$<TARGET_FILE_DIR:dolphin-memory-engine>
+        TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:Qt6::Widgets>
+            $<TARGET_FILE_DIR:dolphin-memory-engine>
+        TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:Qt6::Core>
+            $<TARGET_FILE_DIR:dolphin-memory-engine>
+        TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:Qt6::Gui>
+            $<TARGET_FILE_DIR:dolphin-memory-engine>
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory
             $<TARGET_FILE_DIR:dolphin-memory-engine>/platforms
@@ -99,7 +99,7 @@ if(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:Qt6::QWindowsVistaStylePlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
-	)
+    )
 endif(WIN32)
 
 if(APPLE)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -48,6 +48,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt6Widgets REQUIRED)
 find_package(Qt6Core REQUIRED)
 find_package(Qt6Gui REQUIRED)
+if (NOT APPLE)
+    find_package(Qt6Svg REQUIRED)
+endif ()
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
@@ -61,6 +64,9 @@ add_executable(dolphin-memory-engine ${GUI_TYPE} ${SRCS})
 target_link_libraries(dolphin-memory-engine Qt6::Widgets)
 target_link_libraries(dolphin-memory-engine Qt6::Gui)
 target_link_libraries(dolphin-memory-engine Qt6::Core)
+if (NOT APPLE)
+    target_link_libraries(dolphin-memory-engine Qt6::Svg)
+endif ()
 
 if(WIN32)
     set_target_properties(dolphin-memory-engine PROPERTIES OUTPUT_NAME DolphinMemoryEngine)
@@ -68,10 +74,12 @@ if(WIN32)
         get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
         get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
         get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
+        get_target_property(SVGDLL Qt6::Widgets IMPORTED_LOCATION_DEBUG)
     else($<CONFIG:Debug>)
         get_target_property(WIDGETDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
         get_target_property(COREDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
         get_target_property(GUIDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
+        get_target_property(SVGDLL Qt6::Widgets IMPORTED_LOCATION_RELEASE)
     endif($<CONFIG:Debug>)
     add_custom_command(
         TARGET dolphin-memory-engine POST_BUILD
@@ -87,12 +95,24 @@ if(WIN32)
             $<TARGET_FILE:Qt6::Gui>
             $<TARGET_FILE_DIR:dolphin-memory-engine>
         TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:Qt6::Svg>
+            $<TARGET_FILE_DIR:dolphin-memory-engine>
+        TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            $<TARGET_FILE_DIR:dolphin-memory-engine>/imageformats
+        TARGET dolphin-memory-engine POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:Qt6::QSvgPlugin>
+            $<TARGET_FILE_DIR:dolphin-memory-engine>/imageformats
+        TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory
             $<TARGET_FILE_DIR:dolphin-memory-engine>/platforms
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:Qt6::QWindowsIntegrationPlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/platforms
+        TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
         TARGET dolphin-memory-engine POST_BUILD


### PR DESCRIPTION
Without these libraries, SVG icon engine is not available, and SVG images (only application logo at this time) cannot be rasterized.