### PR TITLE
Upgrade Clang-Format check in GitHub Action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   clang-format-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Clang-Format Check
     steps:
       - uses: actions/checkout@v4
-      - uses: RafikFarhad/clang-format-github-action@v4
+      - uses: jidicula/clang-format-action@v4.13.0
         with:
-          style: "file"
-          sources: "Source/**/*.h,Source/**/*.cpp"
+          clang-format-version: '18'
+          check-path: Source
 
   build-windows:
     runs-on: windows-latest

--- a/Source/Common/CommonUtils.h
+++ b/Source/Common/CommonUtils.h
@@ -5,14 +5,14 @@
 #elif _WIN32
 #include <stdlib.h>
 #elif __APPLE__
-#define bswap_16(value) (static_cast<u16>((((value)&0xff) << 8) | ((value) >> 8)))
+#define bswap_16(value) (static_cast<u16>((((value) & 0xff) << 8) | ((value) >> 8)))
 
 #define bswap_32(value)                                                                            \
-  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \
+  (((uint32_t)bswap_16((uint16_t)((value) & 0xffff)) << 16) |                                      \
    (uint32_t)bswap_16((uint16_t)((value) >> 16)))
 
 #define bswap_64(value)                                                                            \
-  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) |                                    \
+  (((uint64_t)bswap_32((uint32_t)((value) & 0xffffffff)) << 32) |                                  \
    (uint64_t)bswap_32((uint32_t)((value) >> 32)))
 #endif
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -21,8 +21,7 @@ int main(int argc, char** argv)
   parser.addVersionOption();
 
   const QCommandLineOption dolphinProcessNameOption(
-      QStringList() << "d"
-                    << "dolphin-process-name",
+      QStringList() << "d" << "dolphin-process-name",
       QObject::tr("Specify custom name for the Dolphin Emulator process. By default, "
                   "platform-specific names are used (e.g. \"Dolphin.exe\" on Windows, or "
                   "\"dolphin-emu\" on Linux or macOS)."),


### PR DESCRIPTION
The previous GitHub Action (`RafikFarhad/clang-format-github-action`) was not handling deeply nested files correctly: formatting was not enforced in a second directory level or deeper.

A more popular action (`jidicula/clang-format-action`) is now used, which enables Clang-Format 18.