### PR TITLE
Set Struct Editor size limit to 0x5000

### DIFF
--- a/Source/GUI/StructEditor/StructEditorWidget.cpp
+++ b/Source/GUI/StructEditor/StructEditorWidget.cpp
@@ -20,6 +20,8 @@ public:
   LengthValidator(QObject* parent) : QValidator(parent) {}
   QValidator::State validate(QString& input, int& pos) const override
   {
+    constexpr int MAX_SIZE = 0x5000;
+
     (void)pos;
     if (input.isEmpty())
       return Intermediate;
@@ -30,7 +32,7 @@ public:
     if (!ok)
       return Invalid;
 
-    if (value > fmax(Common::GetMEM1Size(), Common::GetMEM2Size()))
+    if (value > MAX_SIZE)
       return Invalid;
 
     return Acceptable;


### PR DESCRIPTION
This fixes #228.

The behavior here is that if you type `0x600` for example and then try to type an additional `0`, it will not accept the last character.