### PR TITLE
Use splitter's section size to determine whether scanner pane is visible.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -86,7 +86,7 @@ void MainWindow::makeMenus()
   m_actScanner->setCheckable(true);
   QTimer::singleShot(0, [this]() {
     QSignalBlocker signalBlocker(m_actScanner);
-    m_actScanner->setChecked(m_scanner->isVisible());
+    m_actScanner->setChecked(m_splitter->sizes()[0] > 0);
   });
 
   m_actQuit = new QAction(tr("&Quit"), this);


### PR DESCRIPTION
This was a regression in e8ea2b3486973, where the visibility predicate was changed to something more readable. As it turned out, the visibility of the widget does not indicate whether it is visible: the splitter may be collapsed.

The predicate has now been reverted to what it was previously.

Test plan:

- Launch DME.
- Collapse the scanner pane.
- Exit DME.
- Launch DME.

Without this change, the **View > Scanner** would be checked, even though the pane is collapsed.