### PR TITLE
Avoid memory leaks in `MemWatchModel::clearRoot()`.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -181,8 +181,9 @@ void MemWatchModel::editEntry(MemWatchEntry* entry, const QModelIndex& index)
 
 void MemWatchModel::clearRoot()
 {
-  m_rootNode->removeChildren();
-  emit layoutChanged();
+  beginResetModel();
+  m_rootNode->deleteChildren();
+  endResetModel();
 }
 
 void MemWatchModel::removeNode(const QModelIndex& index)

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -181,7 +181,7 @@ void MemWatchModel::editEntry(MemWatchEntry* entry, const QModelIndex& index)
 
 void MemWatchModel::clearRoot()
 {
-  m_rootNode->clearAllChild();
+  m_rootNode->removeChildren();
   emit layoutChanged();
 }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -328,8 +328,8 @@ void MemWatchWidget::copySelectedWatchesToClipBoard()
     }
     rootNodeCopy.writeToJson(jsonNode);
 
-    // Clear borrowed children before going out of scope.
-    rootNodeCopy.clearAllChild();
+    // Remove borrowed children before going out of scope.
+    rootNodeCopy.removeChildren();
     for (auto& [childNode, parentNode] : parentMap)
     {
       childNode->setParent(parentNode);
@@ -353,7 +353,7 @@ void MemWatchWidget::pasteWatchFromClipBoard(const QModelIndex& referenceIndex)
   }
 
   const QVector<MemWatchTreeNode*> children{copiedRootNode.getChildren()};
-  copiedRootNode.clearAllChild();
+  copiedRootNode.removeChildren();
 
   std::vector<MemWatchTreeNode*> childrenVec(children.constBegin(), children.constEnd());
   m_watchModel->addNodes(childrenVec, referenceIndex);

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -15,10 +15,10 @@ MemWatchTreeNode::MemWatchTreeNode(MemWatchEntry* const entry, MemWatchTreeNode*
 
 MemWatchTreeNode::~MemWatchTreeNode()
 {
-  if (hasChildren())
-    qDeleteAll(m_children);
+  deleteChildren();
   m_parent = nullptr;
   delete m_entry;
+  m_entry = nullptr;
 }
 
 bool MemWatchTreeNode::isGroup() const
@@ -114,6 +114,12 @@ void MemWatchTreeNode::removeChild(const int row)
 
 void MemWatchTreeNode::removeChildren()
 {
+  m_children.clear();
+}
+
+void MemWatchTreeNode::deleteChildren()
+{
+  qDeleteAll(m_children);
   m_children.clear();
 }
 

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -112,7 +112,7 @@ void MemWatchTreeNode::removeChild(const int row)
   m_children.remove(row);
 }
 
-void MemWatchTreeNode::clearAllChild()
+void MemWatchTreeNode::removeChildren()
 {
   m_children.clear();
 }

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -37,6 +37,7 @@ public:
   void insertChild(int row, MemWatchTreeNode* node);
   void removeChild(int row);
   void removeChildren();
+  void deleteChildren();
 
   void readFromJson(const QJsonObject& json, MemWatchTreeNode* parent = nullptr);
   void writeToJson(QJsonObject& json) const;

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -36,7 +36,7 @@ public:
   void appendChild(MemWatchTreeNode* node);
   void insertChild(int row, MemWatchTreeNode* node);
   void removeChild(int row);
-  void clearAllChild();
+  void removeChildren();
 
   void readFromJson(const QJsonObject& json, MemWatchTreeNode* parent = nullptr);
   void writeToJson(QJsonObject& json) const;


### PR DESCRIPTION
- `MemWatchModel::clearAllChild()` has been renamed to `MemWatchModel::removeChildren()`.
- `MemWatchModel::deleteChildren()` has been added. Unlike `removeChildren()`, this new method does free the memory of the removed children.
- The new method is now used in `MemWatchModel::clearRoot()`, which would previously only remove children but without deleting them.