### PR TITLE
Avoid prematurely freeing buffer during value editing on Linux.

### DIFF
--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -273,9 +273,10 @@ bool LinuxDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const
       break;
     }
   }
-  delete[] bufferCopy;
 
   const ssize_t nwrote{process_vm_writev(m_PID, &local, 1, &remote, 1, 0)};
+  delete[] bufferCopy;
+
   if (nwrote == -1)
   {
     // A more specific error type should be available in `errno` (if ever interested).

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -4,7 +4,6 @@
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
 
-#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
@@ -204,7 +203,6 @@ bool LinuxDolphinProcess::readFromRAM(const u32 offset, char* buffer, const size
       break;
     }
     default:
-      assert(0 && "Unexpected type size");
       break;
     }
   }
@@ -272,7 +270,6 @@ bool LinuxDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const
       break;
     }
     default:
-      assert(0 && "Unexpected type size");
       break;
     }
   }

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -4,7 +4,6 @@
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
 
-#include <cassert>
 #include <cstdlib>
 #include <mach/mach_vm.h>
 #include <memory>
@@ -171,7 +170,6 @@ bool MacDolphinProcess::readFromRAM(const u32 offset, char* buffer, size_t size,
       break;
     }
     default:
-      assert(0 && "Unexpected type size");
       break;
     }
   }
@@ -231,7 +229,6 @@ bool MacDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const s
       break;
     }
     default:
-      assert(0 && "Unexpected type size");
       break;
     }
   }

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -8,7 +8,6 @@
 #ifdef UNICODE
 #include <codecvt>
 #endif
-#include <cassert>
 #include <cstdlib>
 #include <string>
 #include <tlhelp32.h>
@@ -207,7 +206,6 @@ bool WindowsDolphinProcess::readFromRAM(const u32 offset, char* buffer, const si
         break;
       }
       default:
-        assert(0 && "Unexpected type size");
         break;
       }
     }
@@ -268,7 +266,6 @@ bool WindowsDolphinProcess::writeToRAM(const u32 offset, const char* buffer, con
       break;
     }
     default:
-      assert(0 && "Unexpected type size");
       break;
     }
   }

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <cmath>
 #include <cstring>
 #include <stack>


### PR DESCRIPTION
This was a regression in d58cd7687e272a576e49c, where the deletion of the `bufferCopy` buffer was moved to an earlier point. It was overlooked that the buffer is referenced by the `local` structure that used in the `process_vm_writev()` call.

The symptoms were garbage being written into Dolphin's memory when the user would edit a value in a watch node (e.g. user enters `7` in a integer, but `251` was written).

Bonus: Some wrong assertions (a regression too, in e9c0e22ed31) have been removed.