### PR TITLE
Revised watch list item insertion.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -454,8 +454,7 @@ QMimeData* MemWatchModel::mimeData(const QModelIndexList& indexes) const
       nodes << node;
   }
   MemWatchTreeNode* leastDeepNode = getLeastDeepNodeFromList(nodes);
-  const qulonglong leastDeepPointer{
-      Common::bit_cast<qulonglong, MemWatchTreeNode*>(leastDeepNode)};
+  const qulonglong leastDeepPointer{Common::bit_cast<qulonglong, MemWatchTreeNode*>(leastDeepNode)};
   stream << leastDeepPointer;
   stream << static_cast<int>(nodes.count());
   foreach (MemWatchTreeNode* node, nodes)
@@ -661,8 +660,9 @@ void MemWatchModel::loadRootFromJsonRecursive(const QJsonObject& json)
   emit layoutChanged();
 }
 
-MemWatchModel::CTParsingErrors
-MemWatchModel::importRootFromCTFile(QFile* const CTFile, const bool useDolphinPointer, const u32 CEStart)
+MemWatchModel::CTParsingErrors MemWatchModel::importRootFromCTFile(QFile* const CTFile,
+                                                                   const bool useDolphinPointer,
+                                                                   const u32 CEStart)
 {
   CheatEngineParser parser = CheatEngineParser();
   parser.setTableStartAddress(CEStart);

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <QAbstractItemModel>
 #include <QFile>
 #include <QJsonObject>
@@ -54,8 +56,9 @@ public:
 
   void changeType(const QModelIndex& index, Common::MemType type, size_t length);
   static MemWatchEntry* getEntryFromIndex(const QModelIndex& index);
-  void addGroup(const QString& name);
-  void addEntry(MemWatchEntry* entry);
+  void addNodes(const std::vector<MemWatchTreeNode*>& nodes, const QModelIndex& referenceIndex = QModelIndex{});
+  void addGroup(const QString& name, const QModelIndex& referenceIndex = QModelIndex{});
+  void addEntry(MemWatchEntry* entry, const QModelIndex& referenceIndex = QModelIndex{});
   void editEntry(MemWatchEntry* entry, const QModelIndex& index);
   void sortRecursive(int column, Qt::SortOrder order, MemWatchTreeNode* parent);
   void clearRoot();

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -87,9 +87,8 @@ void MemWatchWidget::initialiseWidgets()
   QShortcut* pasteWatchShortcut =
       new QShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key::Key_V), m_watchView);
   connect(pasteWatchShortcut, &QShortcut::activated, this, [this] {
-    pasteWatchFromClipBoard(
-        MemWatchModel::getTreeNodeFromIndex(m_watchView->selectionModel()->currentIndex()),
-        m_watchView->selectionModel()->currentIndex().row() + 1);
+    const QModelIndexList selectedIndexes{m_watchView->selectionModel()->selectedIndexes()};
+    pasteWatchFromClipBoard(selectedIndexes.empty() ? QModelIndex{} : selectedIndexes.back());
   });
 
   m_btnAddGroup = new QPushButton(tr("Add group"), this);
@@ -256,9 +255,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   contextMenu->addAction(copy);
 
   QAction* paste = new QAction(tr("&Paste"), this);
-  connect(paste, &QAction::triggered, this, [this, node] {
-    pasteWatchFromClipBoard(node, m_watchView->selectionModel()->currentIndex().row() + 1);
-  });
+  connect(paste, &QAction::triggered, this, [this, index] { pasteWatchFromClipBoard(index); });
   contextMenu->addAction(paste);
 
   contextMenu->addSeparator();
@@ -346,35 +343,22 @@ void MemWatchWidget::copySelectedWatchesToClipBoard()
   clipboard->setText(nodeJsonStr);
 }
 
-void MemWatchWidget::pasteWatchFromClipBoard(MemWatchTreeNode* node, int row)
+void MemWatchWidget::pasteWatchFromClipBoard(const QModelIndex& referenceIndex)
 {
-  QClipboard* clipboard = QApplication::clipboard();
-  QString nodeStr = clipboard->text();
-
-  QJsonDocument loadDoc(QJsonDocument::fromJson(nodeStr.toUtf8()));
-  MemWatchTreeNode* copiedRootNode = new MemWatchTreeNode(nullptr);
-  copiedRootNode->readFromJson(loadDoc.object(), nullptr);
-  if (copiedRootNode->hasChildren())
+  MemWatchTreeNode copiedRootNode(nullptr);
   {
-    int numberIterated = 0;
-    for (MemWatchTreeNode* const child : copiedRootNode->getChildren())
-    {
-      if (node == nullptr)
-        node = m_watchModel->getRootNode();
-      if (node->isGroup() || (node->getParent() == nullptr))
-      {
-        node->appendChild(child);
-      }
-      else
-      {
-        node->getParent()->insertChild(row + numberIterated, child);
-      }
-      numberIterated++;
-    }
-    emit m_watchModel->layoutChanged();
-
-    m_hasUnsavedChanges = true;
+    const QString nodeStr{QApplication::clipboard()->text()};
+    const QJsonDocument loadDoc{QJsonDocument::fromJson(nodeStr.toUtf8())};
+    copiedRootNode.readFromJson(loadDoc.object(), nullptr);
   }
+
+  const QVector<MemWatchTreeNode*> children{copiedRootNode.getChildren()};
+  copiedRootNode.clearAllChild();
+
+  std::vector<MemWatchTreeNode*> childrenVec(children.constBegin(), children.constEnd());
+  m_watchModel->addNodes(childrenVec, referenceIndex);
+
+  m_hasUnsavedChanges = true;
 }
 
 void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -47,6 +47,7 @@ void MemWatchWidget::initialiseWidgets()
   connect(m_watchModel, &MemWatchModel::writeFailed, this, &MemWatchWidget::onValueWriteError);
   connect(m_watchModel, &MemWatchModel::dropSucceeded, this, &MemWatchWidget::onDropSucceeded);
   connect(m_watchModel, &MemWatchModel::readFailed, this, &MemWatchWidget::mustUnhook);
+  connect(m_watchModel, &MemWatchModel::rowsInserted, this, &MemWatchWidget::onRowsInserted);
 
   m_watchDelegate = new MemWatchDelegate();
 
@@ -615,6 +616,19 @@ void MemWatchWidget::onDeleteSelection()
 void MemWatchWidget::onDropSucceeded()
 {
   m_hasUnsavedChanges = true;
+}
+
+void MemWatchWidget::onRowsInserted(const QModelIndex& parent, const int first, const int last)
+{
+  const QModelIndex firstIndex{m_watchModel->index(first, 0, parent)};
+  const QModelIndex lastIndex{m_watchModel->index(last, 0, parent)};
+  const QItemSelection selection{firstIndex, lastIndex};
+
+  QItemSelectionModel* const selectionModel{m_watchView->selectionModel()};
+  selectionModel->select(selection, QItemSelectionModel::ClearAndSelect);
+  selectionModel->setCurrentIndex(lastIndex, QItemSelectionModel::Current);
+
+  QTimer::singleShot(0, [this, lastIndex] { m_watchView->scrollTo(lastIndex); });
 }
 
 QTimer* MemWatchWidget::getUpdateTimer() const

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -506,7 +506,8 @@ void MemWatchWidget::onAddGroup()
                                        "Enter the group name:", QLineEdit::Normal, "", &ok);
   if (ok && !text.isEmpty())
   {
-    m_watchModel->addGroup(text);
+    const QModelIndexList selectedIndexes{m_watchView->selectionModel()->selectedIndexes()};
+    m_watchModel->addGroup(text, selectedIndexes.empty() ? QModelIndex{} : selectedIndexes.back());
     m_hasUnsavedChanges = true;
   }
 }
@@ -520,7 +521,8 @@ void MemWatchWidget::onAddWatchEntry()
 
 void MemWatchWidget::addWatchEntry(MemWatchEntry* entry)
 {
-  m_watchModel->addEntry(entry);
+  const QModelIndexList selectedIndexes{m_watchView->selectionModel()->selectedIndexes()};
+  m_watchModel->addEntry(entry, selectedIndexes.empty() ? QModelIndex{} : selectedIndexes.back());
   m_hasUnsavedChanges = true;
 }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -30,6 +30,7 @@ public:
   void onLockSelection(bool lockStatus);
   void onDeleteSelection();
   void onDropSucceeded();
+  void onRowsInserted(const QModelIndex& parent, int first, int last);
   void openWatchFile();
   void setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBase base);
   void copySelectedWatchesToClipBoard();

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -35,7 +35,7 @@ public:
   void setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBase base);
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
-  void pasteWatchFromClipBoard(MemWatchTreeNode* node, int row);
+  void pasteWatchFromClipBoard(const QModelIndex& referenceIndex);
   void saveWatchFile();
   void saveAsWatchFile();
   void clearWatchList();


### PR DESCRIPTION
- Groups and watch items are now inserted below (or inside) the currently selected item.
- Newly added items are automatically selected. If nested in a group, they are automatically expanded.
- Paste action reuses the newly added functionality.

Fixes #129.