### PR TITLE
Add options to copy pointer addresses (or base address) of a watch entry

### DIFF
--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -446,7 +446,7 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
     if (0 < yPos && yPos < lbl->height() && 0 < xPos && xPos < lbl->width())
     {
       QAction* copyAddr = new QAction(tr("&Copy Address"), this);
-      connect(copyAddr, &QAction::triggered, this, [this, lbl] {
+      connect(copyAddr, &QAction::triggered, this, [lbl] {
         QApplication::clipboard()->setText(lbl->text().mid(4, lbl->text().length() - 4));
       });
       contextMenu->addAction(copyAddr);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -440,7 +440,7 @@ MemWatchEntry* DlgAddWatchEntry::stealEntry()
 
 void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
 {
-  QLabel* const lbl = static_cast<QLabel*>(sender());
+  QLabel* const lbl = qobject_cast<QLabel*>(sender());
 
   QMenu* contextMenu = new QMenu(this);
   QAction* copyAddr = new QAction(tr("&Copy Address"), this);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -169,7 +169,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
         m_offsets.append(txbOffset);
         QLabel* lblAddressOfPath = new QLabel();
         lblAddressOfPath->setText(
-          QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
+            QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
         lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(i + 1));
         lblAddressOfPath->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this,
@@ -198,10 +198,11 @@ void DlgAddWatchEntry::addPointerOffset()
   m_offsets.append(txbOffset);
   QLabel* lblAddressOfPath = new QLabel(" -> ");
   lblAddressOfPath->setText(
-    QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(level + 1)));
+      QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(level + 1)));
   lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(level + 1));
   lblAddressOfPath->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this, &DlgAddWatchEntry::onPointerOffsetContextMenuRequested);
+  connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this,
+          &DlgAddWatchEntry::onPointerOffsetContextMenuRequested);
   m_addressPath.append(lblAddressOfPath);
   m_offsetsLayout->addWidget(lblLevel, level, 0);
   m_offsetsLayout->addWidget(txbOffset, level, 1);
@@ -397,9 +398,9 @@ void DlgAddWatchEntry::updatePreview()
     for (int i = 0; i < level; ++i)
     {
       QLabel* lblAddressOfPath =
-        qobject_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
+          qobject_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
       lblAddressOfPath->setText(
-        QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
+          QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
       lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(i + 1));
     }
   }
@@ -447,7 +448,7 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
 
   const QString text{QString::number(lbl->property("addr").toUInt(), 16).toUpper()};
   connect(copyAddr, &QAction::triggered, this,
-    [text] { QApplication::clipboard()->setText(text); });
+          [text] { QApplication::clipboard()->setText(text); });
   contextMenu->addAction(copyAddr);
 
   if (!lbl->property("addr").toUInt())

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -451,9 +451,9 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
   contextMenu->addAction(copyAddr);
 
   if (!lbl->property("addr").toUInt())
-    {
-        copyAddr->setEnabled(false);
-      }
+  {
+    copyAddr->setEnabled(false);
+  }
 
   contextMenu->popup(lbl->mapToGlobal(pos));
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -169,7 +169,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
         m_offsets.append(txbOffset);
         QLabel* lblAddressOfPath = new QLabel();
         lblAddressOfPath->setText(
-            QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
+          QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
         lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(i + 1));
         lblAddressOfPath->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this,
@@ -197,11 +197,11 @@ void DlgAddWatchEntry::addPointerOffset()
   QLineEdit* txbOffset = new QLineEdit();
   m_offsets.append(txbOffset);
   QLabel* lblAddressOfPath = new QLabel(" -> ");
-  lblAddressOfPath->setText(QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(level + 1)));
+  lblAddressOfPath->setText(
+    QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(level + 1)));
   lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(level + 1));
   lblAddressOfPath->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this,
-          &DlgAddWatchEntry::onPointerOffsetContextMenuRequested);
+  connect(lblAddressOfPath, &QWidget::customContextMenuRequested, this, &DlgAddWatchEntry::onPointerOffsetContextMenuRequested);
   m_addressPath.append(lblAddressOfPath);
   m_offsetsLayout->addWidget(lblLevel, level, 0);
   m_offsetsLayout->addWidget(txbOffset, level, 1);
@@ -399,7 +399,7 @@ void DlgAddWatchEntry::updatePreview()
       QLabel* lblAddressOfPath =
         qobject_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
       lblAddressOfPath->setText(
-          QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
+        QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
       lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(i + 1));
     }
   }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -1,14 +1,14 @@
 #include "DlgAddWatchEntry.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QDialogButtonBox>
 #include <QFontDatabase>
 #include <QFormLayout>
 #include <QHBoxLayout>
+#include <QMenu>
 #include <QMessageBox>
 #include <QVBoxLayout>
-#include <QMenu>
-#include <QApplication>
-#include <QClipboard>
 #include <sstream>
 
 #include "../../../DolphinProcess/DolphinAccessor.h"

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -397,7 +397,7 @@ void DlgAddWatchEntry::updatePreview()
     for (int i = 0; i < level; ++i)
     {
       QLabel* lblAddressOfPath =
-          static_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
+        qobject_cast<QLabel*>(m_offsetsLayout->itemAtPosition(i, 2)->widget());
       lblAddressOfPath->setText(
           QString::fromStdString(" -> " + m_entry->getAddressStringForPointerLevel(i + 1)));
       lblAddressOfPath->setProperty("addr", m_entry->getAddressForPointerLevel(i + 1));

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -442,8 +442,8 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
 {
   QLabel* const lbl = qobject_cast<QLabel*>(sender());
 
-  QMenu* contextMenu = new QMenu(this);
-  QAction* copyAddr = new QAction(tr("&Copy Address"), this);
+  QMenu* const contextMenu = new QMenu(this);
+  QAction* const copyAddr = new QAction(tr("&Copy Address"), this);
 
   const QString text{QString::number(lbl->property("addr").toUInt(), 16).toUpper()};
   connect(copyAddr, &QAction::triggered, this,

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -44,6 +44,7 @@ private:
   void addPointerOffset();
   void removePointerOffset();
   void removeAllPointerOffset();
+  void onPointerOffsetContextMenuRequested(const QPoint& pos);
 
   MemWatchEntry* m_entry{};
   AddressInputWidget* m_txbAddress{};

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -287,7 +287,6 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
-        std::string const strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
         if (!entry->getAddressForPointerLevel(i + 1))
           break;
         QAction* const copyAddrOfPointer = new QAction(

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -275,11 +275,11 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
 
   if (index.isValid())
   {
-    MemWatchEntry* entry = m_watchModel->getEntryFromIndex(index);
+    MemWatchEntry* const entry = m_watchModel->getEntryFromIndex(index);
     if (entry->isBoundToPointer())
     {
-      QMenu* copyAddrSubmenu = contextMenu->addMenu(tr("Copy add&ress..."));
-      QAction* copyPointer = new QAction(tr("Copy &base address..."), this);
+      QMenu* const copyAddrSubmenu = contextMenu->addMenu(tr("Copy add&ress..."));
+      QAction* const copyPointer = new QAction(tr("Copy &base address..."), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
               [addrString] { QApplication::clipboard()->setText(addrString);
@@ -287,20 +287,21 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
-        std::string strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
+        std::string const strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
         if (!entry->getAddressForPointerLevel(i + 1))
           break;
-        QAction* showAddressOfPathInViewer = new QAction(
+        QAction* const copyAddrOfPointer = new QAction(
             tr("Copy pointed address at &level %1...").arg(i + 1), this);
         const QString addrString{
             QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
         connect(copyAddrOfPointer, &QAction::triggered, this,
                 [addrString] { QApplication::clipboard()->setText(addrString); });
+        copyAddrSubmenu->addAction(copyAddrOfPointer);
       }
     }
     else
     {
-      QAction* copyPointer = new QAction(tr("Copy add&ress"), this);
+      QAction* const copyPointer = new QAction(tr("Copy add&ress"), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
               [addrString] { QApplication::clipboard()->setText(addrString); });

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -282,19 +282,19 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QAction* const copyPointer = new QAction(tr("Copy &base address..."), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-              [addrString] { QApplication::clipboard()->setText(addrString);
+        [addrString] { QApplication::clipboard()->setText(addrString);
       });
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
         if (!entry->getAddressForPointerLevel(i + 1))
           break;
-        QAction* const copyAddrOfPointer = new QAction(
-            tr("Copy pointed address at &level %1...").arg(i + 1), this);
+        QAction* const copyAddrOfPointer =
+          new QAction(tr("Copy pointed address at &level %1...").arg(i + 1), this);
         const QString addrString{
-            QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
+          QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
         connect(copyAddrOfPointer, &QAction::triggered, this,
-                [addrString] { QApplication::clipboard()->setText(addrString); });
+          [addrString] { QApplication::clipboard()->setText(addrString); });
         copyAddrSubmenu->addAction(copyAddrOfPointer);
       }
     }
@@ -303,7 +303,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QAction* const copyPointer = new QAction(tr("Copy add&ress"), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-              [addrString] { QApplication::clipboard()->setText(addrString); });
+        s[addrString] { QApplication::clipboard()->setText(addrString); });
       contextMenu->addAction(copyPointer);
     }
   }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -282,19 +282,18 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QAction* const copyPointer = new QAction(tr("Copy &base address..."), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-        [addrString] { QApplication::clipboard()->setText(addrString);
-      });
+              [addrString] { QApplication::clipboard()->setText(addrString); });
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
         if (!entry->getAddressForPointerLevel(i + 1))
           break;
         QAction* const copyAddrOfPointer =
-          new QAction(tr("Copy pointed address at &level %1...").arg(i + 1), this);
+            new QAction(tr("Copy pointed address at &level %1...").arg(i + 1), this);
         const QString addrString{
-          QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
+            QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
         connect(copyAddrOfPointer, &QAction::triggered, this,
-          [addrString] { QApplication::clipboard()->setText(addrString); });
+                [addrString] { QApplication::clipboard()->setText(addrString); });
         copyAddrSubmenu->addAction(copyAddrOfPointer);
       }
     }
@@ -303,7 +302,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QAction* const copyPointer = new QAction(tr("Copy add&ress"), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-        [addrString] { QApplication::clipboard()->setText(addrString); });
+              [addrString] { QApplication::clipboard()->setText(addrString); });
       contextMenu->addAction(copyPointer);
     }
   }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -283,7 +283,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       connect(copyPointer, &QAction::triggered, this,
               [this, entry] { copyAddressToClipboard(entry->getConsoleAddress()); });
       copyAddrSubmenu->addAction(copyPointer);
-      for (int i = 0; i < entry->getPointerLevel(); ++i)
+      for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
         std::string strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
         if (strAddressOfPath == "???")

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -281,7 +281,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QMenu* copyAddrSubmenu = contextMenu->addMenu(tr("Copy add&ress..."));
       QAction* copyPointer = new QAction(tr("Copy &base address..."), this);
       connect(copyPointer, &QAction::triggered, this,
-              [=] { copyAddressToClipboard(entry->getConsoleAddress()); });
+              [this, entry] { copyAddressToClipboard(entry->getConsoleAddress()); });
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < entry->getPointerLevel(); ++i)
       {
@@ -291,7 +291,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
         QAction* showAddressOfPathInViewer = new QAction(
             tr("Copy pointed address at &level %1...").arg(QString::number(i + 1)), this);
         connect(showAddressOfPathInViewer, &QAction::triggered, this,
-                [=] { copyAddressToClipboard(entry->getAddressForPointerLevel(i + 1)); });
+                [this, entry, i] { copyAddressToClipboard(entry->getAddressForPointerLevel(i + 1)); });
         copyAddrSubmenu->addAction(showAddressOfPathInViewer);
       }
     }
@@ -299,7 +299,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     {
       QAction* copyPointer = new QAction(tr("Copy add&ress"), this);
       connect(copyPointer, &QAction::triggered, this,
-              [=] { copyAddressToClipboard(entry->getConsoleAddress()); });
+              [this, entry] { copyAddressToClipboard(entry->getConsoleAddress()); });
       contextMenu->addAction(copyPointer);
 
       QModelIndexList selection = m_watchView->selectionModel()->selectedRows();
@@ -432,8 +432,8 @@ void MemWatchWidget::pasteWatchFromClipBoard(const QModelIndex& referenceIndex)
 
 void MemWatchWidget::copyAddressToClipboard(u32 addr)
 {
-  char hex_string[10];
-  sprintf(hex_string, "%X", addr);
+  char hex_string[8];
+  snprintf(hex_string, 8, "%X", addr);
   QClipboard* clipboard = QApplication::clipboard();
   clipboard->setText(hex_string);
 }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -280,8 +280,10 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     {
       QMenu* copyAddrSubmenu = contextMenu->addMenu(tr("Copy add&ress..."));
       QAction* copyPointer = new QAction(tr("Copy &base address..."), this);
+      const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-              [this, entry] { copyAddressToClipboard(entry->getConsoleAddress()); });
+              [addrString] { QApplication::clipboard()->setText(addrString);
+      });
       copyAddrSubmenu->addAction(copyPointer);
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
@@ -290,16 +292,18 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
           break;
         QAction* showAddressOfPathInViewer = new QAction(
             tr("Copy pointed address at &level %1...").arg(QString::number(i + 1)), this);
-        connect(showAddressOfPathInViewer, &QAction::triggered, this,
-                [this, entry, i] { copyAddressToClipboard(entry->getAddressForPointerLevel(i + 1)); });
-        copyAddrSubmenu->addAction(showAddressOfPathInViewer);
+        const QString addrString{
+            QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
+        connect(copyAddrOfPointer, &QAction::triggered, this,
+                [addrString] { QApplication::clipboard()->setText(addrString); });
       }
     }
     else
     {
       QAction* copyPointer = new QAction(tr("Copy add&ress"), this);
+      const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-              [this, entry] { copyAddressToClipboard(entry->getConsoleAddress()); });
+              [addrString] { QApplication::clipboard()->setText(addrString); });
       contextMenu->addAction(copyPointer);
 
       QModelIndexList selection = m_watchView->selectionModel()->selectedRows();
@@ -428,14 +432,6 @@ void MemWatchWidget::pasteWatchFromClipBoard(const QModelIndex& referenceIndex)
   m_watchModel->addNodes(childrenVec, referenceIndex);
 
   m_hasUnsavedChanges = true;
-}
-
-void MemWatchWidget::copyAddressToClipboard(u32 addr)
-{
-  char hex_string[8];
-  snprintf(hex_string, 8, "%X", addr);
-  QClipboard* clipboard = QApplication::clipboard();
-  clipboard->setText(hex_string);
 }
 
 void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -288,7 +288,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       for (int i = 0; i < static_cast<int>(entry->getPointerLevel()); ++i)
       {
         std::string strAddressOfPath = entry->getAddressStringForPointerLevel(i + 1);
-        if (strAddressOfPath == "???")
+        if (!entry->getAddressForPointerLevel(i + 1))
           break;
         QAction* showAddressOfPathInViewer = new QAction(
             tr("Copy pointed address at &level %1...").arg(QString::number(i + 1)), this);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -305,12 +305,6 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       connect(copyPointer, &QAction::triggered, this,
               [addrString] { QApplication::clipboard()->setText(addrString); });
       contextMenu->addAction(copyPointer);
-
-      QModelIndexList selection = m_watchView->selectionModel()->selectedRows();
-      if (selection.count() == 0)
-      {
-        copyPointer->setEnabled(false);
-      }
     }
   }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -291,7 +291,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
         if (!entry->getAddressForPointerLevel(i + 1))
           break;
         QAction* showAddressOfPathInViewer = new QAction(
-            tr("Copy pointed address at &level %1...").arg(QString::number(i + 1)), this);
+            tr("Copy pointed address at &level %1...").arg(i + 1), this);
         const QString addrString{
             QString::number(entry->getAddressForPointerLevel(i + 1), 16).toUpper()};
         connect(copyAddrOfPointer, &QAction::triggered, this,

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -273,7 +273,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   connect(copy, &QAction::triggered, this, [this] { copySelectedWatchesToClipBoard(); });
   contextMenu->addAction(copy);
 
-  if (index != QModelIndex())
+  if (index.isValid())
   {
     MemWatchEntry* entry = m_watchModel->getEntryFromIndex(index);
     if (entry->isBoundToPointer())

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -303,7 +303,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
       QAction* const copyPointer = new QAction(tr("Copy add&ress"), this);
       const QString addrString{QString::number(entry->getConsoleAddress(), 16).toUpper()};
       connect(copyPointer, &QAction::triggered, this,
-        s[addrString] { QApplication::clipboard()->setText(addrString); });
+        [addrString] { QApplication::clipboard()->setText(addrString); });
       contextMenu->addAction(copyPointer);
     }
   }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -433,7 +433,7 @@ void MemWatchWidget::pasteWatchFromClipBoard(const QModelIndex& referenceIndex)
 void MemWatchWidget::copyAddressToClipboard(u32 addr)
 {
   char hex_string[10];
-  sprintf_s(hex_string, "%X", addr);
+  sprintf(hex_string, "%X", addr);
   QClipboard* clipboard = QApplication::clipboard();
   clipboard->setText(hex_string);
 }

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -39,6 +39,7 @@ public:
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
   void pasteWatchFromClipBoard(const QModelIndex& referenceIndex);
+  void copyAddressToClipboard(u32 addr);
   bool saveWatchFile();
   bool saveAsWatchFile();
   void clearWatchList();

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -39,7 +39,6 @@ public:
   void copySelectedWatchesToClipBoard();
   void cutSelectedWatchesToClipBoard();
   void pasteWatchFromClipBoard(const QModelIndex& referenceIndex);
-  void copyAddressToClipboard(u32 addr);
   bool saveWatchFile();
   bool saveAsWatchFile();
   void clearWatchList();


### PR DESCRIPTION
Added two methods for copying a pointer address to the clipboard

- Added a context menu to the Edit Address widget for the pointer widget to copy an address from the address label

- Added an option ("Copy address") to the context menu of a Memory Watch widget to copy either the base address of the memory watch, or a selected pointer level if the watch is a pointer.

The second item is currently located after the "Copy" entry of the context menu, though it might fit better after the "Browse memory at" entry. 

reference: #160