### PR TITLE
Prompt user before destructive operations of great impact.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -186,7 +186,7 @@ void MemWatchModel::clearRoot()
   endResetModel();
 }
 
-void MemWatchModel::removeNode(const QModelIndex& index)
+void MemWatchModel::deleteNode(const QModelIndex& index)
 {
   if (index.isValid())
   {

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -55,7 +55,8 @@ public:
 
   void changeType(const QModelIndex& index, Common::MemType type, size_t length);
   static MemWatchEntry* getEntryFromIndex(const QModelIndex& index);
-  void addNodes(const std::vector<MemWatchTreeNode*>& nodes, const QModelIndex& referenceIndex = QModelIndex{});
+  void addNodes(const std::vector<MemWatchTreeNode*>& nodes,
+                const QModelIndex& referenceIndex = QModelIndex{});
   void addGroup(const QString& name, const QModelIndex& referenceIndex = QModelIndex{});
   void addEntry(MemWatchEntry* entry, const QModelIndex& referenceIndex = QModelIndex{});
   void editEntry(MemWatchEntry* entry, const QModelIndex& index);

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -60,7 +60,7 @@ public:
   void addEntry(MemWatchEntry* entry, const QModelIndex& referenceIndex = QModelIndex{});
   void editEntry(MemWatchEntry* entry, const QModelIndex& index);
   void clearRoot();
-  void removeNode(const QModelIndex& index);
+  void deleteNode(const QModelIndex& index);
   void onUpdateTimer();
   void onFreezeTimer();
   void loadRootFromJsonRecursive(const QJsonObject& json);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -732,7 +732,11 @@ void MemWatchWidget::clearWatchList()
   if (!m_watchModel->hasAnyNodes())
     return;
 
-  if (!warnIfUnsavedChanges())
+  const QString msg{tr("Are you sure you want to delete these watches and/or groups?")};
+  QMessageBox box(QMessageBox::Question, tr("Clear watch list confirmation"), msg,
+                  QMessageBox::Yes | QMessageBox::Cancel, this);
+  box.setDefaultButton(QMessageBox::Yes);
+  if (box.exec() != QMessageBox::Yes)
     return;
 
   m_watchModel->clearRoot();

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -301,7 +301,9 @@ void MemWatchWidget::cutSelectedWatchesToClipBoard()
   if (!cutList.empty())
   {
     for (const auto& index : cutList)
-      m_watchModel->removeNode(index);
+    {
+      m_watchModel->deleteNode(index);
+    }
 
     m_hasUnsavedChanges = true;
   }
@@ -592,7 +594,7 @@ void MemWatchWidget::onDeleteSelection()
     const QModelIndexList toDeleteList{simplifySelection()};
     for (const auto& index : toDeleteList)
     {
-      m_watchModel->removeNode(index);
+      m_watchModel->deleteNode(index);
     }
 
     m_hasUnsavedChanges = true;

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -585,7 +585,7 @@ void MemWatchWidget::onDeleteSelection()
 
   QMessageBox* confirmationBox =
       new QMessageBox(QMessageBox::Question, QString("Deleting confirmation"), confirmationMsg,
-                      QMessageBox::Yes | QMessageBox::No, this);
+                      QMessageBox::Yes | QMessageBox::Cancel, this);
   confirmationBox->setDefaultButton(QMessageBox::Yes);
   if (confirmationBox->exec() == QMessageBox::Yes)
   {


### PR DESCRIPTION
The **Clear the watch list** action did not always show a confirmation dialog, only when there were unsaved changes, which overlooked the case where the watch list is only backed up by the data stored in the settings file.