### PR TITLE
Retain file information when closing and reopening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Source/.vscode/
 .vscode/
 .idea/*
 .DS_Store
+.cache

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -41,6 +41,7 @@ MainWindow::MainWindow()
   GUICommon::changeApplicationStyle(
       static_cast<GUICommon::ApplicationStyle>(SConfig::getInstance().getTheme()));
 
+  m_watcher->setWatchFile(SConfig::getInstance().getWatchFile());
   m_watcher->restoreWatchModel(SConfig::getInstance().getWatchModel());
   m_actAutoHook->setChecked(SConfig::getInstance().getAutoHook());
 
@@ -63,7 +64,7 @@ void MainWindow::makeMenus()
   m_actOpenWatchList = new QAction(tr("&Open..."), this);
   m_actSaveWatchList = new QAction(tr("&Save"), this);
   m_actSaveAsWatchList = new QAction(tr("&Save as..."), this);
-  m_actClearWatchList = new QAction(tr("&Clear the watch list"), this);
+  m_actClearWatchList = new QAction(tr("&Reset watch list"), this);
   m_actImportFromCT = new QAction(tr("&Import from Cheat Engine's CT file..."), this);
   m_actExportAsCSV = new QAction(tr("&Export as CSV..."), this);
   QAction* const actOpenConfigDir{new QAction(tr("Open Configuration Directory..."), this)};
@@ -545,6 +546,7 @@ void MainWindow::onQuit()
 void MainWindow::closeEvent(QCloseEvent* event)
 {
   SConfig::getInstance().setAutoHook(m_actAutoHook->isChecked());
+  SConfig::getInstance().setWatchFile(m_watcher->getWatchFile());
   SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());
   SConfig::getInstance().setMainWindowGeometry(saveGeometry());
   SConfig::getInstance().setMainWindowState(saveState());

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -267,7 +267,7 @@ void MemWatchWidget::onMemWatchContextMenuRequested(const QPoint& pos)
     contextMenu->addSeparator();
   }
 
-  if (!node || node->isGroup())
+  if (node == m_watchModel->getRootNode() || node->isGroup())
   {
     QAction* const addGroup{new QAction(tr("Add gro&up"), this)};
     connect(addGroup, &QAction::triggered, this, &MemWatchWidget::onAddGroup);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -853,6 +853,7 @@ void MemWatchWidget::clearWatchList()
     return;
 
   m_watchModel->clearRoot();
+  m_watchListFile = "";
 }
 
 void MemWatchWidget::importFromCTFile()
@@ -982,6 +983,16 @@ QString MemWatchWidget::saveWatchModel()
   m_watchModel->writeRootToJsonRecursive(root);
   QJsonDocument saveDoc(root);
   return saveDoc.toJson();
+}
+
+QString MemWatchWidget::getWatchFile() const
+{
+  return m_watchListFile;
+}
+
+void MemWatchWidget::setWatchFile(const QString& path)
+{
+  m_watchListFile = path;
 }
 
 void MemWatchWidget::updateExpansionState(const MemWatchTreeNode* const node)

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -49,6 +49,8 @@ public:
   bool warnIfUnsavedChanges();
   void restoreWatchModel(const QString& json);
   QString saveWatchModel();
+  QString getWatchFile() const;
+  void setWatchFile(const QString& path);
 
 signals:
   void mustUnhook();

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -63,6 +63,11 @@ QString SConfig::getSettingsFilepath() const
   return m_settings->fileName();
 }
 
+QString SConfig::getWatchFile() const
+{
+  return value("watchFile", QString{}).toString();
+}
+
 QString SConfig::getWatchModel() const
 {
   return value("watchModel", QString{}).toString();
@@ -131,6 +136,11 @@ u32 SConfig::getMEM1Size() const
 u32 SConfig::getMEM2Size() const
 {
   return value("memorySettings/MEM2Size", 64u * 1024 * 1024).toUInt();
+}
+
+void SConfig::setWatchFile(const QString& path)
+{
+  setValue("watchFile", path);
 }
 
 void SConfig::setWatchModel(const QString& json)

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -28,6 +28,7 @@ public:
   QByteArray getMainWindowState() const;
   QByteArray getSplitterState() const;
 
+  QString getWatchFile() const;
   QString getWatchModel() const;
   bool getAutoHook() const;
 
@@ -47,6 +48,7 @@ public:
   void setMainWindowState(QByteArray const&);
   void setSplitterState(QByteArray const&);
 
+  void setWatchFile(const QString& path);
   void setWatchModel(const QString& json);
   void setAutoHook(bool enabled);
 


### PR DESCRIPTION
Previously, closing and reopening the program meant having to re-save the opened file and overwrite the file. This retains the opened file so you no longer have to go through that process.

Also changed "Clear the watch list" to "Reset watch list" and made it discard the saved file information.