### PR TITLE
Show extended scan preview for strings.

### DIFF
--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -1,6 +1,7 @@
 #include "MemoryCommon.h"
 
 #include <bitset>
+#include <cctype>
 #include <cstring>
 #include <iomanip>
 #include <sstream>
@@ -624,13 +625,23 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
   }
   case Common::MemType::type_string:
   {
-    int actualLength = 0;
-    for (actualLength; actualLength < length; ++actualLength)
+    std::string text;
+    for (std::string::size_type i{0}; i < length; ++i)
     {
-      if (*(memory + actualLength) == 0x00)
+      const char c{memory[i]};
+      if (c == '\0')
         break;
+
+      if (std::isprint(c))
+      {
+        text.push_back(c);
+      }
+      else
+      {
+        text += "�";
+      }
     }
-    return std::string(memory, actualLength);
+    return text;
   }
   case Common::MemType::type_byteArray:
   {

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -501,7 +501,8 @@ std::string MemScanner::getFormattedScannedValueAt(const int index) const
   bool aramAccessible = DolphinComm::DolphinAccessor::isARAMAccessible();
   u32 offset = Common::dolphinAddrToOffset(m_resultsConsoleAddr.at(index), aramAccessible);
   u32 ramIndex = Common::offsetToCacheIndex(offset, aramAccessible);
-  return Common::formatMemoryToString(&m_scanRAMCache[ramIndex], m_memType, m_memSize, m_memBase,
+  const size_t length{m_memType == Common::MemType::type_string ? ~0ULL : m_memSize};
+  return Common::formatMemoryToString(&m_scanRAMCache[ramIndex], m_memType, length, m_memBase,
                                       !m_memIsSigned, Common::shouldBeBSwappedForType(m_memType));
 }
 


### PR DESCRIPTION
Scan preview for strings will be unbounded; their length will be determined solely by the null character:

<img src="https://github.com/aldelaro5/dolphin-memory-engine/assets/1853278/7e0949c8-580a-4696-a438-d55a9d2a8bd9" alt="DME - Extended Preview Strings" title="DME - Extended Preview Strings" width="480"/>
<p></p>

Bonus: Non-printable characters in scanned or watched strings will be replaced with the � character (the unrepresentable character).

Fixes #79.