### PR TITLE
Warn user about other instances owning the settings file.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -572,6 +572,17 @@ void MainWindow::closeEvent(QCloseEvent* event)
   SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
   SConfig::getInstance().setMainWindowGeometry(saveGeometry());
   SConfig::getInstance().setMainWindowState(saveState());
+
+  if (!SConfig::getInstance().ownsSettingsFile())
+  {
+    // Give the user a chance to save the ephemeral watch model.
+    if (!m_watcher->warnIfUnsavedChanges())
+    {
+      event->setAccepted(false);
+      return;
+    }
+  }
+
   m_viewer->close();
   event->accept();
 }

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include <QByteArray>
+#include <QLockFile>
 #include <QSettings>
 
 #include "../../Common/CommonTypes.h"
@@ -9,6 +12,10 @@ class SConfig
 {
 public:
   static SConfig& getInstance();
+
+  SConfig();
+  ~SConfig();
+
   SConfig(SConfig const&) = delete;
   void operator=(SConfig const&) = delete;
 
@@ -52,9 +59,13 @@ public:
 
   void setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator);
 
-private:
-  SConfig();
-  ~SConfig();
+  bool ownsSettingsFile() const;
 
-  QSettings* m_settings;
+private:
+  void setValue(const QString& key, const QVariant& value);
+  QVariant value(const QString& key, const QVariant& defaultValue) const;
+
+  std::unique_ptr<QLockFile> m_lockFile;
+  std::unordered_map<QString, QVariant> m_map;
+  QSettings* m_settings{};
 };

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -1,13 +1,17 @@
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QMessageBox>
 
 #include "GUI/MainWindow.h"
+#include "GUI/Settings/SConfig.h"
 
 int main(int argc, char** argv)
 {
   QApplication app(argc, argv);
   QApplication::setApplicationName("Dolphin Memory Engine");
   QApplication::setApplicationVersion("1.1.1");
+
+  SConfig config;  // Initialize global settings object
 
   QCommandLineParser parser;
   parser.setApplicationDescription(
@@ -34,6 +38,19 @@ int main(int argc, char** argv)
   }
 
   MainWindow window;
+
+  if (!config.ownsSettingsFile())
+  {
+    QMessageBox box(
+        QMessageBox::Warning, QObject::tr("Another instance is already running"),
+        QObject::tr(
+            "Changes made to settings will not be preserved in this session. This includes changes "
+            "to the watch list, which will need to be saved manually into a file."),
+        QMessageBox::Ok);
+    box.setWindowIcon(window.windowIcon());
+    box.exec();
+  }
+
   window.show();
   return QApplication::exec();
 }


### PR DESCRIPTION
When multiple DME instances are created, only the first one gets to own the settings file now; previously, the last DME instance to close would rewrite the settings file, potentially causing data loss from the previous instances.

A warning dialog will be shown on startup if the settings lockfile cannot be acquired. On exit, if there are unsaved changes to the watch list, the user will be given an opportunity to save it into a separate `.dmw` file.