### PR TITLE
Make struct children labels read-only

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -529,7 +529,10 @@ Qt::ItemFlags MemWatchModel::flags(const QModelIndex& index) const
 
   if (index.column() == WATCH_COL_LABEL)
   {
-    flags |= Qt::ItemIsEditable;
+    const bool parentContainer{parent->getEntry() != nullptr &&
+                               GUICommon::isContainerType(parent->getEntry()->getType())};
+    const Qt::ItemFlag itemIsEditable{!parentContainer ? Qt::ItemIsEditable : Qt::NoItemFlags};
+    flags |= itemIsEditable;
   }
   else if (index.column() == WATCH_COL_VALUE)
   {


### PR DESCRIPTION
This fixes #220 

If your watchlist contains a struct, double-clicking on the label of a struct's child would allow you to type out a new name. Though this change would be reflected in the tableview, collapsing and re-expanding the struct would undo the change. This is because we do not propagate this change to the actual struct definition. My thought is the correct behavior here is to not allow the record to be editable in the tableview.

What's nice is this means that double-clicking a child struct will cause the struct to expand, rather than renaming the label.