### PR TITLE
Persistent expansion state.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -31,6 +31,8 @@ public:
   void onDeleteSelection();
   void onDropSucceeded();
   void onRowsInserted(const QModelIndex& parent, int first, int last);
+  void onCollapsed(const QModelIndex& index);
+  void onExpanded(const QModelIndex& index);
   void openWatchFile();
   void setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBase base);
   void groupCurrentSelection();
@@ -55,6 +57,7 @@ signals:
 private:
   void initialiseWidgets();
   void makeLayouts();
+  void updateExpansionState(const MemWatchTreeNode* node = nullptr);
 
   QTreeView* m_watchView{};
   MemWatchModel* m_watchModel{};

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -152,6 +152,10 @@ void MemWatchTreeNode::readFromJson(const QJsonObject& json, MemWatchTreeNode* p
   {
     m_isGroup = true;
     m_groupName = json["groupName"].toString();
+    if (json.contains("expanded"))
+    {
+      m_expanded = json["expanded"].toBool();
+    }
     QJsonArray groupEntries = json["groupEntries"].toArray();
     for (auto i : groupEntries)
     {
@@ -200,6 +204,10 @@ void MemWatchTreeNode::writeToJson(QJsonObject& json) const
   if (isGroup())
   {
     json["groupName"] = m_groupName;
+    if (m_expanded)
+    {
+      json["expanded"] = m_expanded;
+    }
     QJsonArray entries;
     for (MemWatchTreeNode* const child : m_children)
     {

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -46,7 +46,7 @@ void MemWatchTreeNode::setValueEditing(const bool valueEditing)
   m_isValueEditing = valueEditing;
 }
 
-QString MemWatchTreeNode::getGroupName() const
+const QString& MemWatchTreeNode::getGroupName() const
 {
   return m_groupName;
 }
@@ -67,7 +67,7 @@ void MemWatchTreeNode::setEntry(MemWatchEntry* entry)
   m_entry = entry;
 }
 
-QVector<MemWatchTreeNode*> MemWatchTreeNode::getChildren() const
+const QVector<MemWatchTreeNode*>& MemWatchTreeNode::getChildren() const
 {
   return m_children;
 }

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -19,6 +19,8 @@ public:
   MemWatchTreeNode& operator=(MemWatchTreeNode&&) = delete;
 
   bool isGroup() const;
+  bool isExpanded() const { return m_expanded; }
+  void setExpanded(const bool expanded) { m_expanded = expanded; };
   QString getGroupName() const;
   void setGroupName(const QString& groupName);
   MemWatchEntry* getEntry() const;
@@ -46,6 +48,7 @@ public:
 
 private:
   bool m_isGroup;
+  bool m_expanded{};
   bool m_isValueEditing = false;
   QString m_groupName;
   MemWatchEntry* m_entry;

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -21,11 +21,11 @@ public:
   bool isGroup() const;
   bool isExpanded() const { return m_expanded; }
   void setExpanded(const bool expanded) { m_expanded = expanded; };
-  QString getGroupName() const;
+  const QString& getGroupName() const;
   void setGroupName(const QString& groupName);
   MemWatchEntry* getEntry() const;
   void setEntry(MemWatchEntry* entry);
-  QVector<MemWatchTreeNode*> getChildren() const;
+  const QVector<MemWatchTreeNode*>& getChildren() const;
   void setChildren(QVector<MemWatchTreeNode*> children);
   MemWatchTreeNode* getParent() const;
   void setParent(MemWatchTreeNode* parent);


### PR DESCRIPTION
The `.dmw` file format now includes the expansion state of group nodes. When the file is loaded, the expansion state is restored. This applies to copy-pasted rows.