### PR TITLE
Lint: Use Clang-Format 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jidicula/clang-format-action@v4.14.0
         with:
-          clang-format-version: '18'
+          clang-format-version: '19'
           check-path: Source
 
   build-windows:


### PR DESCRIPTION
I'm unsure if I also need to manually update:
```
Source/.clang-format
Source/.clang-tidy
```