### PR TITLE
Update VS project to C++20

### DIFF
--- a/Source/dolphin-memory-engine.vcxproj
+++ b/Source/dolphin-memory-engine.vcxproj
@@ -57,7 +57,7 @@
       <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdc17</LanguageStandard_C>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
@@ -78,7 +78,7 @@
       <AdditionalIncludeDirectories>$(QTDIR)include;$(QTDIR)include\QtCore;$(QTDIR)include\QtGui;$(QTDIR)include\QtWidgets</AdditionalIncludeDirectories>
       <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
       <PreprocessorDefinitions>WIN32;WIN64;QT_DLL;QT_NO_DEBUG;NDEBUG;QT_CORE_LIB;QT_GUI_LIB;QT_WIDGETS_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdc17</LanguageStandard_C>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>


### PR DESCRIPTION
ae32ba2 introduces a C++20 standard, which exposes that the Visual Studio project was not updated to support the newer standard.