### PR TITLE
Add fallback for external Qt in CMake file on Windows

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -48,7 +48,17 @@ set(SRCS ${DolphinProcessSrc}
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt6Widgets REQUIRED)
+if (WIN32)
+    find_package(Qt6Widgets QUIET)
+	  if (NOT Qt6Widgets_FOUND)
+		    message(STATUS "Qt package not found, using external lib")
+		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.5.3\\x64")
+		    find_package(Qt6Widgets REQUIRED)
+	  endif ()
+else ()
+	  find_package(Qt6Widgets REQUIRED)
+endif ()
+
 find_package(Qt6Core REQUIRED)
 find_package(Qt6Gui REQUIRED)
 if (NOT APPLE)


### PR DESCRIPTION
On a clean build using CMake on Windows without Qt6 installed, CMakeLists does not use the external library for Qt 6.5.3 provided with the source. On windows, this PR adds a quiet check for Qt6, then if it is not available it adds the external library to the prefix path list and checks again for Qt6.