### PR TITLE
Show Struct name in `Type` field and show no value for Struct itself if valid

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -384,6 +384,8 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
       case WATCH_COL_TYPE:
       {
         Common::MemType type = entry->getType();
+        if (type == Common::MemType::type_struct && !entry->getStructName().isEmpty())
+          return entry->getStructName();
         size_t length = entry->getLength();
         return GUICommon::getStringFromType(type, length);
       }
@@ -404,7 +406,7 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
           else if (!DolphinComm::DolphinAccessor::isValidConsoleAddress(entry->getActualAddress()))
             return QString("???");
           else
-            return QString("%1 definition loaded").arg(entry->getStructName());
+            return QString();
         }
         break;
       }


### PR DESCRIPTION
Resolves https://github.com/aldelaro5/dolphin-memory-engine/issues/214

- 'Value' field will be blank if there is no issues resolving the struct
- 'Type' field will be the name of the struct, or just the 'Struct' string from getStringFromType if there are issues retrieving it. 