### PR TITLE
Add Setting to collapse all Expanded Groups on save

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -52,6 +52,8 @@ MainWindow::MainWindow()
     m_watcher->restoreWatchModel(SConfig::getInstance().getWatchModel());
   }
 
+  m_actCollapseGroupsOnSave->setChecked(SConfig::getInstance().getCollapseGroupsOnSave());
+
   m_actAutoHook->setChecked(SConfig::getInstance().getAutoHook());
 
   if (m_actAutoHook->isChecked())
@@ -78,6 +80,8 @@ void MainWindow::makeMenus()
   m_actExportAsCSV = new QAction(tr("&Export as CSV..."), this);
   m_actAutoloadLastFile = new QAction(tr("Auto-load last file"), this);
   m_actAutoloadLastFile->setCheckable(true);
+  m_actCollapseGroupsOnSave = new QAction(tr("Collapse Groups on save"), this);
+  m_actCollapseGroupsOnSave->setCheckable(true);
   QAction* const actOpenConfigDir{new QAction(tr("Open Configuration Directory..."), this)};
 
   m_actOpenWatchList->setShortcut(Qt::Modifier::CTRL | Qt::Key::Key_O);
@@ -120,6 +124,9 @@ void MainWindow::makeMenus()
   connect(m_actAutoloadLastFile, &QAction::triggered, this,
           &MainWindow::onAutoLoadLastFileTriggered);
 
+  connect(m_actCollapseGroupsOnSave, &QAction::triggered, this,
+          &MainWindow::onCollapseGroupsOnSaveTriggered);
+
   connect(m_actSettings, &QAction::triggered, this, &MainWindow::onOpenSettings);
 
   connect(m_actAutoHook, &QAction::toggled, this, &MainWindow::onAutoHookToggled);
@@ -143,6 +150,7 @@ void MainWindow::makeMenus()
   m_menuFile->addAction(m_actExportAsCSV);
   m_menuFile->addSeparator();
   m_menuFile->addAction(m_actAutoloadLastFile);
+  m_menuFile->addAction(m_actCollapseGroupsOnSave);
   m_menuFile->addSeparator();
   m_menuFile->addAction(actOpenConfigDir);
   m_menuFile->addSeparator();
@@ -362,6 +370,11 @@ void MainWindow::onAutoLoadLastFileTriggered(const bool checked)
   updateStatusBar();
 }
 
+void MainWindow::onCollapseGroupsOnSaveTriggered(const bool checked)
+{
+  SConfig::getInstance().setCollapseGroupsOnSave(checked);
+}
+
 void MainWindow::onAutoHookToggled(const bool checked)
 {
   if (checked)
@@ -579,6 +592,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
   SConfig::getInstance().setAutoHook(m_actAutoHook->isChecked());
   SConfig::getInstance().setAutoloadLastFile(m_actAutoloadLastFile->isChecked());
   SConfig::getInstance().setLastLoadedFile(m_watcher->m_watchListFile);
+  SConfig::getInstance().setCollapseGroupsOnSave(m_actCollapseGroupsOnSave->isChecked());
   if (!m_actAutoloadLastFile->isChecked() || m_watcher->m_watchListFile.isEmpty())
   {
     SConfig::getInstance().setWatchModel(m_watcher->saveWatchModel());

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -37,6 +37,7 @@ public:
   void updateDolphinHookingStatus();
   void onHookAttempt();
   void onUnhook();
+  void onCollapseGroupsOnSaveTriggered(bool checked);
   void onAutoHookToggled(bool checked);
   void onHookIfNotHooked();
   void onOpenMenViewer();
@@ -86,6 +87,7 @@ private:
   QAction* m_actImportFromCT{};
   QAction* m_actExportAsCSV{};
   QAction* m_actAutoloadLastFile{};
+  QAction* m_actCollapseGroupsOnSave{};
   QAction* m_actSettings{};
   QAction* m_actAutoHook{};
   QAction* m_actHook{};

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -14,6 +14,7 @@
 #include "../../Common/CommonUtils.h"
 #include "../../DolphinProcess/DolphinAccessor.h"
 #include "../GUICommon.h"
+#include "../Settings/SConfig.h"
 
 namespace
 {
@@ -666,7 +667,7 @@ MemWatchModel::CTParsingErrors MemWatchModel::importRootFromCTFile(QFile* const 
 
 void MemWatchModel::writeRootToJsonRecursive(QJsonObject& json) const
 {
-  m_rootNode->writeToJson(json);
+  m_rootNode->writeToJson(json, !SConfig::getInstance().getCollapseGroupsOnSave());
 }
 
 QString MemWatchModel::writeRootToCSVStringRecursive() const

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -404,7 +404,7 @@ void MemWatchWidget::copySelectedWatchesToClipBoard()
 
       rootNodeCopy.appendChild(childNode);  // Borrow node temporarily.
     }
-    rootNodeCopy.writeToJson(jsonNode);
+    rootNodeCopy.writeToJson(jsonNode, true);
 
     // Remove borrowed children before going out of scope.
     rootNodeCopy.removeChildren();

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -228,6 +228,16 @@ bool SConfig::ownsSettingsFile() const
   return m_lockFile->isLocked();
 }
 
+bool SConfig::getCollapseGroupsOnSave() const
+{
+  return value("collapseGroupsOnSave", false).toBool();
+}
+
+void SConfig::setCollapseGroupsOnSave(const bool enabled)
+{
+  setValue("collapseGroupsOnSave", enabled);
+}
+
 void SConfig::setValue(const QString& key, const QVariant& value)
 {
   m_map[key] = value;

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -69,6 +69,9 @@ public:
   QString getLastLoadedFile() const;
   void setLastLoadedFile(const QString& fileName);
 
+  bool getCollapseGroupsOnSave() const;
+  void setCollapseGroupsOnSave(bool enabled);
+
 private:
   void setValue(const QString& key, const QVariant& value);
   QVariant value(const QString& key, const QVariant& defaultValue) const;

--- a/Source/MemoryWatch/MemWatchTreeNode.cpp
+++ b/Source/MemoryWatch/MemWatchTreeNode.cpp
@@ -199,12 +199,12 @@ void MemWatchTreeNode::readFromJson(const QJsonObject& json, MemWatchTreeNode* p
   }
 }
 
-void MemWatchTreeNode::writeToJson(QJsonObject& json) const
+void MemWatchTreeNode::writeToJson(QJsonObject& json, const bool writeExpandedState) const
 {
   if (isGroup())
   {
     json["groupName"] = m_groupName;
-    if (m_expanded)
+    if (m_expanded && writeExpandedState)
     {
       json["expanded"] = m_expanded;
     }
@@ -212,7 +212,7 @@ void MemWatchTreeNode::writeToJson(QJsonObject& json) const
     for (MemWatchTreeNode* const child : m_children)
     {
       QJsonObject theNode;
-      child->writeToJson(theNode);
+      child->writeToJson(theNode, writeExpandedState);
       entries.append(theNode);
     }
     json["groupEntries"] = entries;
@@ -225,7 +225,7 @@ void MemWatchTreeNode::writeToJson(QJsonObject& json) const
       for (MemWatchTreeNode* const child : m_children)
       {
         QJsonObject theNode;
-        child->writeToJson(theNode);
+        child->writeToJson(theNode, writeExpandedState);
         watchList.append(theNode);
       }
       json["watchList"] = watchList;

--- a/Source/MemoryWatch/MemWatchTreeNode.h
+++ b/Source/MemoryWatch/MemWatchTreeNode.h
@@ -43,7 +43,7 @@ public:
   void deleteChildren();
 
   void readFromJson(const QJsonObject& json, MemWatchTreeNode* parent = nullptr);
-  void writeToJson(QJsonObject& json) const;
+  void writeToJson(QJsonObject& json, const bool writeExpandedState) const;
   QString writeAsCSV() const;
 
 private:


### PR DESCRIPTION
Implements https://github.com/aldelaro5/dolphin-memory-engine/issues/193

* Collapses expanded groups on save (to the file) - not on the immediate view.
* Only reopening the file (or closing DME and reopening) would show the changes.

Mainly intended for those storing dmws in a git repo with lots of groups to avoid unnecessarily large diffs.

![image](https://github.com/user-attachments/assets/f6030fa6-71a1-4d40-9645-0bf2040b1cbe)


At some point I will probably add a new Menu bar sub section, or move these to Settings. But for now since they are File operation related, I think its fine.