### PR TITLE
Add **Group** context menu action to group currently selected entries.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -62,6 +62,7 @@ public:
   void editEntry(MemWatchEntry* entry, const QModelIndex& index);
   void clearRoot();
   void deleteNode(const QModelIndex& index);
+  void groupSelection(const QModelIndexList& indexes);
   void onUpdateTimer();
   void onFreezeTimer();
   void loadRootFromJsonRecursive(const QJsonObject& json);
@@ -71,6 +72,7 @@ public:
   bool hasAnyNodes() const;
   MemWatchTreeNode* getRootNode() const;
   static MemWatchTreeNode* getTreeNodeFromIndex(const QModelIndex& index);
+  QModelIndex getIndexFromTreeNode(const MemWatchTreeNode* node);
   bool editData(const QModelIndex& index, const QVariant& value, int role, bool emitEdit = false);
 
 signals:

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -247,6 +247,15 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     node = m_watchModel->getRootNode();
   }
 
+  const QModelIndexList simplifiedSelection{simplifySelection()};
+  if (!simplifiedSelection.empty())
+  {
+    QAction* const groupAction{new QAction(tr("&Group"), this)};
+    connect(groupAction, &QAction::triggered, this, &MemWatchWidget::groupCurrentSelection);
+    contextMenu->addAction(groupAction);
+    contextMenu->addSeparator();
+  }
+
   QAction* cut = new QAction(tr("Cu&t"), this);
   connect(cut, &QAction::triggered, this, [this] { cutSelectedWatchesToClipBoard(); });
   contextMenu->addAction(cut);
@@ -291,6 +300,11 @@ void MemWatchWidget::setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBas
     }
   }
   m_hasUnsavedChanges = true;
+}
+
+void MemWatchWidget::groupCurrentSelection()
+{
+  m_watchModel->groupSelection(simplifySelection());
 }
 
 void MemWatchWidget::cutSelectedWatchesToClipBoard()

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -33,6 +33,7 @@ public:
   void onRowsInserted(const QModelIndex& parent, int first, int last);
   void openWatchFile();
   void setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBase base);
+  void groupCurrentSelection();
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
   void pasteWatchFromClipBoard(const QModelIndex& referenceIndex);

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -109,7 +109,17 @@ void MemWatchTreeNode::insertChild(const int row, MemWatchTreeNode* node)
 
 void MemWatchTreeNode::removeChild(const int row)
 {
+  m_children[row]->m_parent = nullptr;
   m_children.remove(row);
+}
+
+void MemWatchTreeNode::removeChild(MemWatchTreeNode* const child)
+{
+  m_children.removeAll(child);
+  if (child->m_parent == this)
+  {
+    child->m_parent = nullptr;
+  }
 }
 
 void MemWatchTreeNode::removeChildren()

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -36,6 +36,7 @@ public:
   void appendChild(MemWatchTreeNode* node);
   void insertChild(int row, MemWatchTreeNode* node);
   void removeChild(int row);
+  void removeChild(MemWatchTreeNode* child);
   void removeChildren();
   void deleteChildren();
 


### PR DESCRIPTION
A new group node is added in the place of the first selected entry, and all the selected entries are moved from their current parents (which can be different parents) into the newly created group node.