### PR TITLE
Crash fixes

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -905,7 +905,7 @@ void MemWatchModel::updateStructEntries(const QString structName)
 
 void MemWatchModel::updateStructNode(MemWatchTreeNode* node)
 {
-  if (!m_structDefMap.contains(node->getEntry()->getStructName()) &&
+  if (!m_structDefMap.contains(node->getEntry()->getStructName()) ||
       !m_structDefMap[node->getEntry()->getStructName()]->getFields().isEmpty())
   {
     while (node->hasChildren())

--- a/Source/GUI/StructEditor/StructEditorWidget.cpp
+++ b/Source/GUI/StructEditor/StructEditorWidget.cpp
@@ -566,7 +566,10 @@ void StructEditorWidget::updateStructReferenceNames(QString old_name, QString ne
   {
     for (QString target : m_structReferences[old_name])
     {
-      m_structRootNode->findNode(target)->getStructDef()->updateStructTypeLabel(old_name, new_name);
+      const StructTreeNode* const targetNode = m_structRootNode->findNode(target);
+      if (targetNode)
+        targetNode->getStructDef()->updateStructTypeLabel(old_name, new_name);
+
       if (m_nodeInDetailEditor != nullptr)
         m_structDetailModel->updateStructTypeLabel(old_name, new_name);
     }
@@ -583,8 +586,12 @@ void StructEditorWidget::updateStructReferenceNames(QString old_name, QString ne
     for (QString target : m_structPointerReferences[old_name])
     {
       if (target != old_name)
-        m_structRootNode->findNode(target)->getStructDef()->updateStructTypeLabel(old_name,
-                                                                                  new_name);
+      {
+        const StructTreeNode* const targetNode = m_structRootNode->findNode(target);
+        if (targetNode)
+          targetNode->getStructDef()->updateStructTypeLabel(old_name, new_name);
+      }
+
       if (m_nodeInDetailEditor != nullptr)
         m_structDetailModel->updateStructTypeLabel(old_name, new_name);
     }
@@ -608,9 +615,12 @@ void StructEditorWidget::updateStructReferenceFieldSize(StructTreeNode* node)
 
   for (QString target : m_structReferences[keyNameSpace])
   {
-    m_structRootNode->findNode(target)->getStructDef()->updateStructFieldSize(keyNameSpace,
-                                                                              structLength);
-    emit updateStructDetails(target);
+    const StructTreeNode* const targetNode = m_structRootNode->findNode(target);
+    if (targetNode)
+    {
+      targetNode->getStructDef()->updateStructFieldSize(keyNameSpace, structLength);
+      emit updateStructDetails(target);
+    }
   }
 }
 


### PR DESCRIPTION
The first commit fixes #224 and the second commit fixes #225.

I believe there was just a typo in `MemWatchModel::updateStructNode` because the second part of the if-statement is only evaluated if the struct is not present in the map, which would guarantee a segfault.

For the second crash, we just have some missing `nullptr` checks to add because structs deleted during an instance of the widget still exists in the `m_structReferences` map. It could make sense to try to remove the deleted struct from `m_structReferences`, but this could become really inefficient as the number of objects dependent on the deleted struct grow in size. So I think it's better to do this.