### PR TITLE
Treat failed save actions as cancel actions.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -672,7 +672,7 @@ void MemWatchWidget::openWatchFile()
   }
 }
 
-void MemWatchWidget::saveWatchFile()
+bool MemWatchWidget::saveWatchFile()
 {
   if (QFile::exists(m_watchListFile))
   {
@@ -684,7 +684,7 @@ void MemWatchWidget::saveWatchFile()
           "An error occured while creating and opening the watch list file for writting",
           QMessageBox::Ok, this);
       errorBox->exec();
-      return;
+      return false;
     }
     QJsonObject root;
     m_watchModel->writeRootToJsonRecursive(root);
@@ -692,14 +692,12 @@ void MemWatchWidget::saveWatchFile()
     watchFile.write(saveDoc.toJson());
     watchFile.close();
     m_hasUnsavedChanges = false;
+    return true;
   }
-  else
-  {
-    saveAsWatchFile();
-  }
+  return saveAsWatchFile();
 }
 
-void MemWatchWidget::saveAsWatchFile()
+bool MemWatchWidget::saveAsWatchFile()
 {
   QString fileName = QFileDialog::getSaveFileName(this, "Save watch list", m_watchListFile,
                                                   "Dolphin memory watches file (*.dmw)");
@@ -715,7 +713,7 @@ void MemWatchWidget::saveAsWatchFile()
           "An error occured while creating and opening the watch list file for writting",
           QMessageBox::Ok, this);
       errorBox->exec();
-      return;
+      return false;
     }
     QJsonObject root;
     m_watchModel->writeRootToJsonRecursive(root);
@@ -724,7 +722,9 @@ void MemWatchWidget::saveAsWatchFile()
     watchFile.close();
     m_watchListFile = fileName;
     m_hasUnsavedChanges = false;
+    return true;
   }
+  return false;
 }
 
 void MemWatchWidget::clearWatchList()
@@ -844,8 +844,7 @@ bool MemWatchWidget::warnIfUnsavedChanges()
     case QMessageBox::No:
       return true;
     case QMessageBox::Yes:
-      saveWatchFile();
-      return true;
+      return saveWatchFile();
     default:
       return false;
     }

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -36,8 +36,8 @@ public:
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
   void pasteWatchFromClipBoard(const QModelIndex& referenceIndex);
-  void saveWatchFile();
-  void saveAsWatchFile();
+  bool saveWatchFile();
+  bool saveAsWatchFile();
   void clearWatchList();
   void importFromCTFile();
   void exportWatchListAsCSV();


### PR DESCRIPTION
Previously, if the user exited the file browser dialog without saving the file (voluntarily, or due to I/O error), DME would still exit (or wipe out the watch model; depending on the case), causing unrecoverable data loss.

Test plan:
- Launch DME.
- Add a few watch entries to mark the model with unsaved changes.
- Clear the watch list via the **File > Clear the watch list** action.
- A confirmation dialog with the **Cancel**, **No**, and **Yes** options should appear.
- Click **Yes**
- Once the file browser dialog opens, close it without selecting a file (or choose a filepath where the user does not have write permissions).

Previous behavior: The watch list was wrongly cleared, without the user having saved it.

New behavior: The user gets back to DME, as if **Cancel** had been selected in the confirmation dialog.