### PR TITLE
Revert "Externals: Qt6.8.2 for Windows"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.8.2\x64"
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.5.3\x64"
           cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
         shell: powershell
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -76,7 +76,7 @@ if (WIN32)
     find_package(Qt6Widgets QUIET)
 	  if (NOT Qt6Widgets_FOUND)
 		    message(STATUS "Qt package not found, using external lib")
-		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.8.2\\x64")
+		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.5.3\\x64")
 		    find_package(Qt6Widgets REQUIRED)
 	  endif ()
 else ()
@@ -174,7 +174,7 @@ if(WIN32)
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:Qt6::QModernWindowsStylePlugin>
+            $<TARGET_FILE:Qt6::QWindowsVistaStylePlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
     )
 endif(WIN32)


### PR DESCRIPTION
Reverts aldelaro5/dolphin-memory-engine#188

We are having issues for some systems without Visual Studio installed, temporarily reverting back to Qt6.5.3 until I have time to look into this.