### PR TITLE
Truncate filepath in status bar if > 50 chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Source/*.obj
 Source/*.tlog
 Source/*.VC.opendb
 Source/*.VC.db
+Source/.cache/
 Source/.vs/
 Source/.vscode/
 .vscode/

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -732,7 +732,10 @@ void MainWindow::updateStatusBar()
 
   if (!m_watcher->m_watchListFile.isEmpty())
   {
-    tags << m_watcher->m_watchListFile;
+    if (m_watcher->m_watchListFile.size() > 50)
+      tags << "..." + m_watcher->m_watchListFile.right(47);
+    else
+      tags << m_watcher->m_watchListFile;
   }
 
   const QSize actualIconSize{icon.actualSize(QSize(100, 100))};


### PR DESCRIPTION
Late on I want to change the overlay minimum size rules to allow shrinking DME beyond what is currently allowed.
This is more of a workaround to prevent an endless large width rather than a true fix, but it'll get the job done.

Note: Lowered to 50 chars for other long status bars

https://github.com/aldelaro5/dolphin-memory-engine/issues/201