### PR TITLE
Compile with C++20.

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(GCC_min_version 10)
 project(dolphin-memory-engine)

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -59,7 +59,7 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   });
 
   connect(m_cmbViewerBytesSeparator, &QComboBox::currentTextChanged, this,
-          [=](const QString& string) { updateMemoryText(); });
+          [this](const QString& string) { updateMemoryText(); });
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCopySettings);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -69,7 +69,7 @@ void MemScanWidget::initialiseWidgets()
   connect(m_btnUndoScan, &QPushButton::clicked, this, &MemScanWidget::onUndoScan);
 
   QShortcut* scanShortcut = new QShortcut(QKeySequence(Qt::Key::Key_Enter), this);
-  connect(scanShortcut, &QShortcut::activated, this, [=] {
+  connect(scanShortcut, &QShortcut::activated, this, [this] {
     if (m_memScanner->hasScanStarted())
       onNextScan();
     else

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -34,7 +34,7 @@ MemViewer::MemViewer(QWidget* parent) : QAbstractScrollArea(parent)
 
   m_copyShortcut = new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_C), parent);
   connect(m_copyShortcut, &QShortcut::activated, this,
-          [=]() { copySelection(Common::MemType::type_byteArray); });
+          [this]() { copySelection(Common::MemType::type_byteArray); });
 
   // The viewport is implicitly updated at the constructor's end
 }
@@ -322,12 +322,12 @@ void MemViewer::contextMenuEvent(QContextMenuEvent* event)
     {
       QAction* copyBytesAction = new QAction(tr("&Copy selection as bytes"));
       connect(copyBytesAction, &QAction::triggered, this,
-              [=]() { copySelection(Common::MemType::type_byteArray); });
+              [this]() { copySelection(Common::MemType::type_byteArray); });
       contextMenu->addAction(copyBytesAction);
 
       QAction* copyStringAction = new QAction(tr("&Copy selection as ASCII string"));
       connect(copyStringAction, &QAction::triggered, this,
-              [=]() { copySelection(Common::MemType::type_string); });
+              [this]() { copySelection(Common::MemType::type_string); });
       contextMenu->addAction(copyStringAction);
 
       QAction* editAction = new QAction(tr("&Edit all selection..."));
@@ -342,7 +342,7 @@ void MemViewer::contextMenuEvent(QContextMenuEvent* event)
 
     QAction* addSingleWatchAction = new QAction(tr("&Add a watch to this address..."));
     connect(addSingleWatchAction, &QAction::triggered, this,
-            [=]() { addByteIndexAsWatch(indexMouse); });
+            [this, indexMouse]() { addByteIndexAsWatch(indexMouse); });
     contextMenu->addAction(addSingleWatchAction);
 
     contextMenu->popup(viewport()->mapToGlobal(event->pos()));

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -14,7 +14,7 @@ MemViewerWidget::MemViewerWidget(QWidget* parent, u32 consoleAddress) : QWidget(
   makeLayouts();
 
   connect(m_memViewer, &MemViewer::addWatch, this,
-          [=](MemWatchEntry* entry) { emit addWatchRequested(entry); });
+          [this](MemWatchEntry* entry) { emit addWatchRequested(entry); });
 }
 
 MemViewerWidget::~MemViewerWidget()

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -529,7 +529,7 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   case WATCH_COL_LABEL:
   {
     std::sort(
-        children.begin(), children.end(), [=](MemWatchTreeNode* left, MemWatchTreeNode* right) {
+        children.begin(), children.end(), [order](MemWatchTreeNode* left, MemWatchTreeNode* right) {
           if (left->isGroup() && right->isGroup())
           {
             int compareResult =
@@ -550,7 +550,7 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   case WATCH_COL_TYPE:
   {
     std::sort(children.begin(), children.end(),
-              [=](MemWatchTreeNode* left, MemWatchTreeNode* right) {
+              [order](MemWatchTreeNode* left, MemWatchTreeNode* right) {
                 if (left->isGroup())
                   return true;
                 else if (right->isGroup())
@@ -565,7 +565,7 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   case WATCH_COL_ADDRESS:
   {
     std::sort(children.begin(), children.end(),
-              [=](MemWatchTreeNode* left, MemWatchTreeNode* right) {
+              [order](MemWatchTreeNode* left, MemWatchTreeNode* right) {
                 if (left->isGroup())
                   return true;
                 else if (right->isGroup())
@@ -582,7 +582,7 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   case WATCH_COL_LOCK:
   {
     std::sort(children.begin(), children.end(),
-              [=](MemWatchTreeNode* left, MemWatchTreeNode* right) {
+              [order](MemWatchTreeNode* left, MemWatchTreeNode* right) {
                 if (left->isGroup())
                   return true;
                 else if (right->isGroup())
@@ -597,7 +597,7 @@ void MemWatchModel::sortRecursive(int column, Qt::SortOrder order, MemWatchTreeN
   case WATCH_COL_VALUE:
   {
     std::sort(
-        children.begin(), children.end(), [=](MemWatchTreeNode* left, MemWatchTreeNode* right) {
+        children.begin(), children.end(), [order](MemWatchTreeNode* left, MemWatchTreeNode* right) {
           if (left->isGroup() && right->isGroup())
             return false;
           else if (left->isGroup())

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -89,7 +89,7 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
   m_buttonsDlg = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
   connect(m_buttonsDlg, &QDialogButtonBox::rejected, this, &QDialog::reject);
-  connect(m_buttonsDlg, &QDialogButtonBox::clicked, this, [=](QAbstractButton* button) {
+  connect(m_buttonsDlg, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
     if (m_buttonsDlg->buttonRole(button) == QDialogButtonBox::AcceptRole)
     {
       saveSettings();


### PR DESCRIPTION
Sets `CMAKE_CXX_STANDARD` to `20` in the CMake file.

Implicit captures (`[=]`), deprecated since C++20, have been dropped in favor of explicit captures.