### PR TITLE
CI: Artifact Naming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,15 +49,18 @@ jobs:
           copy .\README.md .\Source\bin\${{ matrix.configuration }}
         shell: powershell
 
-      - name: Set Artifact Name
-        id: set-artifact-name
-        run: echo "artifact_name=$(echo "windows-${{ matrix.configuration }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-        shell: bash
+      - name: Get Short SHA
+        id: get-short-sha
+        run: |
+          $sha = '${{ github.sha }}'
+          $short_sha = $sha.Substring(0, 7)
+          echo "::set-output name=short_sha::$short_sha"
+        shell: pwsh
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set-artifact-name.outputs.artifact_name }}
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-windows-amd64
           path: Source\bin\${{ matrix.configuration }}
 
   build-linux:
@@ -101,16 +104,21 @@ jobs:
           .github/assets/appimage.sh
         shell: bash
 
-      - name: Publish Artifacts
+      - name: Get Short SHA
+        id: get-short-sha
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Publish Artifacts (Binary)
         uses: actions/upload-artifact@v4
         with:
-          name: linux-ubuntu-22.04-binary
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-ubuntu-22.04-binary
           path: Source/build/artifacts
 
-      - name: Publish Artifacts
+      - name: Publish Artifacts (AppImage)
         uses: actions/upload-artifact@v4
         with:
-          name: linux-ubuntu-22.04-appimage
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-ubuntu-22.04-appimage
           path: dolphin-memory-engine.AppImage
 
   build-macos-intel:
@@ -121,10 +129,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Dependencies
-        run: |
-          brew install cmake
-        shell: bash
+      # Current Runner has cmake we want by default; Omitting for now but restore if they stop bundling it
+      # - name: Install Dependencies
+      #   run: |
+      #     brew install --formula cmake
+      #   shell: bash
 
       - name: Initialize submodules
         run: git submodule update --init
@@ -147,8 +156,13 @@ jobs:
           cp ./Source/build/dolphin-memory-engine.dmg ./Source/build/artifacts/
         shell: bash
 
+      - name: Get Short SHA
+        id: get-short-sha
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: macOS-intel
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS-intel
           path: Source/build/artifacts

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -1,0 +1,157 @@
+name: 🔨 Build (TAG)
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-24.04
+    name: Clang-Format Check (TAG)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jidicula/clang-format-action@v4.14.0
+        with:
+          clang-format-version: '19'
+          check-path: Source
+
+  build-windows:
+    runs-on: windows-latest
+    name: 🪟 Windows x86_64 (TAG)
+    strategy:
+      matrix:
+        configuration: [Release]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Initialize submodules
+        run: git submodule update --init
+        shell: powershell
+        
+      - name: Set APP_VERSION for tags
+        run: echo "APP_VERSION=${{ github.ref_name }}" >> $env:GITHUB_ENV
+        shell: powershell
+
+      - name: Build
+        run: |
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.8.2\x64"
+          cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
+        shell: powershell
+
+      - name: Copy LICENSE, README
+        run: |
+          copy .\LICENSE .\Source\bin\${{ matrix.configuration }}
+          copy .\README.md .\Source\bin\${{ matrix.configuration }}
+        shell: powershell
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dolphin-memory-engine-${{ github.ref_name }}-windows-amd64
+          path: Source\bin\${{ matrix.configuration }}
+
+  build-linux:
+    runs-on: ubuntu-22.04
+    name: 🐧 Linux x86_64 (TAG)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install cmake libevdev-dev qt6-base-private-dev libqt6svg6 libqt6svg6-dev libgl1-mesa-dev libfuse2
+        shell: bash
+
+      - name: Install GCC 10 and G++ 10
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update
+          sudo apt-get install g++-10 gcc-10 -y
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 90
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 90
+
+      - name: Set APP_VERSION for tags
+        run: echo "APP_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          cmake Source -B Source/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build Source/build --parallel
+        shell: bash
+
+      - name: Copy LICENSE, README, Prepare Artifacts
+        run: |
+          mkdir Source/build/artifacts
+          cp ./README.md ./Source/build/artifacts/
+          cp ./LICENSE ./Source/build/artifacts/
+          cp ./Source/build/dolphin-memory-engine ./Source/build/artifacts/
+        shell: bash
+
+      - name: Package AppImage
+        run: |
+          .github/assets/appimage.sh
+        shell: bash
+
+      - name: Publish Artifacts (Binary)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dolphin-memory-engine-${{ github.ref_name }}-linux-ubuntu-22.04-binary
+          path: Source/build/artifacts
+
+      - name: Publish Artifacts (AppImage)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dolphin-memory-engine-${{ github.ref_name }}-linux-ubuntu-22.04-appimage
+          path: dolphin-memory-engine.AppImage
+
+  build-macos-intel:
+    runs-on: macos-13
+    name: 🍎 macOS Intel (TAG)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Current Runner has cmake we want by default; Omitting for now but restore if they stop bundling it
+      # - name: Install Dependencies
+      #   run: |
+      #     brew install --formula cmake
+      #   shell: bash
+
+      - name: Initialize submodules
+        run: git submodule update --init
+        
+      - name: Set APP_VERSION for tags
+        run: echo "APP_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Build
+        run: |
+          mkdir Source/build
+          cd Source/build
+          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)"
+          make
+          echo -e "\n" | ../../Tools/MacDeploy.sh
+        shell: bash
+
+      - name: Copy LICENSE, README, Prepare Artifacts
+        run: |
+          mkdir Source/build/artifacts
+          cp ./README.md ./Source/build/artifacts/
+          cp ./LICENSE ./Source/build/artifacts/
+          cp ./Tools/MacSetup.sh ./Source/build/artifacts/
+          cp ./Source/build/dolphin-memory-engine.dmg ./Source/build/artifacts/
+        shell: bash
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dolphin-memory-engine-${{ github.ref_name }}-macOS-intel
+          path: Source/build/artifacts

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -6,12 +6,20 @@ project(dolphin-memory-engine)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(DEFINED ENV{GITHUB_SHA})
-    string(SUBSTRING "$ENV{GITHUB_SHA}" 0 7 VERSION_SHA) # Get the first 7 chars of the sha
-    set(APP_VERSION "${VERSION_SHA}")
-else()
-    string(TIMESTAMP CURRENT_DATE "%Y-%m-%d")
-    set(APP_VERSION dev-${CURRENT_DATE})
+# Tag run
+if(DEFINED ENV{APP_VERSION})
+    set(APP_VERSION $ENV{APP_VERSION})
+endif()
+
+# Non-tag run
+if(NOT DEFINED APP_VERSION)
+    if(DEFINED ENV{GITHUB_SHA})
+        string(SUBSTRING "$ENV{GITHUB_SHA}" 0 7 VERSION_SHA)
+        set(APP_VERSION ${VERSION_SHA})
+    else()
+        string(TIMESTAMP CURRENT_DATE "%Y-%m-%d")
+        set(APP_VERSION dev-${CURRENT_DATE})
+    endif()
 endif()
 
 configure_file(

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -6,6 +6,22 @@ project(dolphin-memory-engine)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(DEFINED ENV{GITHUB_SHA})
+    string(SUBSTRING "$ENV{GITHUB_SHA}" 0 7 VERSION_SHA) # Get the first 7 chars of the sha
+    set(APP_VERSION "${VERSION_SHA}")
+else()
+    string(TIMESTAMP CURRENT_DATE "%Y-%m-%d")
+    set(APP_VERSION dev-${CURRENT_DATE})
+endif()
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/version.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/version.h"
+)
+
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
+
+
 if(WIN32)
     set(DolphinProcessSrc DolphinProcess/Windows/WindowsDolphinProcess.cpp)
     set(ExeIconSrc Resources/exeicon.rc)

--- a/Source/include/version.h.in
+++ b/Source/include/version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define APP_VERSION "@APP_VERSION@"

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -5,11 +5,13 @@
 #include "GUI/MainWindow.h"
 #include "GUI/Settings/SConfig.h"
 
+#include "version.h"
+
 int main(int argc, char** argv)
 {
   QApplication app(argc, argv);
   QApplication::setApplicationName("Dolphin Memory Engine");
-  QApplication::setApplicationVersion("1.2.5");
+  QApplication::setApplicationVersion(APP_VERSION);
 
   SConfig config;  // Initialize global settings object
 


### PR DESCRIPTION
Updates our CI tasks to:
* Have names similar to the initial thoughts in https://github.com/aldelaro5/dolphin-memory-engine/issues/136

Depending on how DME is built, the below will be the version string (shown in the title bar and About page)
* Locally built =  `dev-YYYY-MM-DD` 
* PR/master = `{commit}`
* Tags/releases = `{tag}`

Artifacts:
* PR/master = `dolphin-memory-engine-{commit}-{platform}`
* Tags/releases = `dolphin-memory-engine-{tag}-{platform}`


I was doing this manually on release, this makes releasing easier. In another PR consider directly auto-releasing/attaching the artifacts.