### PR TITLE
Add Autoload Last File Option

### DIFF
--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -56,6 +56,8 @@ public:
   void onAbout();
   void onQuit();
 
+  void onAutoLoadLastFileTriggered(bool checked);
+
 private:
   void makeMenus();
   void initialiseWidgets();
@@ -83,6 +85,7 @@ private:
   QAction* m_actClearWatchList{};
   QAction* m_actImportFromCT{};
   QAction* m_actExportAsCSV{};
+  QAction* m_actAutoloadLastFile{};
   QAction* m_actSettings{};
   QAction* m_actAutoHook{};
   QAction* m_actHook{};

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -739,11 +739,19 @@ QTimer* MemWatchWidget::getFreezeTimer() const
   return m_freezeTimer;
 }
 
-void MemWatchWidget::openWatchFile()
+void MemWatchWidget::openWatchFile(const QString& fileName)
 {
-  QString fileName = QFileDialog::getOpenFileName(this, "Open watch list", m_watchListFile,
-                                                  "Dolphin memory watches file (*.dmw)");
-  if (fileName != "")
+  QString srcFileName;
+  if (fileName.isEmpty())
+  {
+    srcFileName = QFileDialog::getOpenFileName(this, "Open watch list", m_watchListFile,
+                                               "Dolphin memory watches file (*.dmw)");
+  }
+  else
+  {
+    srcFileName = fileName;
+  }
+  if (!srcFileName.isEmpty())
   {
     if (m_watchModel->hasAnyNodes())
     {
@@ -758,12 +766,12 @@ void MemWatchWidget::openWatchFile()
         m_watchModel->clearRoot();
     }
 
-    QFile watchFile(fileName);
+    QFile watchFile(srcFileName);
     if (!watchFile.exists())
     {
       QMessageBox* errorBox = new QMessageBox(
           QMessageBox::Critical, QString("Error while opening file"),
-          QString("The watch list file " + fileName + " does not exist"), QMessageBox::Ok, this);
+          QString("The watch list file " + srcFileName + " does not exist"), QMessageBox::Ok, this);
       errorBox->exec();
       return;
     }
@@ -780,7 +788,7 @@ void MemWatchWidget::openWatchFile()
     QJsonDocument loadDoc(QJsonDocument::fromJson(bytes));
     m_watchModel->loadRootFromJsonRecursive(loadDoc.object());
     updateExpansionState();
-    m_watchListFile = fileName;
+    m_watchListFile = srcFileName;
     m_hasUnsavedChanges = false;
   }
 }
@@ -842,6 +850,7 @@ bool MemWatchWidget::saveAsWatchFile()
 
 void MemWatchWidget::clearWatchList()
 {
+  m_watchListFile.clear();
   if (!m_watchModel->hasAnyNodes())
     return;
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -33,7 +33,7 @@ public:
   void onRowsInserted(const QModelIndex& parent, int first, int last);
   void onCollapsed(const QModelIndex& index);
   void onExpanded(const QModelIndex& index);
-  void openWatchFile();
+  void openWatchFile(const QString& fileName);
   void setSelectedWatchesBase(MemWatchEntry* entry, Common::MemBase base);
   void groupCurrentSelection();
   void copySelectedWatchesToClipBoard();
@@ -49,6 +49,7 @@ public:
   bool warnIfUnsavedChanges();
   void restoreWatchModel(const QString& json);
   QString saveWatchModel();
+  QString m_watchListFile;
 
 signals:
   void mustUnhook();
@@ -66,7 +67,6 @@ private:
   QPushButton* m_btnAddWatchEntry{};
   QTimer* m_updateTimer{};
   QTimer* m_freezeTimer{};
-  QString m_watchListFile = "";
   bool m_hasUnsavedChanges = false;
 
   bool isAnyAncestorSelected(const QModelIndex& index) const;

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -203,6 +203,26 @@ void SConfig::setMEM2Size(const u32 mem2SizeReal)
   setValue("memorySettings/MEM2Size", mem2SizeReal);
 }
 
+bool SConfig::getAutoloadLastFile() const
+{
+  return value("autoloadLastFile", false).toBool();
+}
+
+void SConfig::setAutoloadLastFile(const bool enabled)
+{
+  setValue("autoloadLastFile", enabled);
+}
+
+QString SConfig::getLastLoadedFile() const
+{
+  return value("lastLoadedFile", QString{}).toString();
+}
+
+void SConfig::setLastLoadedFile(const QString& fileName)
+{
+  setValue("lastLoadedFile", fileName);
+}
+
 bool SConfig::ownsSettingsFile() const
 {
   return m_lockFile->isLocked();

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -64,6 +64,11 @@ public:
 
   bool ownsSettingsFile() const;
 
+  bool getAutoloadLastFile() const;
+  void setAutoloadLastFile(bool enabled);
+  QString getLastLoadedFile() const;
+  void setLastLoadedFile(const QString& fileName);
+
 private:
   void setValue(const QString& key, const QVariant& value);
   QVariant value(const QString& key, const QVariant& defaultValue) const;


### PR DESCRIPTION
Implements https://github.com/aldelaro5/dolphin-memory-engine/issues/121

![image](https://github.com/user-attachments/assets/12a77809-1ac7-46a0-98f1-29c0007b9561)

This feature autoloads the last .DMW you have previously loaded.
This is useful if working on a .DMW file you regularly commit to a shared repository.

- Enabling the feature will stop saving to the 'temporary' watchlist space.
- Disabling the feature will clear your current watchlist (giving you an opportunity to save it if you have not), and then load the old 'temporary' watchlist.
- Closing DME will now prompt you to save if this mode is on and you have not saved

---

## Changes
* Clearing the watchlist now also drops the file reference
* Closing DME while the Auto-load checkbox is enabled will prompt you if you have unsaved changes, just like if two DME instances are running.
* This is NOT enabled by default.
* Makes `m_watchListFile` public - necessary to get file location, and to be used later in https://github.com/aldelaro5/dolphin-memory-engine/issues/182 


<details><summary>TODOs (All Done)</summary>
[WONTDO]  // TODO: Potentially restoreWatchModel first, then openWatchFile in autoload scenario. If they don't match, warn/prompt unsaved changes in model.

[x] Do we want auto-load by default - _No, for now we will default to off_

[x] Potentially a way to switch between 'scratch' (the stored watchmodel in the config) and files on the fly? - _The config watchlist will not be saved, that way you can turn off the feature to switch between them_

[x] Lint

[x] Ensure when a user toggles the feature on/off the stored watchmodel is *not* overwritten. Warn the user if unsaved changes, and then reload the watchlist, or prompt to save it

[x] Don't save the config/scratch stored watchlist if this feature is enabled - prevents data loss

</details> 
