### PR TITLE
Externals: Qt6.8.2 for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.5.3\x64"
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.8.2\x64"
           cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
         shell: powershell
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -52,7 +52,7 @@ if (WIN32)
     find_package(Qt6Widgets QUIET)
 	  if (NOT Qt6Widgets_FOUND)
 		    message(STATUS "Qt package not found, using external lib")
-		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.5.3\\x64")
+		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.8.2\\x64")
 		    find_package(Qt6Widgets REQUIRED)
 	  endif ()
 else ()
@@ -150,7 +150,7 @@ if(WIN32)
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:Qt6::QWindowsVistaStylePlugin>
+            $<TARGET_FILE:Qt6::QModernWindowsStylePlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
     )
 endif(WIN32)


### PR DESCRIPTION
* Upgrades our Qt for Windows external from 6.5.3 to 6.8.2
* This is mainly done since we may do the same for Dolphin, and I don't see any issues in my brief testing.

The only notable changes I've seen:
* Depending on your color scheme fusion dark has some tweaks.
* Window sizes are slightly different. About is larger, and Memory Viewer is smaller

The enable/disable look, drag and drop, and general usage seems just like 6.5.3, unlike the disaster the 6.7.0 experiment was (broken enable/disable colors and more).

Left is Qt6.5.3, Right is Qt6.8.2
![image](https://github.com/user-attachments/assets/b3966470-6c3f-42a0-ac3c-8075cd04bd2c)

![image](https://github.com/user-attachments/assets/c3e6f566-55f4-437a-9e7e-5e22541114ff)

