### PR TITLE
CI: Update clang-format-action to v4.14.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Clang-Format Check
     steps:
       - uses: actions/checkout@v4
-      - uses: jidicula/clang-format-action@v4.13.0
+      - uses: jidicula/clang-format-action@v4.14.0
         with:
           clang-format-version: '18'
           check-path: Source


### PR DESCRIPTION
* Update our lint action to [v4.14.0](https://github.com/jidicula/clang-format-action/releases)