### PR TITLE
Upgrade Windows Qt Submodule to 6.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.5.1\x64"
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.7.0\x64"
           cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
         shell: powershell
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
-[submodule "Externals/Qt"]
-	path = Externals/Qt
-	url = https://github.com/dolphin-emu/ext-win-qt.git
-	branch = master
-	shallow = true
 [submodule "Externals/Qt-macOS"]
 	path = Externals/Qt-macOS
 	url = https://github.com/campital/ext-macos-qt-dme
+[submodule "Externals/Qt"]
+	path = Externals/Qt
+	url = https://github.com/dreamsyntax/dme-ext-win-qt.git
+	branch = master
+	shallow = true

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -117,7 +117,7 @@ if(WIN32)
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:Qt6::QWindowsVistaStylePlugin>
+            $<TARGET_FILE:Qt6::QModernWindowsStylePlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
     )
 endif(WIN32)

--- a/Source/dolphin-memory-engine.default.props
+++ b/Source/dolphin-memory-engine.default.props
@@ -12,7 +12,7 @@
     <!-- Root of project -->
     <ProjectRoot>$(SolutionDir)..\</ProjectRoot>
     <!-- Path to Qt build files -->
-    <QTDIR>$(ProjectRoot)Externals\Qt\Qt6.5.1\x64\</QTDIR>
+    <QTDIR>$(ProjectRoot)Externals\Qt\Qt6.7.0\x64\</QTDIR>
     <!-- Flags passed to Qt's MOC tool, values dependent on current configuration -->
     <QtMocFlags Condition="'$(Configuration)' == 'Debug'">-DWIN32 -DWIN64 -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB</QtMocFlags>
     <QtMocFlags Condition="'$(Configuration)' == 'Release'">-DWIN32 -DWIN64 -DQT_DLL -DQT_NO_DEBUG -DNDEBUG -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB</QtMocFlags>

--- a/Source/dolphin-memory-engine.vcxproj
+++ b/Source/dolphin-memory-engine.vcxproj
@@ -106,7 +106,7 @@
     <FilesToCopy Include="$(QTDIR)plugins\platforms\qwindows$(DebugSuffix).dll">
       <SubDir>platforms\</SubDir>
     </FilesToCopy>
-    <FilesToCopy Include="$(QTDIR)plugins\styles\qwindowsvistastyle$(DebugSuffix).dll">
+    <FilesToCopy Include="$(QTDIR)plugins\styles\qmodernwindowsstyle$(DebugSuffix).dll">
       <SubDir>styles\</SubDir>
     </FilesToCopy>
   </ItemGroup>


### PR DESCRIPTION
* No longer dependent on Dolphin updating Qt Submodule (https://github.com/dreamsyntax/dme-ext-win-qt)
* Upgrade to 6.7.0