### PR TITLE
Use correct font in painter in **Memory Viewer** dialog.

### DIFF
--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -372,15 +372,9 @@ void MemViewer::updateFontSize(int newSize)
 {
   m_memoryFontSize = newSize;
 
-#ifdef __linux__
-  setFont(QFont("Monospace", m_memoryFontSize));
-#elif _WIN32
-  setFont(QFont("Courier New", m_memoryFontSize));
-#elif __APPLE__
   QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
   fixedFont.setPointSize(m_memoryFontSize);
   setFont(fixedFont);
-#endif
 
   m_charWidthEm = fontMetrics().horizontalAdvance(QLatin1Char('M'));
   m_charHeight = fontMetrics().height();

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -49,7 +49,7 @@ MemViewer::~MemViewer()
 
 void MemViewer::initialise()
 {
-  updateFontSize(m_memoryFontSize);
+  updateFontSize();
   m_curosrRect = new QRect();
   m_updatedRawMemoryData = new char[m_numCells];
   m_lastRawMemoryData = new char[m_numCells];
@@ -356,9 +356,14 @@ void MemViewer::wheelEvent(QWheelEvent* event)
   if (event->modifiers().testFlag(Qt::ControlModifier))
   {
     if (event->angleDelta().y() < 0 && m_memoryFontSize > 5)
-      updateFontSize(m_memoryFontSize - 1);
+    {
+      m_memoryFontSize -= 1;
+    }
     else if (event->angleDelta().y() > 0)
-      updateFontSize(m_memoryFontSize + 1);
+    {
+      m_memoryFontSize += 1;
+    }
+    updateFontSize();
 
     viewport()->update();
   }
@@ -368,9 +373,12 @@ void MemViewer::wheelEvent(QWheelEvent* event)
   }
 }
 
-void MemViewer::updateFontSize(int newSize)
+void MemViewer::updateFontSize()
 {
-  m_memoryFontSize = newSize;
+  if (m_memoryFontSize == -1)
+  {
+    m_memoryFontSize = static_cast<int>(font().pointSize() * 1.5);
+  }
 
   QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
   fixedFont.setPointSize(m_memoryFontSize);

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -1007,6 +1007,7 @@ void MemViewer::paintEvent(QPaintEvent* event)
   (void)event;
 
   QPainter painter(viewport());
+  painter.setFont(font());
   painter.setPen(QColor(Qt::black));
 
   renderSeparatorLines(painter);

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -67,7 +67,7 @@ private:
 
   void initialise();
 
-  void updateFontSize(int newSize);
+  void updateFontSize();
   bytePosFromMouse mousePosToBytePos(QPoint pos);
   void scrollToSelection();
   void copySelection(Common::MemType type) const;
@@ -93,7 +93,7 @@ private:
   const int m_numRows = 16;
   const int m_numColumns = 16;  // Should be a multiple of 16, or the header doesn't make much sense
   const int m_numCells = m_numRows * m_numColumns;
-  int m_memoryFontSize = 15;
+  int m_memoryFontSize = -1;
   int m_StartBytesSelectionPosX = 0;
   int m_StartBytesSelectionPosY = 0;
   int m_EndBytesSelectionPosX = 0;


### PR DESCRIPTION
Although the font was set up in the **Memory Viewer** dialog's main widget, the viewport's painter that actually renders the text was still using the default font.

When a theme (other than **System**) was used, this resulted in the grid and the text having a mismatched size, which was specially noticeable when the font size was made large or small:

| Before | After |
| --- | --- |
| ![DME - Memory Viewer (incorrect font size) png](https://github.com/aldelaro5/dolphin-memory-engine/assets/1853278/08e2597e-aa6a-4c6e-be5c-1fa46555b340) | ![DME - Memory Viewer (correct font size)](https://github.com/aldelaro5/dolphin-memory-engine/assets/1853278/348ee9f0-c407-4666-b040-caac62a63fb1) |

Bonus changes: initial font size is no longer hardcoded to 15; now it's based on a percentage (+50%) of the size of the default font.