### PR TITLE
MemWatchEntry: Show address pointed to by the chain

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -200,9 +200,7 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
       }
       case WATCH_COL_ADDRESS:
       {
-        u32 address = entry->getConsoleAddress();
-        bool isPointer = entry->isBoundToPointer();
-        return getAddressString(address, isPointer);
+        return getAddressString(entry);
       }
       case WATCH_COL_VALUE:
       {
@@ -624,14 +622,17 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   }
 }
 
-QString MemWatchModel::getAddressString(u32 address, bool isPointer) const
+QString MemWatchModel::getAddressString(const MemWatchEntry* entry) const
 {
   std::stringstream ss;
-  if (isPointer)
+  if (entry->isBoundToPointer())
   {
-    ss << "P->" << std::hex << std::uppercase << address;
+    int level = static_cast<int>(entry->getPointerLevel());
+    std::string strAddress = entry->getAddressStringForPointerLevel(level);
+    ss << "(" << level << "*)" << std::hex << std::uppercase << strAddress;
     return QString::fromStdString(ss.str());
   }
+  u32 address = entry->getConsoleAddress();
   ss << std::hex << std::uppercase << address;
   return QString::fromStdString(ss.str());
 }

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -79,7 +79,7 @@ private:
                                 const bool readSucess = true);
   bool freezeNodeValueRecursive(MemWatchTreeNode* node, const QModelIndex& parent = QModelIndex(),
                                 const bool writeSucess = true);
-  QString getAddressString(u32 address, bool isPointer) const;
+  QString getAddressString(const MemWatchEntry* entry) const;
   MemWatchTreeNode* getLeastDeepNodeFromList(const QList<MemWatchTreeNode*> nodes) const;
   int getNodeDeepness(const MemWatchTreeNode* node) const;
 

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -186,7 +186,7 @@ Common::MemOperationReturnCode MemWatchEntry::freeze()
   return writeCode;
 }
 
-u32 MemWatchEntry::getAddressForPointerLevel(const int level)
+u32 MemWatchEntry::getAddressForPointerLevel(const int level) const
 {
   if (!m_boundToPointer && level > m_pointerOffsets.size() && level > 0)
     return 0;
@@ -213,7 +213,7 @@ u32 MemWatchEntry::getAddressForPointerLevel(const int level)
   return address;
 }
 
-std::string MemWatchEntry::getAddressStringForPointerLevel(const int level)
+std::string MemWatchEntry::getAddressStringForPointerLevel(const int level) const
 {
   u32 address = getAddressForPointerLevel(level);
   if (address == 0)

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -44,8 +44,8 @@ public:
 
   Common::MemOperationReturnCode freeze();
 
-  u32 getAddressForPointerLevel(const int level);
-  std::string getAddressStringForPointerLevel(const int level);
+  u32 getAddressForPointerLevel(const int level) const;
+  std::string getAddressStringForPointerLevel(const int level) const;
   Common::MemOperationReturnCode readMemoryFromRAM();
 
   std::string getStringFromMemory() const;


### PR DESCRIPTION
I am currently fleshing out a DME watch table for various classes, each having several members. These classes are allocated dynamically, so their location in memory changes. Often times, I will want to use DME to quickly resolve the pointer chains so I know where to set memory breakpoints in Dolphin for particular members. The current address column behavior does not give the user any information unique to that entry; two entries using the same pointer but with different offsets show the same address information. In order to deduce where in memory these members are, I have to double-click the entry to see the entire pointer chain in the pop-up window.

**Before:**
<img src="https://github.com/aldelaro5/dolphin-memory-engine/assets/16770560/b27cfc33-24fb-497f-aea9-b83cbbdc04c6" width="400" />

**After:**
<img src="https://github.com/aldelaro5/dolphin-memory-engine/assets/16770560/3435bb7e-b174-4c00-84de-bc84b34ab52c" width="400" />
