### PR TITLE
Enable compile warnings.

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -61,6 +61,31 @@ IF(WIN32)
 SET(GUI_TYPE WIN32)
 ENDIF(WIN32)
 
+if (UNIX)
+    add_compile_options(
+        -Wall
+        -Wextra
+
+        -Wconversion
+        -Wsuggest-override
+
+        -Werror
+    )
+endif ()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    add_compile_options(
+        -Wno-fortify-source   # FIXME(CA): Too verbose at the moment, but worth fixing
+        -Wno-sign-conversion  # FIXME(CA): Too verbose at the moment, but worth fixing
+    )
+endif ()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    add_compile_options(
+        -W4
+    )
+endif ()
+
 add_executable(dolphin-memory-engine ${GUI_TYPE} ${SRCS})
 
 target_link_libraries(dolphin-memory-engine Qt6::Widgets)

--- a/Source/CheatEngineParser/CheatEngineParser.cpp
+++ b/Source/CheatEngineParser/CheatEngineParser.cpp
@@ -27,7 +27,7 @@ bool CheatEngineParser::hasACriticalErrorOccured() const
   return m_criticalErrorOccured;
 }
 
-void CheatEngineParser::setTableStartAddress(const u64 tableStartAddress)
+void CheatEngineParser::setTableStartAddress(const u32 tableStartAddress)
 {
   m_tableStartAddress = tableStartAddress;
 }
@@ -190,7 +190,7 @@ void CheatEngineParser::parseCheatEntry(MemWatchTreeNode* node, const bool useDo
         else
         {
           currentCheatEntryState.consoleAddressFound = true;
-          u64 consoleAddressCandidate = 0;
+          u32 consoleAddressCandidate = 0;
           std::string strCEAddress = m_xmlReader->readElementText().toStdString();
           std::stringstream ss(strCEAddress);
           ss >> std::hex;

--- a/Source/CheatEngineParser/CheatEngineParser.h
+++ b/Source/CheatEngineParser/CheatEngineParser.h
@@ -14,7 +14,7 @@ public:
 
   QString getErrorMessages() const;
   bool hasACriticalErrorOccured() const;
-  void setTableStartAddress(const u64 tableStartAddress);
+  void setTableStartAddress(u32 tableStartAddress);
   MemWatchTreeNode* parseCTFile(QIODevice* CTFileIODevice, const bool useDolphinPointer);
 
 private:
@@ -40,7 +40,7 @@ private:
                                      bool isGroup, const bool useDolphinPointer);
   static QString formatImportedEntryBasicInfo(const MemWatchEntry* entry);
 
-  u64 m_tableStartAddress = 0;
+  u32 m_tableStartAddress = 0;
   QString m_errorMessages = "";
   bool m_criticalErrorOccured = false;
   QXmlStreamReader* m_xmlReader;

--- a/Source/Common/CommonUtils.h
+++ b/Source/Common/CommonUtils.h
@@ -5,7 +5,7 @@
 #elif _WIN32
 #include <stdlib.h>
 #elif __APPLE__
-#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
+#define bswap_16(value) (static_cast<u16>((((value)&0xff) << 8) | ((value) >> 8)))
 
 #define bswap_32(value)                                                                            \
   (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \

--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -147,6 +147,8 @@ char* formatStringToMemory(MemOperationReturnCode& returnCode, size_t& actualLen
   case MemBase::base_hexadecimal:
     ss >> std::hex;
     break;
+  default:
+    break;
   }
 
   size_t size = getSizeForType(type, length);
@@ -472,6 +474,8 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
     break;
   case Common::MemBase::base_hexadecimal:
     ss << std::hex << std::uppercase;
+    break;
+  default:
     break;
   }
 

--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -668,7 +668,7 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
   {
     if (base == Common::MemBase::base_binary)
     {
-      for (int i = 0; i < length; ++i)
+      for (size_t i{0}; i < length; ++i)
       {
         ss << std::bitset<sizeof(u8) * 8>(static_cast<u8>(memory[i])).to_string() << " ";
       }
@@ -677,7 +677,7 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
     {
       // Force Hexadecimal, no matter the base
       ss << std::hex << std::uppercase;
-      for (int i = 0; i < length; ++i)
+      for (size_t i{0}; i < length; ++i)
       {
         ss << std::setfill('0') << std::setw(2) << static_cast<int>(static_cast<u8>(memory[i]))
            << " ";

--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -34,7 +34,6 @@ enum class MemType
   type_double,
   type_string,
   type_byteArray,
-  type_num
 };
 
 enum class MemBase

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -48,15 +48,14 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     if (!foundDevShmDolphin)
       continue;
 
-    u32 offset = 0;
     std::string offsetStr("0x" + lineData[2]);
-    offset = std::stoul(offsetStr, nullptr, 16);
+    const u32 offset{static_cast<u32>(std::stoul(offsetStr, nullptr, 16))};
     if (offset != 0 && offset != Common::GetMEM1Size() + 0x40000)
       continue;
 
     u64 firstAddress = 0;
     u64 SecondAddress = 0;
-    int indexDash = lineData[0].find('-');
+    const std::size_t indexDash{lineData[0].find('-')};
     std::string firstAddressStr("0x" + lineData[0].substr(0, indexDash));
     std::string secondAddressStr("0x" + lineData[0].substr(indexDash + 1));
 

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -27,7 +27,7 @@ bool MacDolphinProcess::findPID()
   static const char* const s_dolphinProcessName{std::getenv("DME_DOLPHIN_PROCESS_NAME")};
 
   m_PID = -1;
-  for (int i = 0; i < procSize / sizeof(kinfo_proc); i++)
+  for (size_t i{0}; i < procSize / sizeof(kinfo_proc); ++i)
   {
     const std::string_view name{procs[i].kp_proc.p_comm};
     const bool match{s_dolphinProcessName ? name == s_dolphinProcessName :

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -230,7 +230,8 @@ bool MacDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const s
     }
   }
 
-  if (vm_write(m_task, RAMAddress, reinterpret_cast<vm_offset_t>(bufferCopy), size) != KERN_SUCCESS)
+  if (vm_write(m_task, RAMAddress, reinterpret_cast<vm_offset_t>(bufferCopy),
+               static_cast<mach_msg_type_number_t>(size)) != KERN_SUCCESS)
   {
     delete[] bufferCopy;
     return false;

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -183,7 +183,7 @@ void MainWindow::makeLayouts()
 
 void MainWindow::makeMemViewer()
 {
-  m_viewer = new MemViewerWidget(nullptr, Common::MEM1_START);
+  m_viewer = new MemViewerWidget(nullptr);
   connect(m_viewer, &MemViewerWidget::mustUnhook, this, &MainWindow::onUnhook);
   connect(m_viewer, &MemViewerWidget::addWatchRequested, m_watcher, &MemWatchWidget::addWatchEntry);
   connect(m_watcher, &MemWatchWidget::goToAddressInViewer, this,
@@ -367,6 +367,9 @@ void MainWindow::onHookIfNotHooked()
 
 void MainWindow::onSplitterMoved(const int pos, const int index)
 {
+  (void)pos;
+  (void)index;
+
   SConfig::getInstance().setSplitterState(m_splitter->saveState());
 
   const QList<int> currentSizes{m_splitter->sizes()};

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -444,7 +444,7 @@ void MainWindow::onScannerActionToggled(const bool checked)
     const QVariant scannerFactorVariant{m_splitter->property("previous_scanner_factor")};
     const double scannerFactor{scannerFactorVariant.isValid() ? scannerFactorVariant.toDouble() :
                                                                 0.5};
-    const double scannerSize{std::round(scannerFactor * totalSize)};
+    const int scannerSize{static_cast<int>(std::round(scannerFactor * totalSize))};
 
     sizes << scannerSize << totalSize - scannerSize;
   }

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -20,7 +20,7 @@ class MainWindow : public QMainWindow
 
 public:
   MainWindow();
-  ~MainWindow();
+  ~MainWindow() override;
   void closeEvent(QCloseEvent* event) override;
   void addWatchRequested(u32 address, Common::MemType type, size_t length, bool isUnsigned,
                          Common::MemBase base);

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -260,7 +260,7 @@ std::string DlgCopy::charToHexString(const char* const input, const size_t count
 
   ss << beforeAll;
 
-  for (int i = 0; i < count; i++)
+  for (size_t i{0}; i < count; ++i)
   {
     ss << beforeByte << convert[(input[i] >> 4) & 0xf] << convert[input[i] & 0xf];
 

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -61,7 +61,7 @@ DlgCopy::DlgCopy(QWidget* parent) : QDialog(parent)
   });
 
   connect(m_cmbViewerBytesSeparator, &QComboBox::currentTextChanged, this,
-          [this](const QString& string) { updateMemoryText(); });
+          [this](const QString&) { updateMemoryText(); });
 
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCopySettings);

--- a/Source/GUI/MemCopy/DlgCopy.h
+++ b/Source/GUI/MemCopy/DlgCopy.h
@@ -15,7 +15,7 @@ class DlgCopy : public QDialog
 {
 public:
   DlgCopy(QWidget* parent = nullptr);
-  ~DlgCopy();
+  ~DlgCopy() override;
 
 private:
   enum ByteStringFormats

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -216,7 +216,7 @@ QModelIndexList MemScanWidget::getSelectedResults() const
 
 MemScanner::ScanFiter MemScanWidget::getSelectedFilter() const
 {
-  int index = GUICommon::g_memScanFilter.indexOf(
+  const auto index = GUICommon::g_memScanFilter.indexOf(
       QRegularExpression("^" + m_cmbScanFilter->currentText() + "$"));
   return static_cast<MemScanner::ScanFiter>(index);
 }

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -403,9 +403,9 @@ void MemScanWidget::onFirstScan()
   }
   else
   {
-    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
-    m_lblResultCount->setText(
-        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    const size_t resultsFound{m_memScanner->getResultCount()};
+    m_lblResultCount->setText(tr("%1 result(s) found", "", static_cast<int>(resultsFound))
+                                  .arg(QString::number(resultsFound)));
     if (resultsFound <= m_showThreshold && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
@@ -438,9 +438,9 @@ void MemScanWidget::onNextScan()
   }
   else
   {
-    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
-    m_lblResultCount->setText(
-        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    const size_t resultsFound{m_memScanner->getResultCount()};
+    m_lblResultCount->setText(tr("%1 result(s) found", "", static_cast<int>(resultsFound))
+                                  .arg(QString::number(resultsFound)));
     if (resultsFound <= m_showThreshold && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
@@ -458,9 +458,9 @@ void MemScanWidget::onUndoScan()
   {
     m_memScanner->undoScan();
 
-    int resultsFound = static_cast<int>(m_memScanner->getResultCount());
-    m_lblResultCount->setText(
-        tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+    const size_t resultsFound{m_memScanner->getResultCount()};
+    m_lblResultCount->setText(tr("%1 result(s) found", "", static_cast<int>(resultsFound))
+                                  .arg(QString::number(resultsFound)));
     if (resultsFound <= 1000 && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
@@ -519,9 +519,9 @@ void MemScanWidget::onRemoveSelection()
     m_resultsListModel->removeRow(m_tblResulstList->selectionModel()->selectedRows().at(0).row());
 
   // The result count is already updated at the backend by this point
-  int resultsFound = static_cast<int>(m_memScanner->getResultCount());
-  m_lblResultCount->setText(
-      tr("%1 result(s) found", "", resultsFound).arg(QString::number(resultsFound)));
+  const size_t resultsFound{m_memScanner->getResultCount()};
+  m_lblResultCount->setText(tr("%1 result(s) found", "", static_cast<int>(resultsFound))
+                                .arg(QString::number(resultsFound)));
 }
 
 void MemScanWidget::onAddAll()

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -20,7 +20,7 @@ class MemScanWidget : public QWidget
 
 public:
   MemScanWidget();
-  ~MemScanWidget();
+  ~MemScanWidget() override;
 
   ResultsListModel* getResultListModel() const;
   std::vector<u32> getAllResults() const;

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -9,11 +9,15 @@ ResultsListModel::~ResultsListModel() = default;
 
 int ResultsListModel::columnCount(const QModelIndex& parent) const
 {
+  (void)parent;
+
   return RESULT_COL_NUM;
 }
 
 int ResultsListModel::rowCount(const QModelIndex& parent) const
 {
+  (void)parent;
+
   if (m_scanner->getResultCount() > m_showThreshold)
     return 0;
   return static_cast<int>(m_scanner->getResultCount());

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -18,7 +18,7 @@ public:
   };
 
   ResultsListModel(QObject* parent, MemScanner* scanner);
-  ~ResultsListModel();
+  ~ResultsListModel() override;
 
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -384,7 +384,7 @@ void MemViewer::updateFontSize(int newSize)
   m_charHeight = fontMetrics().height();
   m_hexAreaWidth = m_numColumns * (m_charWidthEm * 2 + m_charWidthEm / 2);
   m_hexAreaHeight = m_numRows * m_charHeight;
-  m_rowHeaderWidth = m_charWidthEm * (sizeof(u32) * 2 + 1) + m_charWidthEm / 2;
+  m_rowHeaderWidth = m_charWidthEm * (static_cast<int>(sizeof(u32)) * 2 + 1) + m_charWidthEm / 2;
   m_hexAsciiSeparatorPosX = m_rowHeaderWidth + m_hexAreaWidth;
   m_columnHeaderHeight = m_charHeight + m_charWidthEm / 2;
 }
@@ -725,9 +725,9 @@ bool MemViewer::writeCharacterToSelectedMemory(char byteToWrite)
 
     const char selectedMemoryValue = *(m_updatedRawMemoryData + memoryOffset);
     if (m_carretBetweenHex)
-      byteToWrite = (selectedMemoryValue & 0xF0) | byteToWrite;
+      byteToWrite = (selectedMemoryValue & static_cast<char>(0xF0)) | byteToWrite;
     else
-      byteToWrite = (selectedMemoryValue & 0x0F) | (byteToWrite << 4);
+      byteToWrite = (selectedMemoryValue & static_cast<char>(0x0F)) | (byteToWrite << 4);
   }
 
   const u32 offsetToWrite{
@@ -842,7 +842,8 @@ void MemViewer::renderColumnsHeaderText(QPainter& painter)
 {
   QColor oldPenColor = painter.pen().color();
   painter.setPen(QGuiApplication::palette().color(QPalette::WindowText));
-  painter.drawText(m_charWidthEm * 1.5f, m_charHeight, tr("Address"));
+  painter.drawText(static_cast<int>(static_cast<double>(m_charWidthEm) * 1.5), m_charHeight,
+                   tr("Address"));
   int posXHeaderText = m_rowHeaderWidth;
   for (int i = 0; i < m_numColumns; i++)
   {
@@ -854,8 +855,9 @@ void MemViewer::renderColumnsHeaderText(QPainter& painter)
     posXHeaderText += m_charWidthEm * 2 + m_charWidthEm / 2;
   }
 
-  painter.drawText(m_hexAsciiSeparatorPosX + m_charWidthEm * 2.5f, m_charHeight,
-                   tr("Text (ASCII)"));
+  painter.drawText(m_hexAsciiSeparatorPosX +
+                       static_cast<int>(static_cast<double>(m_charWidthEm) * 2.5),
+                   m_charHeight, tr("Text (ASCII)"));
   painter.drawText(0, 0, 0, 0, 0, QString());
   painter.setPen(oldPenColor);
 }
@@ -907,7 +909,8 @@ void MemViewer::determineMemoryTextRenderProperties(const int rowIndex, const in
   else if (m_lastRawMemoryData[rowIndex * m_numColumns + columnIndex] !=
            m_updatedRawMemoryData[rowIndex * m_numColumns + columnIndex])
   {
-    m_memoryMsElapsedLastChange[rowIndex * m_numColumns + columnIndex] = m_elapsedTimer.elapsed();
+    m_memoryMsElapsedLastChange[rowIndex * m_numColumns + columnIndex] =
+        static_cast<int>(m_elapsedTimer.elapsed());
     bgColor = QColor(Qt::red);
   }
   // If the last changes is less than a second old
@@ -922,7 +925,8 @@ void MemViewer::determineMemoryTextRenderProperties(const int rowIndex, const in
          static_cast<float>(m_elapsedTimer.elapsed() -
                             m_memoryMsElapsedLastChange[rowIndex * m_numColumns + columnIndex])) /
         (1000.0f / 100.0f);
-    int newAlpha = std::trunc(baseColor.alpha() * (alphaPercentage / 100));
+    const int newAlpha{
+        static_cast<int>(static_cast<float>(baseColor.alpha()) * alphaPercentage / 100.0f)};
     bgColor = QColor(baseColor.red(), baseColor.green(), baseColor.blue(), newAlpha);
   }
 }

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -725,9 +725,9 @@ bool MemViewer::writeCharacterToSelectedMemory(char byteToWrite)
 
     const char selectedMemoryValue = *(m_updatedRawMemoryData + memoryOffset);
     if (m_carretBetweenHex)
-      byteToWrite = selectedMemoryValue & 0xF0 | byteToWrite;
+      byteToWrite = (selectedMemoryValue & 0xF0) | byteToWrite;
     else
-      byteToWrite = selectedMemoryValue & 0x0F | (byteToWrite << 4);
+      byteToWrite = (selectedMemoryValue & 0x0F) | (byteToWrite << 4);
   }
 
   const u32 offsetToWrite{

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -791,6 +791,8 @@ void MemViewer::keyPressEvent(QKeyEvent* event)
 
 void MemViewer::scrollContentsBy(int dx, int dy)
 {
+  (void)dx;
+
   if (!m_disableScrollContentEvent && m_validMemory)
   {
     u32 newAddress = m_currentFirstAddress + m_numColumns * (-dy);
@@ -999,6 +1001,8 @@ void MemViewer::renderMemory(QPainter& painter, const int rowIndex, const int co
 
 void MemViewer::paintEvent(QPaintEvent* event)
 {
+  (void)event;
+
   QPainter painter(viewport());
   painter.setPen(QColor(Qt::black));
 

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -727,7 +727,8 @@ bool MemViewer::writeCharacterToSelectedMemory(char byteToWrite)
     if (m_carretBetweenHex)
       byteToWrite = (selectedMemoryValue & static_cast<char>(0xF0)) | byteToWrite;
     else
-      byteToWrite = (selectedMemoryValue & static_cast<char>(0x0F)) | (byteToWrite << 4);
+      byteToWrite =
+          (selectedMemoryValue & static_cast<char>(0x0F)) | static_cast<char>(byteToWrite << 4);
   }
 
   const u32 offsetToWrite{

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -19,7 +19,7 @@ class MemViewer : public QAbstractScrollArea
 
 public:
   MemViewer(QWidget* parent);
-  ~MemViewer();
+  ~MemViewer() override;
   QSize sizeHint() const override;
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -7,7 +7,7 @@
 
 #include "../../DolphinProcess/DolphinAccessor.h"
 
-MemViewerWidget::MemViewerWidget(QWidget* parent, u32 consoleAddress) : QWidget(parent)
+MemViewerWidget::MemViewerWidget(QWidget* const parent) : QWidget(parent)
 {
   setWindowTitle("Memory Viewer");
   initialiseWidgets();

--- a/Source/GUI/MemViewer/MemViewerWidget.h
+++ b/Source/GUI/MemViewer/MemViewerWidget.h
@@ -11,7 +11,7 @@ class MemViewerWidget : public QWidget
   Q_OBJECT
 
 public:
-  MemViewerWidget(QWidget* parent, u32 consoleAddress);
+  explicit MemViewerWidget(QWidget* parent);
   ~MemViewerWidget();
 
   void onJumpToAddressTextChanged();

--- a/Source/GUI/MemViewer/MemViewerWidget.h
+++ b/Source/GUI/MemViewer/MemViewerWidget.h
@@ -12,7 +12,7 @@ class MemViewerWidget : public QWidget
 
 public:
   explicit MemViewerWidget(QWidget* parent);
-  ~MemViewerWidget();
+  ~MemViewerWidget() override;
 
   void onJumpToAddressTextChanged();
   void onGoToMEM1Start();

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -149,7 +149,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     if (m_entry->isBoundToPointer())
     {
       m_pointerWidget->show();
-      for (int i = 0; i < m_entry->getPointerLevel(); ++i)
+      for (int i{0}; i < static_cast<int>(m_entry->getPointerLevel()); ++i)
       {
         std::stringstream ss;
         ss << std::hex << std::uppercase << m_entry->getPointerOffset(i);
@@ -376,7 +376,7 @@ void DlgAddWatchEntry::updatePreview()
   m_lblValuePreview->setText(QString::fromStdString(m_entry->getStringFromMemory()));
   if (m_entry->isBoundToPointer())
   {
-    size_t level = m_entry->getPointerLevel();
+    const int level{static_cast<int>(m_entry->getPointerLevel())};
     for (int i = 0; i < level; ++i)
     {
       QLabel* lblAddressOfPath =

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -300,7 +300,7 @@ void DlgAddWatchEntry::accept()
     {
       bool allOffsetsValid = true;
       int i = 0;
-      for (i; i < m_offsets.count(); ++i)
+      for (; i < m_offsets.count(); ++i)
       {
         allOffsetsValid = validateAndSetOffset(i);
         if (!allOffsetsValid)
@@ -379,7 +379,6 @@ void DlgAddWatchEntry::updatePreview()
     size_t level = m_entry->getPointerLevel();
     for (int i = 0; i < level; ++i)
     {
-      QWidget* test = m_offsetsLayout->itemAtPosition(i, 2)->widget();
       QLabel* lblAddressOfPath =
           static_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
       lblAddressOfPath->setText(

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -17,9 +17,9 @@ class DlgAddWatchEntry : public QDialog
 {
 public:
   DlgAddWatchEntry(bool newEntry, MemWatchEntry* entry, QWidget* parent);
-  ~DlgAddWatchEntry();
+  ~DlgAddWatchEntry() override;
   void onTypeChange(int index);
-  void accept();
+  void accept() override;
   void onAddressChanged();
   void onIsPointerChanged();
   void onLengthChanged();

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
@@ -12,7 +12,7 @@ public:
   DlgChangeType(QWidget* parent, const int typeIndex, const size_t length);
   int getTypeIndex() const;
   size_t getLength() const;
-  void accept();
+  void accept() override;
   void onTypeChange(int index);
 
 private:

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -8,7 +8,7 @@
 #include <QMessageBox>
 #include <QVBoxLayout>
 
-DlgImportCTFile::DlgImportCTFile(QWidget* parent)
+DlgImportCTFile::DlgImportCTFile(QWidget* const parent) : QDialog(parent)
 {
   initialiseWidgets();
   makeLayouts();

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.cpp
@@ -111,7 +111,7 @@ bool DlgImportCTFile::willUseDolphinPointers() const
   return m_useDolphinPointers;
 }
 
-u64 DlgImportCTFile::getCommonBase() const
+u32 DlgImportCTFile::getCommonBase() const
 {
   return m_commonBase;
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
@@ -17,14 +17,14 @@ public:
   void makeLayouts();
   QString getFileName() const;
   bool willUseDolphinPointers() const;
-  u64 getCommonBase() const;
+  u32 getCommonBase() const;
   void onAddressImportMethodChanged();
   void onBrowseFiles();
   void accept();
 
 private:
   bool m_useDolphinPointers;
-  u64 m_commonBase = 0;
+  u32 m_commonBase = 0;
   QString m_strFileName;
   QLineEdit* m_txbFileName;
   QPushButton* m_btnBrowseFiles;

--- a/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgImportCTFile.h
@@ -20,7 +20,7 @@ public:
   u32 getCommonBase() const;
   void onAddressImportMethodChanged();
   void onBrowseFiles();
-  void accept();
+  void accept() override;
 
 private:
   bool m_useDolphinPointers;

--- a/Source/GUI/MemWatcher/MemWatchDelegate.cpp
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.cpp
@@ -9,6 +9,8 @@
 QWidget* MemWatchDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& option,
                                         const QModelIndex& index) const
 {
+  (void)option;
+
   const MemWatchModel* model = static_cast<const MemWatchModel*>(index.model());
   MemWatchTreeNode* node = model->getTreeNodeFromIndex(index);
   QLineEdit* editor = new QLineEdit(parent);

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -189,7 +189,7 @@ int MemWatchModel::rowCount(const QModelIndex& parent) const
   else
     parentItem = static_cast<MemWatchTreeNode*>(parent.internalPointer());
 
-  return parentItem->getChildren().size();
+  return static_cast<int>(parentItem->getChildren().size());
 }
 
 QVariant MemWatchModel::data(const QModelIndex& index, int role) const
@@ -654,7 +654,7 @@ void MemWatchModel::loadRootFromJsonRecursive(const QJsonObject& json)
 }
 
 MemWatchModel::CTParsingErrors
-MemWatchModel::importRootFromCTFile(QFile* CTFile, const bool useDolphinPointer, const u64 CEStart)
+MemWatchModel::importRootFromCTFile(QFile* const CTFile, const bool useDolphinPointer, const u32 CEStart)
 {
   CheatEngineParser parser = CheatEngineParser();
   parser.setTableStartAddress(CEStart);

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -156,7 +156,6 @@ void MemWatchModel::removeNode(const QModelIndex& index)
   if (index.isValid())
   {
     MemWatchTreeNode* toDelete = static_cast<MemWatchTreeNode*>(index.internalPointer());
-    MemWatchTreeNode* parent = toDelete->getParent();
 
     int toDeleteRow = toDelete->getRow();
 

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -173,6 +173,8 @@ void MemWatchModel::removeNode(const QModelIndex& index)
 
 int MemWatchModel::columnCount(const QModelIndex& parent) const
 {
+  (void)parent;
+
   return WATCH_COL_NUM;
 }
 
@@ -463,6 +465,11 @@ QMimeData* MemWatchModel::mimeData(const QModelIndexList& indexes) const
 bool MemWatchModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
                                  const QModelIndex& parent)
 {
+  (void)column;
+
+  if (action != Qt::CopyAction && action != Qt::MoveAction)
+    return false;
+
   if (!data->hasFormat("application/x-memwatchtreenode"))
     return false;
 

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -29,7 +29,7 @@ public:
   };
 
   MemWatchModel(QObject* parent);
-  ~MemWatchModel();
+  ~MemWatchModel() override;
 
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -59,8 +59,7 @@ public:
   void onUpdateTimer();
   void onFreezeTimer();
   void loadRootFromJsonRecursive(const QJsonObject& json);
-  CTParsingErrors importRootFromCTFile(QFile* CTFile, const bool useDolphinPointer,
-                                       const u64 CEStart = 0);
+  CTParsingErrors importRootFromCTFile(QFile* CTFile, bool useDolphinPointer, u32 CEStart = 0);
   void writeRootToJsonRecursive(QJsonObject& json) const;
   QString writeRootToCSVStringRecursive() const;
   bool hasAnyNodes() const;

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -483,6 +483,8 @@ void MemWatchWidget::onValueWriteError(const QModelIndex& index,
     emit mustUnhook();
     break;
   }
+  case Common::MemOperationReturnCode::OK:
+    break;
   }
 }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -143,7 +143,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
         connect(showPointerInViewer, &QAction::triggered, this,
                 [this, entry] { emit goToAddressInViewer(entry->getConsoleAddress()); });
         memViewerSubMenu->addAction(showPointerInViewer);
-        for (int i = 0; i < entry->getPointerLevel(); ++i)
+        for (int i{0}; i < static_cast<int>(entry->getPointerLevel()); ++i)
         {
           std::string strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
           if (strAddressOfPath == "???")

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -13,7 +13,7 @@ class MemWatchWidget : public QWidget
 
 public:
   MemWatchWidget(QWidget* parent);
-  ~MemWatchWidget();
+  ~MemWatchWidget() override;
 
   void onMemWatchContextMenuRequested(const QPoint& pos);
   void onDataEdited(const QModelIndex& index, const QVariant& value, int role);

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -12,7 +12,7 @@ class DlgSettings : public QDialog
 {
 public:
   DlgSettings(QWidget* parent = nullptr);
-  ~DlgSettings();
+  ~DlgSettings() override;
 
 private:
   void loadSettings();

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -10,8 +10,8 @@ namespace
 std::string addSpacesToBytesArrays(const std::string_view bytesArray)
 {
   std::string result(bytesArray);
-  int spacesAdded = 0;
-  for (int i = 2; i < bytesArray.length(); i += 2)
+  std::string::size_type spacesAdded = 0;
+  for (std::string::size_type i{2}; i < bytesArray.length(); i += 2)
   {
     if (bytesArray[i] != ' ')
     {

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -392,6 +392,8 @@ inline MemScanner::CompareResult
 MemScanner::compareMemoryAsNumbers(const char* first, const char* second, const char* offset,
                                    bool offsetInvert, bool bswapSecond, size_t length) const
 {
+  (void)length;
+
   switch (m_memType)
   {
   case Common::MemType::type_byte:

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -87,7 +87,7 @@ Common::MemOperationReturnCode MemScanner::firstScan(const MemScanner::ScanFiter
     return Common::MemOperationReturnCode::OK;
   }
 
-  bool m_wasUnknownInitialValue = false;
+  m_wasUnknownInitialValue = false;
   Common::MemOperationReturnCode scanReturn = Common::MemOperationReturnCode::OK;
   size_t termActualLength = 0;
   size_t termMaxLength = 0;
@@ -129,8 +129,6 @@ Common::MemOperationReturnCode MemScanner::firstScan(const MemScanner::ScanFiter
       return scanReturn;
     }
   }
-
-  bool withBSwap = Common::shouldBeBSwappedForType(m_memType);
 
   m_memSize = Common::getSizeForType(m_memType, termActualLength);
 
@@ -242,8 +240,6 @@ Common::MemOperationReturnCode MemScanner::nextScan(const MemScanner::ScanFiter 
     if (scanReturn != Common::MemOperationReturnCode::OK)
       return scanReturn;
   }
-
-  bool withBSwap = Common::shouldBeBSwappedForType(m_memType);
 
   m_memSize = Common::getSizeForType(m_memType, termActualLength);
 

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -179,6 +179,8 @@ Common::MemOperationReturnCode MemScanner::firstScan(const MemScanner::ScanFiter
                                          m_memSize) == MemScanner::CompareResult::smaller);
       break;
     }
+    default:
+      break;
     }
 
     if (isResult)

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -188,7 +188,7 @@ Common::MemOperationReturnCode MemWatchEntry::freeze()
 
 u32 MemWatchEntry::getAddressForPointerLevel(const int level) const
 {
-  if (!m_boundToPointer && level > m_pointerOffsets.size() && level > 0)
+  if (!m_boundToPointer && level > static_cast<int>(m_pointerOffsets.size()) && level > 0)
     return 0;
 
   u32 address = m_consoleAddress;

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -14,8 +14,8 @@
 MemWatchEntry::MemWatchEntry(QString label, const u32 consoleAddress, const Common::MemType type,
                              const Common::MemBase base, const bool isUnsigned, const size_t length,
                              const bool isBoundToPointer)
-    : m_label(std::move(label)), m_consoleAddress(consoleAddress), m_type(type),
-      m_isUnsigned(isUnsigned), m_base(base), m_boundToPointer(isBoundToPointer), m_length(length)
+    : m_label(std::move(label)), m_consoleAddress(consoleAddress), m_type(type), m_base(base),
+      m_isUnsigned(isUnsigned), m_boundToPointer(isBoundToPointer), m_length(length)
 {
   m_memory = new char[getSizeForType(m_type, m_length)];
 }
@@ -32,9 +32,9 @@ MemWatchEntry::MemWatchEntry()
 
 MemWatchEntry::MemWatchEntry(MemWatchEntry* entry)
     : m_label(entry->m_label), m_consoleAddress(entry->m_consoleAddress), m_type(entry->m_type),
-      m_isUnsigned(entry->m_isUnsigned), m_base(entry->m_base),
+      m_base(entry->m_base), m_isUnsigned(entry->m_isUnsigned),
       m_boundToPointer(entry->m_boundToPointer), m_pointerOffsets(entry->m_pointerOffsets),
-      m_length(entry->m_length), m_isValidPointer(entry->m_isValidPointer)
+      m_isValidPointer(entry->m_isValidPointer), m_length(entry->m_length)
 {
   m_memory = new char[getSizeForType(entry->getType(), entry->getLength())];
   std::memcpy(m_memory, entry->getMemory(), getSizeForType(entry->getType(), entry->getLength()));

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -43,7 +43,7 @@ bool MemWatchTreeNode::hasChildren() const
 
 int MemWatchTreeNode::childrenCount() const
 {
-  return m_children.count();
+  return static_cast<int>(m_children.count());
 }
 
 bool MemWatchTreeNode::isValueEditing() const
@@ -95,7 +95,7 @@ MemWatchTreeNode* MemWatchTreeNode::getParent() const
 int MemWatchTreeNode::getRow() const
 {
   if (m_parent != nullptr)
-    return m_parent->m_children.indexOf(const_cast<MemWatchTreeNode*>(this));
+    return static_cast<int>(m_parent->m_children.indexOf(const_cast<MemWatchTreeNode*>(this)));
 
   return 0;
 }

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -9,7 +9,7 @@
 
 MemWatchTreeNode::MemWatchTreeNode(MemWatchEntry* const entry, MemWatchTreeNode* const parent,
                                    const bool isGroup, QString groupName)
-    : m_entry(entry), m_parent(parent), m_isGroup(isGroup), m_groupName(std::move(groupName))
+    : m_isGroup(isGroup), m_groupName(std::move(groupName)), m_entry(entry), m_parent(parent)
 {
 }
 

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -227,7 +227,7 @@ void MemWatchTreeNode::writeToJson(QJsonObject& json) const
       if (m_entry->isBoundToPointer())
       {
         QJsonArray offsets;
-        for (int i = 0; i < m_entry->getPointerOffsets().size(); ++i)
+        for (int i{0}; i < static_cast<int>(m_entry->getPointerOffsets().size()); ++i)
         {
           std::stringstream ssOffset;
           ssOffset << std::hex << std::uppercase << m_entry->getPointerOffset(i);
@@ -257,7 +257,7 @@ QString MemWatchTreeNode::writeAsCSV() const
     ssAddress << std::hex << std::uppercase << m_entry->getConsoleAddress();
     if (m_entry->isBoundToPointer())
     {
-      for (int i = 0; i < m_entry->getPointerLevel(); i++)
+      for (int i = 0; i < static_cast<int>(m_entry->getPointerLevel()); ++i)
       {
         std::stringstream ssOffset;
         ssOffset << std::hex << std::uppercase << m_entry->getPointerOffset(i);


### PR DESCRIPTION
- `-Wall` and `-Wextra` have been enabled in GCC/Clang.
- `-W4` has been enabled in MSVC.

All warnings have been promoted to errors on Unix compilers via `-Werror`. All warnings (with a couple of exceptions in Clang) have been addressed.