### PR TITLE
Further fixes for Clang-Tidy warnings (2).

### DIFF
--- a/Source/.clang-tidy
+++ b/Source/.clang-tidy
@@ -9,6 +9,7 @@ Checks:  >
   hicpp-*,
   -hicpp-avoid-c-arrays,
   -hicpp-braces-around-statements,
+  -hicpp-signed-bitwise,
   -hicpp-uppercase-literal-suffix,
   -hicpp-use-auto,
   -hicpp-use-equals-default,

--- a/Source/.clang-tidy
+++ b/Source/.clang-tidy
@@ -26,6 +26,7 @@ Checks:  >
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
+  -performance-enum-size,
   -performance-no-int-to-ptr,
   readability-*,
   -readability-braces-around-statements,

--- a/Source/CheatEngineParser/CheatEngineParser.h
+++ b/Source/CheatEngineParser/CheatEngineParser.h
@@ -20,7 +20,7 @@ public:
   QString getErrorMessages() const;
   bool hasACriticalErrorOccured() const;
   void setTableStartAddress(u32 tableStartAddress);
-  MemWatchTreeNode* parseCTFile(QIODevice* CTFileIODevice, const bool useDolphinPointer);
+  MemWatchTreeNode* parseCTFile(QIODevice* CTFileIODevice, bool useDolphinPointer);
 
 private:
   struct cheatEntryParsingState
@@ -38,11 +38,11 @@ private:
     bool validLengthForStr = true;
   };
 
-  MemWatchTreeNode* parseCheatTable(MemWatchTreeNode* rootNode, const bool useDolphinPointer);
-  MemWatchTreeNode* parseCheatEntries(MemWatchTreeNode* node, const bool useDolphinPointer);
-  void parseCheatEntry(MemWatchTreeNode* node, const bool useDolphinPointer);
+  MemWatchTreeNode* parseCheatTable(MemWatchTreeNode* rootNode, bool useDolphinPointer);
+  MemWatchTreeNode* parseCheatEntries(MemWatchTreeNode* node, bool useDolphinPointer);
+  void parseCheatEntry(MemWatchTreeNode* node, bool useDolphinPointer);
   void verifyCheatEntryParsingErrors(cheatEntryParsingState state, MemWatchEntry* entry,
-                                     bool isGroup, const bool useDolphinPointer);
+                                     bool isGroup, bool useDolphinPointer);
   static QString formatImportedEntryBasicInfo(const MemWatchEntry* entry);
 
   u32 m_tableStartAddress = 0;

--- a/Source/CheatEngineParser/CheatEngineParser.h
+++ b/Source/CheatEngineParser/CheatEngineParser.h
@@ -12,6 +12,11 @@ public:
   CheatEngineParser();
   ~CheatEngineParser();
 
+  CheatEngineParser(const CheatEngineParser&) = delete;
+  CheatEngineParser(CheatEngineParser&&) = delete;
+  CheatEngineParser& operator=(const CheatEngineParser&) = delete;
+  CheatEngineParser& operator=(CheatEngineParser&&) = delete;
+
   QString getErrorMessages() const;
   bool hasACriticalErrorOccured() const;
   void setTableStartAddress(u32 tableStartAddress);

--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -54,12 +54,11 @@ enum class MemOperationReturnCode
   OK
 };
 
-size_t getSizeForType(const MemType type, const size_t length);
-bool shouldBeBSwappedForType(const MemType type);
-int getNbrBytesAlignmentForType(const MemType type);
+size_t getSizeForType(MemType type, size_t length);
+bool shouldBeBSwappedForType(MemType type);
+int getNbrBytesAlignmentForType(MemType type);
 char* formatStringToMemory(MemOperationReturnCode& returnCode, size_t& actualLength,
                            std::string_view inputString, MemBase base, MemType type, size_t length);
-std::string formatMemoryToString(const char* memory, const MemType type, const size_t length,
-                                 const MemBase base, const bool isUnsigned,
-                                 const bool withBSwap = false);
+std::string formatMemoryToString(const char* memory, MemType type, size_t length, MemBase base,
+                                 bool isUnsigned, bool withBSwap = false);
 }  // namespace Common

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -22,9 +22,8 @@ public:
   static void free();
   static void hook();
   static void unHook();
-  static bool readFromRAM(const u32 offset, char* buffer, const size_t size, const bool withBSwap);
-  static bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
-                         const bool withBSwap);
+  static bool readFromRAM(u32 offset, char* buffer, size_t size, bool withBSwap);
+  static bool writeToRAM(u32 offset, const char* buffer, size_t size, bool withBSwap);
   static int getPID();
   static u64 getEmuRAMAddressStart();
   static DolphinStatus getStatus();
@@ -33,10 +32,10 @@ public:
   static bool isMEM2Present();
   static size_t getRAMTotalSize();
   static Common::MemOperationReturnCode readEntireRAM(char* buffer);
-  static std::string getFormattedValueFromMemory(const u32 ramIndex, Common::MemType memType,
+  static std::string getFormattedValueFromMemory(u32 ramIndex, Common::MemType memType,
                                                  size_t memSize, Common::MemBase memBase,
                                                  bool memIsUnsigned);
-  static bool isValidConsoleAddress(const u32 address);
+  static bool isValidConsoleAddress(u32 address);
 
 private:
   static IDolphinProcess* m_instance;

--- a/Source/DolphinProcess/IDolphinProcess.h
+++ b/Source/DolphinProcess/IDolphinProcess.h
@@ -20,10 +20,8 @@ public:
 
   virtual bool findPID() = 0;
   virtual bool obtainEmuRAMInformations() = 0;
-  virtual bool readFromRAM(const u32 offset, char* buffer, const size_t size,
-                           const bool withBSwap) = 0;
-  virtual bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
-                          const bool withBSwap) = 0;
+  virtual bool readFromRAM(u32 offset, char* buffer, size_t size, bool withBSwap) = 0;
+  virtual bool writeToRAM(u32 offset, const char* buffer, size_t size, bool withBSwap) = 0;
 
   int getPID() const { return m_PID; };
   u64 getEmuRAMAddressStart() const { return m_emuRAMAddressStart; };

--- a/Source/DolphinProcess/IDolphinProcess.h
+++ b/Source/DolphinProcess/IDolphinProcess.h
@@ -10,7 +10,14 @@ namespace DolphinComm
 class IDolphinProcess
 {
 public:
+  IDolphinProcess() = default;
   virtual ~IDolphinProcess() = default;
+
+  IDolphinProcess(const IDolphinProcess&) = delete;
+  IDolphinProcess(IDolphinProcess&&) = delete;
+  IDolphinProcess& operator=(const IDolphinProcess&) = delete;
+  IDolphinProcess& operator=(IDolphinProcess&&) = delete;
+
   virtual bool findPID() = 0;
   virtual bool obtainEmuRAMInformations() = 0;
   virtual bool readFromRAM(const u32 offset, char* buffer, const size_t size,

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -113,13 +113,14 @@ bool LinuxDolphinProcess::findPID()
   struct dirent* directoryEntry = nullptr;
   while (m_PID == -1 && (directoryEntry = readdir(directoryPointer)))
   {
-    std::istringstream conversionStream(directoryEntry->d_name);
+    const char* const name{static_cast<const char*>(directoryEntry->d_name)};
+    std::istringstream conversionStream(name);
     int aPID = 0;
     if (!(conversionStream >> aPID))
       continue;
     std::ifstream aCmdLineFile;
     std::string line;
-    aCmdLineFile.open("/proc/" + std::string(directoryEntry->d_name) + "/comm");
+    aCmdLineFile.open("/proc/" + std::string(name) + "/comm");
     getline(aCmdLineFile, line);
 
     const bool match{s_dolphinProcessName ? line == s_dolphinProcessName :

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.h
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.h
@@ -16,9 +16,8 @@ public:
   LinuxDolphinProcess() = default;
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
-  bool readFromRAM(const u32 offset, char* buffer, size_t size, const bool withBSwap) override;
-  bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
-                  const bool withBSwap) override;
+  bool readFromRAM(u32 offset, char* buffer, size_t size, bool withBSwap) override;
+  bool writeToRAM(u32 offset, const char* buffer, size_t size, bool withBSwap) override;
 };
 }  // namespace DolphinComm
 #endif

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.h
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.h
@@ -13,9 +13,8 @@ public:
   MacDolphinProcess() = default;
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
-  bool readFromRAM(const u32 offset, char* buffer, size_t size, const bool withBSwap) override;
-  bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
-                  const bool withBSwap) override;
+  bool readFromRAM(u32 offset, char* buffer, size_t size, bool withBSwap) override;
+  bool writeToRAM(u32 offset, const char* buffer, size_t size, bool withBSwap) override;
 
 private:
   task_t m_task;

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.h
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.h
@@ -14,10 +14,8 @@ public:
   WindowsDolphinProcess() = default;
   bool findPID() override;
   bool obtainEmuRAMInformations() override;
-  bool readFromRAM(const u32 offset, char* buffer, const size_t size,
-                   const bool withBSwap) override;
-  bool writeToRAM(const u32 offset, const char* buffer, const size_t size,
-                  const bool withBSwap) override;
+  bool readFromRAM(u32 offset, char* buffer, size_t size, bool withBSwap) override;
+  bool writeToRAM(u32 offset, const char* buffer, size_t size, bool withBSwap) override;
 
 private:
   HANDLE m_hDolphin;

--- a/Source/GUI/GUICommon.h
+++ b/Source/GUI/GUICommon.h
@@ -11,8 +11,8 @@ extern QStringList g_memTypeNames;
 extern QStringList g_memScanFilter;
 extern QStringList g_memBaseNames;
 
-QString getStringFromType(const Common::MemType type, const size_t length = 0);
-QString getNameFromBase(const Common::MemBase base);
+QString getStringFromType(Common::MemType type, size_t length = 0);
+QString getNameFromBase(Common::MemBase base);
 
 void changeApplicationStyle(int);
 

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -21,6 +21,12 @@ class MainWindow : public QMainWindow
 public:
   MainWindow();
   ~MainWindow() override;
+
+  MainWindow(const MainWindow&) = delete;
+  MainWindow(MainWindow&&) = delete;
+  MainWindow& operator=(const MainWindow&) = delete;
+  MainWindow& operator=(MainWindow&&) = delete;
+
   void closeEvent(QCloseEvent* event) override;
   void addWatchRequested(u32 address, Common::MemType type, size_t length, bool isUnsigned,
                          Common::MemBase base);

--- a/Source/GUI/MemCopy/DlgCopy.cpp
+++ b/Source/GUI/MemCopy/DlgCopy.cpp
@@ -96,10 +96,10 @@ bool DlgCopy::copyMemory()
   {
     QString errorMsg = tr("The address you entered is invalid, make sure it is an "
                           "hexadecimal number between 0x%08X and 0x%08X")
-                           .arg(Common::MEM1_START, Common::GetMEM1End() - 1);
+                           .arg(Common::MEM1_START, static_cast<int>(Common::GetMEM1End()) - 1);
     if (DolphinComm::DolphinAccessor::isMEM2Present())
-      errorMsg.append(
-          tr(" or between 0x%08X and 0x%08X").arg(Common::MEM2_START, Common::GetMEM2End() - 1));
+      errorMsg.append(tr(" or between 0x%08X and 0x%08X")
+                          .arg(Common::MEM2_START, static_cast<int>(Common::GetMEM2End()) - 1));
 
     errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid address"), errorMsg,
                                QMessageBox::Ok, nullptr);

--- a/Source/GUI/MemCopy/DlgCopy.h
+++ b/Source/GUI/MemCopy/DlgCopy.h
@@ -17,6 +17,11 @@ public:
   explicit DlgCopy(QWidget* parent = nullptr);
   ~DlgCopy() override;
 
+  DlgCopy(const DlgCopy&) = delete;
+  DlgCopy(DlgCopy&&) = delete;
+  DlgCopy& operator=(const DlgCopy&) = delete;
+  DlgCopy& operator=(DlgCopy&&) = delete;
+
 private:
   enum ByteStringFormats
   {

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -22,6 +22,11 @@ public:
   MemScanWidget();
   ~MemScanWidget() override;
 
+  MemScanWidget(const MemScanWidget&) = delete;
+  MemScanWidget(MemScanWidget&&) = delete;
+  MemScanWidget& operator=(const MemScanWidget&) = delete;
+  MemScanWidget& operator=(MemScanWidget&&) = delete;
+
   ResultsListModel* getResultListModel() const;
   std::vector<u32> getAllResults() const;
   QModelIndexList getSelectedResults() const;

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -35,7 +35,7 @@ public:
   void onScanMemTypeChanged();
   void onCurrentValuesUpdateTimer();
   void onResultListDoubleClicked(const QModelIndex& index);
-  void handleScannerErrors(const Common::MemOperationReturnCode errorCode);
+  void handleScannerErrors(Common::MemOperationReturnCode errorCode);
   void onFirstScan();
   void onNextScan();
   void onUndoScan();

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -20,6 +20,11 @@ public:
   ResultsListModel(QObject* parent, MemScanner* scanner);
   ~ResultsListModel() override;
 
+  ResultsListModel(const ResultsListModel&) = delete;
+  ResultsListModel(ResultsListModel&&) = delete;
+  ResultsListModel& operator=(const ResultsListModel&) = delete;
+  ResultsListModel& operator=(ResultsListModel&&) = delete;
+
   int columnCount(const QModelIndex& parent) const override;
   int rowCount(const QModelIndex& parent) const override;
   QVariant data(const QModelIndex& index, int role) const override;

--- a/Source/GUI/MemScanner/ResultsListModel.h
+++ b/Source/GUI/MemScanner/ResultsListModel.h
@@ -31,7 +31,7 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
   bool removeRows(int row, int count, const QModelIndex& parent) override;
 
-  u32 getResultAddress(const int row) const;
+  u32 getResultAddress(int row) const;
   void updateScanner();
   void updateAfterScannerReset();
   void setShowThreshold(size_t showThreshold);

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -89,7 +89,8 @@ void MemViewer::memoryValidityChanged(const bool valid)
       m_memViewStart = Common::ARAM_START;
       m_memViewEnd = Common::ARAM_END;
     }
-    verticalScrollBar()->setRange(0, ((m_memViewEnd - m_memViewStart) / m_numColumns) - m_numRows);
+    verticalScrollBar()->setRange(
+        0, (static_cast<int>(m_memViewEnd - m_memViewStart) / m_numColumns) - m_numRows);
   }
   viewport()->update();
 }
@@ -143,7 +144,8 @@ void MemViewer::jumpToAddress(const u32 address)
     m_carretBetweenHex = false;
 
     m_disableScrollContentEvent = true;
-    verticalScrollBar()->setValue(((address & 0xFFFFFFF0) - m_memViewStart) / m_numColumns);
+    verticalScrollBar()->setValue(static_cast<int>((address & 0xFFFFFFF0) - m_memViewStart) /
+                                  m_numColumns);
     m_disableScrollContentEvent = false;
 
     viewport()->update();
@@ -167,7 +169,8 @@ void MemViewer::changeMemoryRegion(const MemoryRegion region)
     m_memViewEnd = Common::GetMEM2End();
     break;
   }
-  verticalScrollBar()->setRange(0, ((m_memViewEnd - m_memViewStart) / m_numColumns) - m_numRows);
+  verticalScrollBar()->setRange(
+      0, (static_cast<int>(m_memViewEnd - m_memViewStart) / m_numColumns) - m_numRows);
 }
 
 MemViewer::bytePosFromMouse MemViewer::mousePosToBytePos(QPoint pos)
@@ -720,10 +723,11 @@ bool MemViewer::writeCharacterToSelectedMemory(char byteToWrite)
 
     const char selectedMemoryValue = *(m_updatedRawMemoryData + memoryOffset);
     if (m_carretBetweenHex)
-      byteToWrite = (selectedMemoryValue & static_cast<char>(0xF0)) | byteToWrite;
+      byteToWrite = static_cast<char>((static_cast<u32>(selectedMemoryValue) & 0xF0) |
+                                      static_cast<u32>(byteToWrite));
     else
-      byteToWrite =
-          (selectedMemoryValue & static_cast<char>(0x0F)) | static_cast<char>(byteToWrite << 4);
+      byteToWrite = static_cast<char>((static_cast<u32>(selectedMemoryValue) & 0x0F) |
+                                      (static_cast<u32>(byteToWrite) << 4));
   }
 
   const u32 offsetToWrite{
@@ -845,7 +849,7 @@ void MemViewer::renderColumnsHeaderText(QPainter& painter) const
   for (int i = 0; i < m_numColumns; i++)
   {
     std::stringstream ss;
-    int byte = (m_currentFirstAddress + i) & 0xF;
+    const u32 byte{(m_currentFirstAddress + static_cast<u32>(i)) & 0xF};
     ss << std::hex << std::uppercase << byte;
     std::string headerText = "." + ss.str();
     painter.drawText(posXHeaderText, m_charHeight, QString::fromStdString(headerText));

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -35,9 +35,9 @@ public:
   void paintEvent(QPaintEvent* event) override;
   void scrollContentsBy(int dx, int dy) override;
   u32 getCurrentFirstAddress() const;
-  void jumpToAddress(const u32 address);
+  void jumpToAddress(u32 address);
   void updateViewer();
-  void memoryValidityChanged(const bool valid);
+  void memoryValidityChanged(bool valid);
 
 signals:
   void memErrorOccured();
@@ -74,21 +74,21 @@ private:
   void editSelection();
   void addSelectionAsArrayOfBytes();
   void addByteIndexAsWatch(int index);
-  bool handleNaviguationKey(const int key, bool shiftIsHeld);
+  bool handleNaviguationKey(int key, bool shiftIsHeld);
   bool writeCharacterToSelectedMemory(char byteToWrite);
   void updateMemoryData();
-  void changeMemoryRegion(const MemoryRegion region);
+  void changeMemoryRegion(MemoryRegion region);
   void renderColumnsHeaderText(QPainter& painter) const;
   void renderRowHeaderText(QPainter& painter, int rowIndex) const;
   void renderSeparatorLines(QPainter& painter) const;
-  void renderMemory(QPainter& painter, const int rowIndex, const int columnIndex);
-  void renderHexByte(QPainter& painter, const int rowIndex, const int columnIndex, QColor& bgColor,
+  void renderMemory(QPainter& painter, int rowIndex, int columnIndex);
+  void renderHexByte(QPainter& painter, int rowIndex, int columnIndex, QColor& bgColor,
                      QColor& fgColor, bool drawCarret);
-  void renderASCIIText(QPainter& painter, const int rowIndex, const int columnIndex,
-                       QColor& bgColor, QColor& fgColor);
-  void renderCarret(QPainter& painter, const int rowIndex, const int columnIndex);
-  void determineMemoryTextRenderProperties(const int rowIndex, const int columnIndex,
-                                           bool& drawCarret, QColor& bgColor, QColor& fgColor);
+  void renderASCIIText(QPainter& painter, int rowIndex, int columnIndex, QColor& bgColor,
+                       QColor& fgColor);
+  void renderCarret(QPainter& painter, int rowIndex, int columnIndex);
+  void determineMemoryTextRenderProperties(int rowIndex, int columnIndex, bool& drawCarret,
+                                           QColor& bgColor, QColor& fgColor);
 
   const int m_numRows = 16;
   const int m_numColumns = 16;  // Should be a multiple of 16, or the header doesn't make much sense

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -20,6 +20,12 @@ class MemViewer : public QAbstractScrollArea
 public:
   explicit MemViewer(QWidget* parent);
   ~MemViewer() override;
+
+  MemViewer(const MemViewer&) = delete;
+  MemViewer(MemViewer&&) = delete;
+  MemViewer& operator=(const MemViewer&) = delete;
+  MemViewer& operator=(MemViewer&&) = delete;
+
   QSize sizeHint() const override;
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;

--- a/Source/GUI/MemViewer/MemViewerWidget.h
+++ b/Source/GUI/MemViewer/MemViewerWidget.h
@@ -14,6 +14,11 @@ public:
   explicit MemViewerWidget(QWidget* parent);
   ~MemViewerWidget() override;
 
+  MemViewerWidget(const MemViewerWidget&) = delete;
+  MemViewerWidget(MemViewerWidget&&) = delete;
+  MemViewerWidget& operator=(const MemViewerWidget&) = delete;
+  MemViewerWidget& operator=(MemViewerWidget&&) = delete;
+
   void onJumpToAddressTextChanged();
   void onGoToMEM1Start();
   void onGoToSecondaryRAMStart();

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -18,6 +18,12 @@ class DlgAddWatchEntry : public QDialog
 public:
   DlgAddWatchEntry(bool newEntry, MemWatchEntry* entry, QWidget* parent);
   ~DlgAddWatchEntry() override;
+
+  DlgAddWatchEntry(const DlgAddWatchEntry&) = delete;
+  DlgAddWatchEntry(DlgAddWatchEntry&&) = delete;
+  DlgAddWatchEntry& operator=(const DlgAddWatchEntry&) = delete;
+  DlgAddWatchEntry& operator=(DlgAddWatchEntry&&) = delete;
+
   void onTypeChange(int index);
   void accept() override;
   void onAddressChanged();

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
@@ -9,7 +9,7 @@ class DlgChangeType : public QDialog
   Q_OBJECT
 
 public:
-  DlgChangeType(QWidget* parent, const int typeIndex, const size_t length);
+  DlgChangeType(QWidget* parent, int typeIndex, size_t length);
   int getTypeIndex() const;
   size_t getLength() const;
   void accept() override;

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -31,6 +31,11 @@ public:
   explicit MemWatchModel(QObject* parent);
   ~MemWatchModel() override;
 
+  MemWatchModel(const MemWatchModel&) = delete;
+  MemWatchModel(MemWatchModel&&) = delete;
+  MemWatchModel& operator=(const MemWatchModel&) = delete;
+  MemWatchModel& operator=(MemWatchModel&&) = delete;
+
   int columnCount(const QModelIndex& parent) const override;
   int rowCount(const QModelIndex& parent) const override;
   QVariant data(const QModelIndex& index, int role) const override;

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -52,7 +52,7 @@ public:
   bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
                     const QModelIndex& parent) override;
 
-  void changeType(const QModelIndex& index, const Common::MemType type, const size_t length);
+  void changeType(const QModelIndex& index, Common::MemType type, size_t length);
   static MemWatchEntry* getEntryFromIndex(const QModelIndex& index);
   void addGroup(const QString& name);
   void addEntry(MemWatchEntry* entry);
@@ -79,9 +79,9 @@ signals:
 
 private:
   bool updateNodeValueRecursive(MemWatchTreeNode* node, const QModelIndex& parent = QModelIndex(),
-                                const bool readSucess = true);
+                                bool readSucess = true);
   bool freezeNodeValueRecursive(MemWatchTreeNode* node, const QModelIndex& parent = QModelIndex(),
-                                const bool writeSucess = true);
+                                bool writeSucess = true);
   MemWatchTreeNode* getLeastDeepNodeFromList(const QList<MemWatchTreeNode*>& nodes) const;
   int getNodeDeepness(const MemWatchTreeNode* node) const;
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -541,7 +541,7 @@ QModelIndexList MemWatchWidget::simplifySelection() const
   return simplifiedSelection;
 }
 
-bool MemWatchWidget::isAnyAncestorSelected(const QModelIndex index) const
+bool MemWatchWidget::isAnyAncestorSelected(const QModelIndex& index) const
 {
   if (m_watchModel->parent(index) == QModelIndex())
     return false;

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -299,12 +299,11 @@ void MemWatchWidget::cutSelectedWatchesToClipBoard()
 {
   copySelectedWatchesToClipBoard();
 
-  QModelIndexList* cutList = simplifySelection();
-
-  if (cutList->count() > 0)
+  const QModelIndexList cutList{simplifySelection()};
+  if (!cutList.empty())
   {
-    for (auto i : *cutList)
-      m_watchModel->removeNode(i);
+    for (const auto& index : cutList)
+      m_watchModel->removeNode(index);
 
     m_hasUnsavedChanges = true;
   }
@@ -318,13 +317,13 @@ void MemWatchWidget::copySelectedWatchesToClipBoard()
 
   QJsonObject jsonNode;
   {
-    QModelIndexList* toCopyList = simplifySelection();
+    const QModelIndexList toCopyList{simplifySelection()};
 
     std::unordered_map<MemWatchTreeNode*, MemWatchTreeNode*> parentMap;
     MemWatchTreeNode rootNodeCopy(nullptr, nullptr, false, QString{});
-    for (auto i : *toCopyList)
+    for (const auto& index : toCopyList)
     {
-      MemWatchTreeNode* const childNode{MemWatchModel::getTreeNodeFromIndex(i)};
+      MemWatchTreeNode* const childNode{MemWatchModel::getTreeNodeFromIndex(index)};
       parentMap[childNode] = childNode->getParent();
 
       rootNodeCopy.appendChild(childNode);  // Borrow node temporarily.
@@ -525,9 +524,9 @@ void MemWatchWidget::addWatchEntry(MemWatchEntry* entry)
   m_hasUnsavedChanges = true;
 }
 
-QModelIndexList* MemWatchWidget::simplifySelection() const
+QModelIndexList MemWatchWidget::simplifySelection() const
 {
-  QModelIndexList* simplifiedSelection = new QModelIndexList();
+  QModelIndexList simplifiedSelection;
   QModelIndexList selection = m_watchView->selectionModel()->selectedRows();
 
   // Discard all indexes whose parent is selected already
@@ -535,7 +534,9 @@ QModelIndexList* MemWatchWidget::simplifySelection() const
   {
     const QModelIndex index = selection.at(i);
     if (!isAnyAncestorSelected(index))
-      simplifiedSelection->append(index);
+    {
+      simplifiedSelection.append(index);
+    }
   }
   return simplifiedSelection;
 }
@@ -599,10 +600,11 @@ void MemWatchWidget::onDeleteSelection()
   confirmationBox->setDefaultButton(QMessageBox::Yes);
   if (confirmationBox->exec() == QMessageBox::Yes)
   {
-    QModelIndexList* toDeleteList = simplifySelection();
-
-    for (auto i : *toDeleteList)
-      m_watchModel->removeNode(i);
+    const QModelIndexList toDeleteList{simplifySelection()};
+    for (const auto& index : toDeleteList)
+    {
+      m_watchModel->removeNode(index);
+    }
 
     m_hasUnsavedChanges = true;
   }

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -15,6 +15,11 @@ public:
   explicit MemWatchWidget(QWidget* parent);
   ~MemWatchWidget() override;
 
+  MemWatchWidget(const MemWatchWidget&) = delete;
+  MemWatchWidget(MemWatchWidget&&) = delete;
+  MemWatchWidget& operator=(const MemWatchWidget&) = delete;
+  MemWatchWidget& operator=(MemWatchWidget&&) = delete;
+
   void onMemWatchContextMenuRequested(const QPoint& pos);
   void onDataEdited(const QModelIndex& index, const QVariant& value, int role);
   void onValueWriteError(const QModelIndex& index, Common::MemOperationReturnCode writeReturn);

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -64,6 +64,6 @@ private:
   QString m_watchListFile = "";
   bool m_hasUnsavedChanges = false;
 
-  bool isAnyAncestorSelected(const QModelIndex index) const;
+  bool isAnyAncestorSelected(const QModelIndex& index) const;
   QModelIndexList simplifySelection() const;
 };

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -65,5 +65,5 @@ private:
   bool m_hasUnsavedChanges = false;
 
   bool isAnyAncestorSelected(const QModelIndex index) const;
-  QModelIndexList* simplifySelection() const;
+  QModelIndexList simplifySelection() const;
 };

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -157,8 +157,8 @@ void DlgSettings::loadSettings()
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
   m_cmbTheme->setCurrentIndex(m_cmbTheme->findData(SConfig::getInstance().getTheme()));
   // This erases fractional mebibyte sizes, but nobody should be using those anyway.
-  m_sldMEM1Size->setValue(SConfig::getInstance().getMEM1Size() / 1024 / 1024);
-  m_sldMEM2Size->setValue(SConfig::getInstance().getMEM2Size() / 1024 / 1024);
+  m_sldMEM1Size->setValue(static_cast<int>(SConfig::getInstance().getMEM1Size()) / 1024 / 1024);
+  m_sldMEM2Size->setValue(static_cast<int>(SConfig::getInstance().getMEM2Size()) / 1024 / 1024);
 }
 
 void DlgSettings::saveSettings() const

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -14,6 +14,11 @@ public:
   explicit DlgSettings(QWidget* parent = nullptr);
   ~DlgSettings() override;
 
+  DlgSettings(const DlgSettings&) = delete;
+  DlgSettings(DlgSettings&&) = delete;
+  DlgSettings& operator=(const DlgSettings&) = delete;
+  DlgSettings& operator=(DlgSettings&&) = delete;
+
 private:
   void loadSettings();
   void saveSettings() const;

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -49,17 +49,17 @@ public:
   void setWatchModel(const QString& json);
   void setAutoHook(bool enabled);
 
-  void setTheme(const int theme);
+  void setTheme(int theme);
 
-  void setWatcherUpdateTimerMs(const int watcherUpdateTimerMs);
-  void setFreezeTimerMs(const int freezeTimerMs);
-  void setScannerUpdateTimerMs(const int scannerUpdateTimerMs);
-  void setViewerUpdateTimerMs(const int viewerUpdateTimerMs);
+  void setWatcherUpdateTimerMs(int watcherUpdateTimerMs);
+  void setFreezeTimerMs(int freezeTimerMs);
+  void setScannerUpdateTimerMs(int scannerUpdateTimerMs);
+  void setViewerUpdateTimerMs(int viewerUpdateTimerMs);
   void setScannerShowThreshold(int scannerShowThreshold);
-  void setMEM1Size(const u32 mem1SizeReal);
-  void setMEM2Size(const u32 mem2SizeReal);
+  void setMEM1Size(u32 mem1SizeReal);
+  void setMEM2Size(u32 mem2SizeReal);
 
-  void setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator);
+  void setViewerNbrBytesSeparator(int viewerNbrBytesSeparator);
 
   bool ownsSettingsFile() const;
 

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -16,8 +16,10 @@ public:
   SConfig();
   ~SConfig();
 
-  SConfig(SConfig const&) = delete;
-  void operator=(SConfig const&) = delete;
+  SConfig(const SConfig&) = delete;
+  SConfig(SConfig&&) = delete;
+  SConfig& operator=(const SConfig&) = delete;
+  SConfig& operator=(SConfig&&) = delete;
 
   QString getSettingsFilepath() const;
 

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -40,6 +40,12 @@ public:
 
   MemScanner();
   ~MemScanner();
+
+  MemScanner(const MemScanner&) = delete;
+  MemScanner(MemScanner&&) = delete;
+  MemScanner& operator=(const MemScanner&) = delete;
+  MemScanner& operator=(MemScanner&&) = delete;
+
   Common::MemOperationReturnCode firstScan(const ScanFiter filter, const std::string& searchTerm1,
                                            const std::string& searchTerm2);
   Common::MemOperationReturnCode nextScan(const ScanFiter filter, const std::string& searchTerm1,

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -46,9 +46,9 @@ public:
   MemScanner& operator=(const MemScanner&) = delete;
   MemScanner& operator=(MemScanner&&) = delete;
 
-  Common::MemOperationReturnCode firstScan(const ScanFiter filter, const std::string& searchTerm1,
+  Common::MemOperationReturnCode firstScan(ScanFiter filter, const std::string& searchTerm1,
                                            const std::string& searchTerm2);
-  Common::MemOperationReturnCode nextScan(const ScanFiter filter, const std::string& searchTerm1,
+  Common::MemOperationReturnCode nextScan(ScanFiter filter, const std::string& searchTerm1,
                                           const std::string& searchTerm2);
   bool undoScan();
   void reset();
@@ -136,10 +136,10 @@ public:
     return CompareResult::equal;
   }
 
-  void setType(const Common::MemType type);
-  void setBase(const Common::MemBase base);
-  void setEnforceMemAlignment(const bool enforceAlignment);
-  void setIsSigned(const bool isSigned);
+  void setType(Common::MemType type);
+  void setBase(Common::MemBase base);
+  void setEnforceMemAlignment(bool enforceAlignment);
+  void setIsSigned(bool isSigned);
   void resetSearchRange();
   bool setSearchRangeBegin(u32 beginRange);
   bool setSearchRangeEnd(u32 endRange);
@@ -154,17 +154,16 @@ public:
   Common::MemBase getBase() const;
   size_t getLength() const;
   bool getIsUnsigned() const;
-  std::string getFormattedScannedValueAt(const int index) const;
+  std::string getFormattedScannedValueAt(int index) const;
   std::string getFormattedCurrentValueAt(int index) const;
   void removeResultAt(int index);
   static bool typeSupportsAdditionalOptions(Common::MemType type);
   bool hasScanStarted() const;
 
 private:
-  inline bool isHitNextScan(const ScanFiter filter, const char* memoryToCompare1,
+  inline bool isHitNextScan(ScanFiter filter, const char* memoryToCompare1,
                             const char* memoryToCompare2, const char* noOffset,
-                            const char* newerRAMCache, const size_t realSize,
-                            const u32 consoleOffset) const;
+                            const char* newerRAMCache, size_t realSize, u32 consoleOffset) const;
 
   bool m_searchInRangeBegin = false;
   bool m_searchInRangeEnd = false;

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -1,5 +1,6 @@
 #include "MemWatchEntry.h"
 
+#include <array>
 #include <bitset>
 #include <cstring>
 #include <iomanip>
@@ -192,14 +193,14 @@ u32 MemWatchEntry::getAddressForPointerLevel(const int level) const
     return 0;
 
   u32 address = m_consoleAddress;
-  char addressBuffer[sizeof(u32)] = {0};
+  std::array<char, sizeof(u32)> addressBuffer{};
   for (int i = 0; i < level; ++i)
   {
     if (DolphinComm::DolphinAccessor::readFromRAM(
             Common::dolphinAddrToOffset(address, DolphinComm::DolphinAccessor::isARAMAccessible()),
-            addressBuffer, sizeof(u32), true))
+            addressBuffer.data(), sizeof(u32), true))
     {
-      std::memcpy(&address, addressBuffer, sizeof(u32));
+      std::memcpy(&address, addressBuffer.data(), sizeof(u32));
       if (DolphinComm::DolphinAccessor::isValidConsoleAddress(address))
         address += m_pointerOffsets.at(i);
       else
@@ -231,15 +232,15 @@ Common::MemOperationReturnCode MemWatchEntry::readMemoryFromRAM()
   u32 realConsoleAddress = m_consoleAddress;
   if (m_boundToPointer)
   {
-    char realConsoleAddressBuffer[sizeof(u32)] = {0};
+    std::array<char, sizeof(u32)> realConsoleAddressBuffer{};
     for (int offset : m_pointerOffsets)
     {
       if (DolphinComm::DolphinAccessor::readFromRAM(
               Common::dolphinAddrToOffset(realConsoleAddress,
                                           DolphinComm::DolphinAccessor::isARAMAccessible()),
-              realConsoleAddressBuffer, sizeof(u32), true))
+              realConsoleAddressBuffer.data(), sizeof(u32), true))
       {
-        std::memcpy(&realConsoleAddress, realConsoleAddressBuffer, sizeof(u32));
+        std::memcpy(&realConsoleAddress, realConsoleAddressBuffer.data(), sizeof(u32));
         if (DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
         {
           realConsoleAddress += offset;
@@ -276,15 +277,15 @@ Common::MemOperationReturnCode MemWatchEntry::writeMemoryToRAM(const char* memor
   u32 realConsoleAddress = m_consoleAddress;
   if (m_boundToPointer)
   {
-    char realConsoleAddressBuffer[sizeof(u32)] = {0};
+    std::array<char, sizeof(u32)> realConsoleAddressBuffer{};
     for (int offset : m_pointerOffsets)
     {
       if (DolphinComm::DolphinAccessor::readFromRAM(
               Common::dolphinAddrToOffset(realConsoleAddress,
                                           DolphinComm::DolphinAccessor::isARAMAccessible()),
-              realConsoleAddressBuffer, sizeof(u32), true))
+              realConsoleAddressBuffer.data(), sizeof(u32), true))
       {
-        std::memcpy(&realConsoleAddress, realConsoleAddressBuffer, sizeof(u32));
+        std::memcpy(&realConsoleAddress, realConsoleAddressBuffer.data(), sizeof(u32));
         if (DolphinComm::DolphinAccessor::isValidConsoleAddress(realConsoleAddress))
         {
           realConsoleAddress += offset;

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -18,6 +18,11 @@ public:
   explicit MemWatchEntry(MemWatchEntry* entry);
   ~MemWatchEntry();
 
+  MemWatchEntry(const MemWatchEntry&) = delete;
+  MemWatchEntry(MemWatchEntry&&) = delete;
+  MemWatchEntry& operator=(const MemWatchEntry&) = delete;
+  MemWatchEntry& operator=(MemWatchEntry&&) = delete;
+
   QString getLabel() const;
   Common::MemType getType() const;
   u32 getConsoleAddress() const;

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -32,31 +32,31 @@ public:
   size_t getLength() const;
   char* getMemory() const;
   bool isUnsigned() const;
-  int getPointerOffset(const int index) const;
+  int getPointerOffset(int index) const;
   std::vector<int> getPointerOffsets() const;
   size_t getPointerLevel() const;
   void setLabel(const QString& label);
-  void setConsoleAddress(const u32 address);
-  void setTypeAndLength(const Common::MemType type, const size_t length = 1);
-  void setBase(const Common::MemBase base);
-  void setLock(const bool doLock);
-  void setSignedUnsigned(const bool isUnsigned);
-  void setBoundToPointer(const bool boundToPointer);
-  void setPointerOffset(const int pointerOffset, const int index);
-  void addOffset(const int offset);
+  void setConsoleAddress(u32 address);
+  void setTypeAndLength(Common::MemType type, size_t length = 1);
+  void setBase(Common::MemBase base);
+  void setLock(bool doLock);
+  void setSignedUnsigned(bool isUnsigned);
+  void setBoundToPointer(bool boundToPointer);
+  void setPointerOffset(int pointerOffset, int index);
+  void addOffset(int offset);
   void removeOffset();
 
   Common::MemOperationReturnCode freeze();
 
-  u32 getAddressForPointerLevel(const int level) const;
-  std::string getAddressStringForPointerLevel(const int level) const;
+  u32 getAddressForPointerLevel(int level) const;
+  std::string getAddressStringForPointerLevel(int level) const;
   Common::MemOperationReturnCode readMemoryFromRAM();
 
   std::string getStringFromMemory() const;
   Common::MemOperationReturnCode writeMemoryFromString(const std::string& inputString);
 
 private:
-  Common::MemOperationReturnCode writeMemoryToRAM(const char* memory, const size_t size);
+  Common::MemOperationReturnCode writeMemoryToRAM(const char* memory, size_t size);
 
   QString m_label;
   u32 m_consoleAddress;

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -13,16 +13,6 @@ MemWatchTreeNode::MemWatchTreeNode(MemWatchEntry* const entry, MemWatchTreeNode*
 {
 }
 
-MemWatchTreeNode::MemWatchTreeNode(const MemWatchTreeNode& node)
-{
-  m_isGroup = node.m_isGroup;
-  m_isValueEditing = node.m_isValueEditing;
-  m_groupName = node.m_groupName;
-  m_entry = node.m_entry;
-  m_children = node.m_children;
-  m_parent = node.m_parent;
-}
-
 MemWatchTreeNode::~MemWatchTreeNode()
 {
   if (hasChildren())
@@ -90,6 +80,11 @@ void MemWatchTreeNode::setChildren(QVector<MemWatchTreeNode*> children)
 MemWatchTreeNode* MemWatchTreeNode::getParent() const
 {
   return m_parent;
+}
+
+void MemWatchTreeNode::setParent(MemWatchTreeNode* const parent)
+{
+  m_parent = parent;
 }
 
 int MemWatchTreeNode::getRow() const

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -11,8 +11,12 @@ class MemWatchTreeNode
 public:
   explicit MemWatchTreeNode(MemWatchEntry* entry, MemWatchTreeNode* parent = nullptr,
                             bool isGroup = false, QString groupName = {});
-  MemWatchTreeNode(const MemWatchTreeNode& node);
   ~MemWatchTreeNode();
+
+  MemWatchTreeNode(const MemWatchTreeNode&) = delete;
+  MemWatchTreeNode(MemWatchTreeNode&&) = delete;
+  MemWatchTreeNode& operator=(const MemWatchTreeNode&) = delete;
+  MemWatchTreeNode& operator=(MemWatchTreeNode&&) = delete;
 
   bool isGroup() const;
   QString getGroupName() const;
@@ -22,6 +26,7 @@ public:
   QVector<MemWatchTreeNode*> getChildren() const;
   void setChildren(QVector<MemWatchTreeNode*> children);
   MemWatchTreeNode* getParent() const;
+  void setParent(MemWatchTreeNode* parent);
   int getRow() const;
   bool isValueEditing() const;
   bool hasChildren() const;

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -31,11 +31,11 @@ public:
   bool isValueEditing() const;
   bool hasChildren() const;
   int childrenCount() const;
-  void setValueEditing(const bool valueEditing);
+  void setValueEditing(bool valueEditing);
 
   void appendChild(MemWatchTreeNode* node);
-  void insertChild(const int row, MemWatchTreeNode* node);
-  void removeChild(const int row);
+  void insertChild(int row, MemWatchTreeNode* node);
+  void removeChild(int row);
   void clearAllChild();
 
   void readFromJson(const QJsonObject& json, MemWatchTreeNode* parent = nullptr);


### PR DESCRIPTION
Follows #125 and #132.

These are the last warnings that Clang-Tidy (v18) reports.

A number of warning types have been suppressed, as they are not totally helpful and addressing them may leave the code in a more error-prone state.

At this time, no linting/checking has been added in the form of a GitHub Action. After some more local testing by devs, automatic linting/checking could be added; perhaps only to touched files, as Clang-Tidy can be slow.