### PR TITLE
Fix two crash bugs, add new context menu items

### DIFF
--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -193,6 +193,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 void DlgAddWatchEntry::addPointerOffset()
 {
   int level = static_cast<int>(m_entry->getPointerLevel());
+  m_entry->addOffset(0);
   QLabel* lblLevel = new QLabel(QString::fromStdString("Level " + std::to_string(level + 1) + ":"));
   QLineEdit* txbOffset = new QLineEdit();
   m_offsets.append(txbOffset);
@@ -207,7 +208,7 @@ void DlgAddWatchEntry::addPointerOffset()
   m_offsetsLayout->addWidget(lblLevel, level, 0);
   m_offsetsLayout->addWidget(txbOffset, level, 1);
   m_offsetsLayout->addWidget(lblAddressOfPath, level, 2);
-  m_entry->addOffset(0);
+
   connect(txbOffset, &QLineEdit::textEdited, this, &DlgAddWatchEntry::onOffsetChanged);
   if (m_entry->getPointerLevel() > 1)
     m_btnRemoveOffset->setEnabled(true);

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -119,7 +119,9 @@ void MemWatchModel::changeType(const QModelIndex& index, Common::MemType type, s
 MemWatchEntry* MemWatchModel::getEntryFromIndex(const QModelIndex& index)
 {
   MemWatchTreeNode* node = static_cast<MemWatchTreeNode*>(index.internalPointer());
-  return node->getEntry();
+  if (node)
+    return node->getEntry();
+  return nullptr;
 }
 
 void MemWatchModel::addNodes(const std::vector<MemWatchTreeNode*>& nodes,

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -267,6 +267,17 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     contextMenu->addSeparator();
   }
 
+  MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
+  if (!entry) {
+    QAction* const addGroup{new QAction(tr("Add &group"), this)};
+    connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);
+    contextMenu->addAction(addGroup);
+    QAction* const addWatch{new QAction(tr("Add &watch"), this)};
+    connect(addWatch, &QAction::triggered, this, &MemWatchWidget::onAddWatchEntry);
+    contextMenu->addAction(addWatch);
+    contextMenu->addSeparator();
+  }
+
   QAction* cut = new QAction(tr("Cu&t"), this);
   connect(cut, &QAction::triggered, this, [this] { cutSelectedWatchesToClipBoard(); });
   contextMenu->addAction(cut);
@@ -274,7 +285,6 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   connect(copy, &QAction::triggered, this, [this] { copySelectedWatchesToClipBoard(); });
   contextMenu->addAction(copy);
 
-  MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
   if (entry)
   {
     if (entry->isBoundToPointer())

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -268,7 +268,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   }
 
   MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
-  if (!entry) {
+  if (!entry || node->isGroup()) {
     QAction* const addGroup{new QAction(tr("Add &group"), this)};
     connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);
     contextMenu->addAction(addGroup);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -268,7 +268,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   }
 
   if (!node || node->isGroup()) {
-    QAction* const addGroup{new QAction(tr("Add &group"), this)};
+    QAction* const addGroup{new QAction(tr("Add gro&up"), this)};
     connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);
     contextMenu->addAction(addGroup);
     QAction* const addWatch{new QAction(tr("Add &watch"), this)};

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -267,8 +267,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     contextMenu->addSeparator();
   }
 
-  MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
-  if (!entry || node->isGroup()) {
+  if (!node || node->isGroup()) {
     QAction* const addGroup{new QAction(tr("Add &group"), this)};
     connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);
     contextMenu->addAction(addGroup);
@@ -285,6 +284,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
   connect(copy, &QAction::triggered, this, [this] { copySelectedWatchesToClipBoard(); });
   contextMenu->addAction(copy);
 
+  MemWatchEntry* const entry{MemWatchModel::getEntryFromIndex(index)};
   if (entry)
   {
     if (entry->isBoundToPointer())

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -267,7 +267,8 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     contextMenu->addSeparator();
   }
 
-  if (!node || node->isGroup()) {
+  if (!node || node->isGroup())
+  {
     QAction* const addGroup{new QAction(tr("Add gro&up"), this)};
     connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);
     contextMenu->addAction(addGroup);


### PR DESCRIPTION
- Fixed a bug where opening a context menu with nothing selected crashed the program
- Fixed a bug where adding pointer levels could crash the program
- Created new 'Add Watch' and 'Add Group' context menu items when not selecting anything