### PR TITLE
Set initial state of the **Scanner** checkable action in the next event loop tick.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -7,6 +7,7 @@
 #include <QMenuBar>
 #include <QShortcut>
 #include <QString>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <string>
 
@@ -80,7 +81,10 @@ void MainWindow::makeMenus()
   m_actScanner = new QAction(tr("&Scanner"), this);
   m_actScanner->setShortcut(QKeySequence("F3"));
   m_actScanner->setCheckable(true);
-  m_actScanner->setChecked(m_splitter->sizes()[0] > 0);
+  QTimer::singleShot(0, [this]() {
+    QSignalBlocker signalBlocker(m_actScanner);
+    m_actScanner->setChecked(m_scanner->isVisible());
+  });
 
   m_actQuit = new QAction(tr("&Quit"), this);
   m_actAbout = new QAction(tr("&About"), this);


### PR DESCRIPTION
Previously, the initial size of the main splitter was used to initialize the checkable action. However, that size is not accurate until the main window has been shown.

The action is now initialized in the next event loop tick, when the GUI is ready.

Fixes #131.