### PR TITLE
Add context menu to results list in scanner pane.

### DIFF
--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -37,6 +37,7 @@ public:
   void onScanMemTypeChanged();
   void onCurrentValuesUpdateTimer();
   void onResultListDoubleClicked(const QModelIndex& index);
+  void onResultsListContextMenuRequested(const QPoint& pos);
   void handleScannerErrors(Common::MemOperationReturnCode errorCode);
   void onFirstScan();
   void onNextScan();


### PR DESCRIPTION
The context menu currently includes two actions:
- **Add Watch** (same as double-clicking), added for discoverability.
- **Copy Address**, as users may occasionally want to copy the address without first having to create the watch entry.