### PR TITLE
Bouquet of GUI fixes and improvements.

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -283,7 +283,6 @@ void MainWindow::updateDolphinHookingStatus()
         tr("Hooked successfully to Dolphin, current start address: ") +
         QString::number(DolphinComm::DolphinAccessor::getEmuRAMAddressStart(), 16).toUpper());
     m_scanner->setEnabled(true);
-    m_watcher->setEnabled(true);
     m_copier->setEnabled(true);
     m_actMemoryViewer->setEnabled(true);
     m_actCopyMemory->setEnabled(true);
@@ -295,7 +294,6 @@ void MainWindow::updateDolphinHookingStatus()
   {
     m_lblDolphinStatus->setText(tr("Cannot hook to Dolphin, the process is not running"));
     m_scanner->setDisabled(true);
-    m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
     m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);
@@ -308,7 +306,6 @@ void MainWindow::updateDolphinHookingStatus()
     m_lblDolphinStatus->setText(
         tr("Cannot hook to Dolphin, the process is running, but no emulation has been started"));
     m_scanner->setDisabled(true);
-    m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
     m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);
@@ -320,7 +317,6 @@ void MainWindow::updateDolphinHookingStatus()
   {
     m_lblDolphinStatus->setText(tr("Unhooked, press \"Hook\" to hook to Dolphin again"));
     m_scanner->setDisabled(true);
-    m_watcher->setDisabled(true);
     m_copier->setDisabled(true);
     m_actMemoryViewer->setDisabled(true);
     m_actCopyMemory->setDisabled(true);

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -201,6 +201,7 @@ void MainWindow::makeLayouts()
 void MainWindow::makeMemViewer()
 {
   m_viewer = new MemViewerWidget(nullptr);
+  m_viewer->setWindowIcon(windowIcon());
   connect(m_viewer, &MemViewerWidget::mustUnhook, this, &MainWindow::onUnhook);
   connect(m_viewer, &MemViewerWidget::addWatchRequested, m_watcher, &MemWatchWidget::addWatchEntry);
   connect(m_watcher, &MemWatchWidget::goToAddressInViewer, this,

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -133,7 +133,7 @@ void MemScanWidget::initialiseWidgets()
   m_btnGroupScanBase->addButton(m_rdbBaseBinary, 3);
   m_rdbBaseDecimal->setChecked(true);
 
-  m_groupScanBase = new QGroupBox(tr("Base to use"));
+  m_groupScanBase = new QGroupBox({});
 
   m_chkSignedScan = new QCheckBox(tr("Signed value scan"));
   m_chkSignedScan->setChecked(false);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -35,8 +35,14 @@ void MemScanWidget::initialiseWidgets()
   m_tblResulstList->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
   m_tblResulstList->horizontalHeader()->setStretchLastSection(true);
-  m_tblResulstList->horizontalHeader()->resizeSection(ResultsListModel::RESULT_COL_ADDRESS, 125);
-  m_tblResulstList->horizontalHeader()->resizeSection(ResultsListModel::RESULT_COL_SCANNED, 150);
+
+  const int charWidth{m_tblResulstList->fontMetrics().averageCharWidth()};
+  m_tblResulstList->horizontalHeader()->setMinimumSectionSize(charWidth);
+  m_tblResulstList->horizontalHeader()->resizeSection(ResultsListModel::RESULT_COL_SCANNED,
+                                                      charWidth * 15);
+
+  m_tblResulstList->horizontalHeader()->setSectionResizeMode(ResultsListModel::RESULT_COL_ADDRESS,
+                                                             QHeaderView::ResizeToContents);
 
   m_tblResulstList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
   m_tblResulstList->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -38,6 +38,8 @@ void MemScanWidget::initialiseWidgets()
   m_tblResulstList->horizontalHeader()->resizeSection(ResultsListModel::RESULT_COL_ADDRESS, 125);
   m_tblResulstList->horizontalHeader()->resizeSection(ResultsListModel::RESULT_COL_SCANNED, 150);
 
+  m_tblResulstList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+  m_tblResulstList->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
   m_tblResulstList->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_tblResulstList->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_tblResulstList->setMinimumWidth(385);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -1,5 +1,6 @@
 #include "MemScanWidget.h"
 
+#include <QFontDatabase>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QMessageBox>
@@ -97,6 +98,12 @@ void MemScanWidget::initialiseWidgets()
   m_txbSearchRange2->setMaxLength(8);
   m_txbSearchRange2->setPlaceholderText("Search End (Optional)");
   m_txbSearchRange2->setToolTip("Search Range End (Optional)");
+
+  const QFont fixedFont{QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont)};
+  m_txbSearchTerm1->setFont(fixedFont);
+  m_txbSearchTerm2->setFont(fixedFont);
+  m_txbSearchRange1->setFont(fixedFont);
+  m_txbSearchRange2->setFont(fixedFont);
 
   m_searchTerm2Widget = new QWidget();
 

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -1,5 +1,7 @@
 #include "ResultsListModel.h"
 
+#include <QFontDatabase>
+
 ResultsListModel::ResultsListModel(QObject* parent, MemScanner* scanner)
     : QAbstractTableModel(parent), m_scanner(scanner)
 {
@@ -27,6 +29,12 @@ QVariant ResultsListModel::data(const QModelIndex& index, int role) const
 {
   if (!index.isValid())
     return {};
+
+  if (role == Qt::FontRole)
+  {
+    static const QFont s_fixedFont{QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont)};
+    return s_fixedFont;
+  }
 
   if (role == Qt::DisplayRole)
   {

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -1,6 +1,7 @@
 #include "DlgAddWatchEntry.h"
 
 #include <QDialogButtonBox>
+#include <QFontDatabase>
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QMessageBox>
@@ -43,6 +44,10 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_txbAddress = new QLineEdit(this);
   m_txbAddress->setMaxLength(10);
   connect(m_txbAddress, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onAddressChanged);
+
+  const QFont fixedFont{QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont)};
+  m_txbAddress->setFont(fixedFont);
+  m_lblValuePreview->setFont(fixedFont);
 
   m_offsetsLayout = new QGridLayout;
 

--- a/Source/GUI/MemWatcher/MemWatchDelegate.cpp
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.cpp
@@ -1,5 +1,6 @@
 #include "MemWatchDelegate.h"
 
+#include <QFontDatabase>
 #include <QLineEdit>
 
 #include "../../MemoryWatch/MemWatchTreeNode.h"
@@ -14,7 +15,10 @@ QWidget* MemWatchDelegate::createEditor(QWidget* parent, const QStyleOptionViewI
   MemWatchTreeNode* const node{MemWatchModel::getTreeNodeFromIndex(index)};
   QLineEdit* editor = new QLineEdit(parent);
   if (index.column() == MemWatchModel::WATCH_COL_VALUE && !node->isGroup())
+  {
+    editor->setFont(QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont));
     node->setValueEditing(true);
+  }
   GUICommon::g_valueEditing = true;
   return editor;
 }

--- a/Source/GUI/MemWatcher/MemWatchDelegate.cpp
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.cpp
@@ -1,7 +1,9 @@
 #include "MemWatchDelegate.h"
 
+#include <QApplication>
 #include <QFontDatabase>
 #include <QLineEdit>
+#include <QPainter>
 
 #include "../../MemoryWatch/MemWatchTreeNode.h"
 #include "../GUICommon.h"
@@ -38,4 +40,68 @@ void MemWatchDelegate::destroyEditor(QWidget* editor, const QModelIndex& index) 
     node->setValueEditing(false);
   GUICommon::g_valueEditing = false;
   editor->deleteLater();
+}
+
+void MemWatchDelegate::paint(QPainter* const painter, const QStyleOptionViewItem& option_,
+                             const QModelIndex& index) const
+{
+  QStyleOptionViewItem option = option_;
+  initStyleOption(&option, index);
+
+  const int column{index.column()};
+  if (column == MemWatchModel::WATCH_COL_LOCK)
+  {
+    MemWatchTreeNode* const node{MemWatchModel::getTreeNodeFromIndex(index)};
+    MemWatchEntry* const entry{node->getEntry()};
+    if (entry)
+    {
+      QStyleOptionButton checkboxstyle;
+      QRect checkbox_rect =
+          QApplication::style()->subElementRect(QStyle::SE_CheckBoxIndicator, &checkboxstyle);
+      checkboxstyle.rect = option.rect;
+      checkboxstyle.rect.setLeft(option.rect.x() + option.rect.width() / 2 -
+                                 checkbox_rect.width() / 2);
+
+      const bool checked{entry->isLocked()};
+      checkboxstyle.state = checked ? QStyle::State_On : QStyle::State_Off;
+      const bool enabled{static_cast<bool>(option.state & QStyle::State_Enabled)};
+      if (enabled)
+      {
+        checkboxstyle.state |= QStyle::State_Enabled;
+      }
+      checkboxstyle.palette = option.palette;
+
+      QStyledItemDelegate::paint(painter, option, index);
+      QApplication::style()->drawControl(QStyle::CE_CheckBox, &checkboxstyle, painter);
+      return;
+    }
+  }
+
+  QStyledItemDelegate::paint(painter, option, index);
+}
+
+bool MemWatchDelegate::editorEvent(QEvent* const event, QAbstractItemModel* const model,
+                                   const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  const QEvent::Type eventType{event->type()};
+
+  const int column{index.column()};
+  if (column == MemWatchModel::WATCH_COL_LOCK)
+  {
+    if (eventType == QEvent::MouseButtonDblClick)
+      return true;  // Consume event
+
+    if (eventType == QEvent::MouseButtonRelease)
+    {
+      MemWatchTreeNode* const node{MemWatchModel::getTreeNodeFromIndex(index)};
+      MemWatchEntry* const entry{node->getEntry()};
+      if (entry)
+      {
+        entry->setLock(!entry->isLocked());
+        return true;
+      }
+    }
+  }
+
+  return QStyledItemDelegate::editorEvent(event, model, option, index);
 }

--- a/Source/GUI/MemWatcher/MemWatchDelegate.h
+++ b/Source/GUI/MemWatcher/MemWatchDelegate.h
@@ -10,4 +10,8 @@ public:
   void setModelData(QWidget* editor, QAbstractItemModel* model,
                     const QModelIndex& index) const override;
   void destroyEditor(QWidget* editor, const QModelIndex& index) const override;
+  void paint(QPainter* painter, const QStyleOptionViewItem& option,
+             const QModelIndex& index) const override;
+  bool editorEvent(QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option,
+                   const QModelIndex& index) override;
 };

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -280,12 +280,6 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
         break;
       }
     }
-    else if (role == Qt::CheckStateRole && index.column() == WATCH_COL_LOCK)
-    {
-      if (entry->isLocked())
-        return Qt::Checked;
-      return Qt::Unchecked;
-    }
   }
   else
   {
@@ -349,12 +343,6 @@ bool MemWatchModel::editData(const QModelIndex& index, const QVariant& value, co
       }
       }
     }
-    else if (role == Qt::CheckStateRole && index.column() == WATCH_COL_LOCK)
-    {
-      value == Qt::Checked ? entry->setLock(true) : entry->setLock(false);
-      emit dataChanged(index, index);
-      return true;
-    }
     else
     {
       return false;
@@ -388,7 +376,7 @@ Qt::ItemFlags MemWatchModel::flags(const QModelIndex& index) const
   }
 
   if (index.column() == WATCH_COL_LOCK)
-    return flags |= Qt::ItemIsUserCheckable;
+    return flags;
 
   if (index.column() != WATCH_COL_ADDRESS && index.column() != WATCH_COL_TYPE)
     flags |= Qt::ItemIsEditable;

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1,6 +1,7 @@
 #include "MemWatchModel.h"
 
 #include <QDataStream>
+#include <QFontDatabase>
 #include <QIcon>
 #include <QMimeData>
 
@@ -233,10 +234,22 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
   if (!index.isValid())
     return {};
 
+  const int column{index.column()};
+
   MemWatchTreeNode* item = static_cast<MemWatchTreeNode*>(index.internalPointer());
 
   if (!item->isGroup())
   {
+    if (role == Qt::FontRole)
+    {
+      if (column == WATCH_COL_ADDRESS || column == WATCH_COL_VALUE)
+      {
+        static const QFont s_fixedFont{
+            QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont)};
+        return s_fixedFont;
+      }
+    }
+
     if (role == Qt::EditRole && index.column() == WATCH_COL_TYPE)
       return {static_cast<int>(item->getEntry()->getType())};
 

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -12,6 +12,7 @@
 
 #include "../../CheatEngineParser/CheatEngineParser.h"
 #include "../../Common/CommonUtils.h"
+#include "../../DolphinProcess/DolphinAccessor.h"
 #include "../GUICommon.h"
 
 namespace
@@ -378,8 +379,18 @@ Qt::ItemFlags MemWatchModel::flags(const QModelIndex& index) const
   if (index.column() == WATCH_COL_LOCK)
     return flags;
 
-  if (index.column() != WATCH_COL_ADDRESS && index.column() != WATCH_COL_TYPE)
+  if (index.column() == WATCH_COL_LABEL)
+  {
     flags |= Qt::ItemIsEditable;
+  }
+  else if (index.column() == WATCH_COL_VALUE)
+  {
+    const bool hooked{DolphinComm::DolphinAccessor::getStatus() ==
+                      DolphinComm::DolphinAccessor::DolphinStatus::hooked};
+    const Qt::ItemFlag itemIsEditable{hooked ? Qt::ItemIsEditable : Qt::NoItemFlags};
+    flags |= itemIsEditable;
+  }
+
   return flags;
 }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -618,7 +618,8 @@ void MemWatchWidget::onRowsInserted(const QModelIndex& parent, const int first, 
 {
   const QModelIndex firstIndex{m_watchModel->index(first, 0, parent)};
   const QModelIndex lastIndex{m_watchModel->index(last, 0, parent)};
-  const QItemSelection selection{firstIndex, lastIndex};
+  const QItemSelection selection{firstIndex,
+                                 lastIndex.siblingAtColumn(MemWatchModel::WATCH_COL_NUM - 1)};
 
   QItemSelectionModel* const selectionModel{m_watchView->selectionModel()};
   selectionModel->select(selection, QItemSelectionModel::ClearAndSelect);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -68,10 +68,16 @@ void MemWatchWidget::initialiseWidgets()
   m_watchView->setItemDelegate(m_watchDelegate);
   m_watchView->setModel(m_watchModel);
 
-  m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_LOCK, 50);
-  m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_LABEL, 225);
-  m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_TYPE, 130);
-  m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_ADDRESS, 120);
+  const int charWidth{m_watchView->fontMetrics().averageCharWidth()};
+  m_watchView->header()->setMinimumSectionSize(charWidth);
+  m_watchView->header()->resizeSection(MemWatchModel::WATCH_COL_LABEL, charWidth * 35);
+
+  m_watchView->header()->setSectionResizeMode(MemWatchModel::WATCH_COL_TYPE,
+                                              QHeaderView::ResizeToContents);
+  m_watchView->header()->setSectionResizeMode(MemWatchModel::WATCH_COL_ADDRESS,
+                                              QHeaderView::ResizeToContents);
+  m_watchView->header()->setSectionResizeMode(MemWatchModel::WATCH_COL_LOCK,
+                                              QHeaderView::ResizeToContents);
 
   QShortcut* deleteWatchShortcut = new QShortcut(QKeySequence::Delete, m_watchView);
   connect(deleteWatchShortcut, &QShortcut::activated, this, &MemWatchWidget::onDeleteSelection);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -56,6 +56,8 @@ void MemWatchWidget::initialiseWidgets()
   m_watchView->setAcceptDrops(true);
   m_watchView->setDragDropMode(QAbstractItemView::InternalMove);
   m_watchView->setDropIndicatorShown(true);
+  m_watchView->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+  m_watchView->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
   m_watchView->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_watchView->setSelectionMode(QAbstractItemView::ExtendedSelection);
   m_watchView->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -3,10 +3,10 @@
 #include <cassert>
 #include <iostream>
 
-#include <qcoreapplication.h>
 #include <QDir>
-#include <qfile.h>
 #include <QFileInfo>
+#include <qcoreapplication.h>
+#include <qfile.h>
 
 namespace
 {


### PR DESCRIPTION
A collection of small fixes and improvements:

- Enable per-pixel scrolling in table-like widgets.
- Define initial column width based on font metrics.
- Configure certain columns to fit to content (addresses and watch types).
- Show application icon in **Memory Viewer** dialog.
- Use system's fixed-width font for address and value columns.
- Center check boxes in **Lock** column.
- Keep watcher widget enabled at all times, even when not hooked to Dolphin [^1].
  - Value editing is now disallowed when not hooked to Dolphin.
- Drop label for the scan base group box.
- Select entire row when auto-selecting newly inserted rows.

[^1]: Even though the widget and the buttons are enabled, there are certain operations such as adding watch entries or editing addresses that will not work: DME currently attempts to verify memory addresses before accepting the address, which will fail if not hooked. This will be addressed in a separate work item.