### PR TITLE
Fix incorrect struct update loop bound

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1019,7 +1019,7 @@ void MemWatchModel::updateStructAddresses(MemWatchTreeNode* node)
       QVector<FieldDef*> fields = def->getFields();
       QVector<MemWatchTreeNode*> children = node->getChildren();
 
-      for (int i = 0; i < def->getFields().count(); ++i)
+      for (int i = 0; i < children.count(); ++i)
       {
         children[i]->getEntry()->setConsoleAddress(addr + fields[i]->getOffset());
         if (GUICommon::isContainerType(children[i]->getEntry()->getType()))


### PR DESCRIPTION
This fixes #208. This also fixes #213, though I don't entirely follow why.

When a struct is collapsed, there is only 1 child. Thus, `fields.count() > children.count()`, which will result in a segfault. We really want to iterate based on the children array, since those are the nodes we want to update.