### PR TITLE
Attempt to make the directories before trying to lock the lockfile.

### DIFF
--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -4,7 +4,9 @@
 #include <iostream>
 
 #include <qcoreapplication.h>
+#include <QDir>
 #include <qfile.h>
+#include <QFileInfo>
 
 namespace
 {
@@ -32,6 +34,7 @@ SConfig::SConfig()
   }
 
   const QString lockFilepath{m_settings->fileName() + "_lock"};
+  QDir().mkpath(QFileInfo{lockFilepath}.absolutePath());
   m_lockFile = std::make_unique<QLockFile>(lockFilepath);
   if (!m_lockFile->tryLock())
   {


### PR DESCRIPTION
In a fresh installation where the `.ini` file does not yet exist, the application could wrongly determine that another instance was running as the lockfile could not be created due to the missing parent directory.

All the intermediate-level directories needed to contain the lockfile are now created if they did not exist.