### PR TITLE
Mark session with unsaved changes during grouping and inline label editing.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -368,6 +368,8 @@ bool MemWatchModel::editData(const QModelIndex& index, const QVariant& value, co
       {
         entry->setLabel(value.toString());
         emit dataChanged(index, index);
+        if (emitEdit)
+          emit dataEdited(index, value, role);
         return true;
       }
       case WATCH_COL_VALUE:

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -312,7 +312,13 @@ void MemWatchWidget::setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBas
 
 void MemWatchWidget::groupCurrentSelection()
 {
-  m_watchModel->groupSelection(simplifySelection());
+  const QModelIndexList indexes{simplifySelection()};
+  if (indexes.isEmpty())
+    return;
+
+  m_watchModel->groupSelection(indexes);
+
+  m_hasUnsavedChanges = true;
 }
 
 void MemWatchWidget::cutSelectedWatchesToClipBoard()

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -417,12 +417,18 @@ void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)
 
 void MemWatchWidget::onDataEdited(const QModelIndex& index, const QVariant& value, const int role)
 {
-  MemWatchTreeNode* const node{static_cast<MemWatchTreeNode*>(index.internalPointer())};
-  if (node->isGroup())
+  if (role != Qt::EditRole)
     return;
 
-  if (role == Qt::EditRole && index.column() == MemWatchModel::WATCH_COL_VALUE)
+  const int column{index.column()};
+  if (column == MemWatchModel::WATCH_COL_LABEL || column == MemWatchModel::WATCH_COL_TYPE ||
+      column == MemWatchModel::WATCH_COL_ADDRESS)
   {
+    m_hasUnsavedChanges = true;
+  }
+  else if (column == MemWatchModel::WATCH_COL_VALUE)
+  {
+    MemWatchTreeNode* const node{static_cast<MemWatchTreeNode*>(index.internalPointer())};
     MemWatchEntry* const entry{node->getEntry()};
     const Common::MemType entryType{entry->getType()};
 


### PR DESCRIPTION
The document was not being flagged as dirty in two cases:
- When watch node labels were edited inline in the table via double-clicking on the cell.
- When the currently selected watch nodes were grouped via the grouping functionality introduced in #152.