### PR TITLE
Bugfix: Allow selecting scanning options for float and double

### DIFF
--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -509,7 +509,8 @@ int MemScanner::getTermsNumForFilter(const MemScanner::ScanFiter filter)
 bool MemScanner::typeSupportsAdditionalOptions(const Common::MemType type)
 {
   return (type == Common::MemType::type_byte || type == Common::MemType::type_halfword ||
-          type == Common::MemType::type_word);
+          type == Common::MemType::type_word || type == Common::MemType::type_float ||
+          type == Common::MemType::type_double);
 }
 
 std::vector<u32> MemScanner::getResultsConsoleAddr() const


### PR DESCRIPTION
Resolves https://github.com/aldelaro5/dolphin-memory-engine/issues/191

Previously set value while viewing binary/word etc would influence scan.
I verified unaligned option also works, though doing so makes scanning take longer.

I don't really see why you'd want to use the other types, but I suppose it doesn't hurt to expose it either rather than forcing decimal.