### PR TITLE
Convert to `unsigned char` before invoking `std::isprint()`.

### DIFF
--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -651,7 +651,7 @@ std::string formatMemoryToString(const char* memory, const MemType type, const s
       if (c == '\0')
         break;
 
-      if (std::isprint(c))
+      if (std::isprint(static_cast<int>(static_cast<unsigned char>(c))))
       {
         text.push_back(c);
       }

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -588,7 +588,7 @@ void MainWindow::updateStatusBar()
     {
       for (char& c : gameID)
       {
-        if (!std::isprint(c))
+        if (!std::isprint(static_cast<int>(static_cast<unsigned char>(c))))
         {
           c = '?';
         }


### PR DESCRIPTION
As the documentation states, the caller must check that the input character in [`std::isprint()`](https://en.cppreference.com/w/cpp/string/byte/isprint) is a valid `unsigned char`:

> Like all other functions from `<cctype>`, the behavior of `std::isprint` is undefined if the argument's value is neither representable as `unsigned char` nor equal to `EOF`. To use these functions safely with plain `char`s (or `signed char`s), the argument should first be converted to `unsigned char`:
>
> ```cpp
> bool my_isprint(char ch)
> {
>     return std::isprint(static_cast<unsigned char>(ch));
> }
> ```

The aforementioned undefined behavior manifests as a debug assertion when compiled with MSVC:

![image](https://github.com/user-attachments/assets/144e3573-f53c-4e89-a0cd-d615caa2749e)

The affected functionality was introduced in #122.

Fixes #173.