### PR TITLE
Memory leak and more specific model invalidation.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -702,7 +702,10 @@ MemWatchModel::CTParsingErrors MemWatchModel::importRootFromCTFile(QFile* const 
   parser.setTableStartAddress(CEStart);
   MemWatchTreeNode* importedRoot = parser.parseCTFile(CTFile, useDolphinPointer);
   if (importedRoot != nullptr)
+  {
+    delete m_rootNode;
     m_rootNode = importedRoot;
+  }
 
   CTParsingErrors parsingErrors;
   parsingErrors.errorStr = parser.getErrorMessages();


### PR DESCRIPTION
A memory leak in `MemWatchModel::importRootFromCTFile()` has been fixed, and specific `dataChanged()`, or `beginModelReset()`/`endModelReset()`calls are now used where appropriate.