### PR TITLE
Check watch entry pointer to avoid dereferencing null pointer when a group node is right-clicked.

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -274,9 +274,9 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   connect(copy, &QAction::triggered, this, [this] { copySelectedWatchesToClipBoard(); });
   contextMenu->addAction(copy);
 
-  if (index.isValid())
+  MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
+  if (entry)
   {
-    MemWatchEntry* const entry = m_watchModel->getEntryFromIndex(index);
     if (entry->isBoundToPointer())
     {
       QMenu* const copyAddrSubmenu = contextMenu->addMenu(tr("Copy add&ress..."));


### PR DESCRIPTION
This was a regression in #167.

Group nodes do not have a watch entry associated with them. When a group node was right-clicked, a null pointer would be fatally dereferenced:

```
#0  MemWatchEntry::isBoundToPointer() const (this=this@entry=0x0) at /w/dolphin-memory-engine/Source/MemoryWatch/MemWatchEntry.cpp:77
#1  0x0000561a4ab96c94 in MemWatchWidget::onMemWatchContextMenuRequested(QPoint const&) (this=0x561a4c28c580, pos=...) at /w/dolphin-memory-engine/Source/GUI/MemWatcher/MemWatchWidget.cpp:280
#2  0x00007f56ac7be023 in  () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#3  0x00007f56ad489889 in QWidget::customContextMenuRequested(QPoint const&) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#4  0x00007f56ad4a6020 in QWidget::event(QEvent*) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#5  0x00007f56ad541406 in QFrame::event(QEvent*) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#6  0x00007f56ac765818 in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#7  0x00007f56ad44bd25 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#8  0x00007f56ad454c5e in QApplication::notify(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#9  0x00007f56ac765a58 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#10 0x00007f56ad4b796c in  () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#11 0x00007f56ad4ba635 in  () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#12 0x00007f56ad44bd36 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Widgets.so.6
#13 0x00007f56ac765a58 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#14 0x00007f56acd0a6bf in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) () at /lib/x86_64-linux-gnu/libQt6Gui.so.6
#15 0x00007f56acd52c8c in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib/x86_64-linux-gnu/libQt6Gui.so.6
#16 0x00007f56a8c7686e in  () at /usr/lib/x86_64-linux-gnu/qt6/plugins/platforms/../../../libQt6XcbQpa.so.6
#17 0x00007f56abe32d3b in g_main_context_dispatch () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#18 0x00007f56abe882b8 in  () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#19 0x00007f56abe303e3 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#20 0x00007f56ac98deae in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#21 0x00007f56ac772adb in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#22 0x00007f56ac76e0f3 in QCoreApplication::exec() () at /lib/x86_64-linux-gnu/libQt6Core.so.6
#23 0x0000561a4ab66e8c in main(int, char**) (argc=<optimised out>, argv=<optimised out>) at /w/dolphin-memory-engine/Source/main.cpp:54
```

Fixes #170.