### PR TITLE
Fix struct member updating on address change

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1011,25 +1011,22 @@ void MemWatchModel::updateStructAddresses(MemWatchTreeNode* node)
 
   StructDef* def = m_structDefMap[node->getEntry()->getStructName()];
 
-  if (def->getFields().count() != node->getChildren().count())
+  if (node->isExpanded())
+    updateStructNode(node);
+  else if (!node->getEntry()->hasAddressChanged())
+    return;
+  else
   {
-    if (node->isExpanded())
-      updateStructNode(node);
-    else if (!node->getEntry()->hasAddressChanged())
-      return;
-    else
-    {
-      u32 addr = node->getEntry()->getActualAddress();
-      node->getEntry()->updateActualAddress(addr);
-      QVector<FieldDef*> fields = def->getFields();
-      QVector<MemWatchTreeNode*> children = node->getChildren();
+    u32 addr = node->getEntry()->getActualAddress();
+    node->getEntry()->updateActualAddress(addr);
+    QVector<FieldDef*> fields = def->getFields();
+    QVector<MemWatchTreeNode*> children = node->getChildren();
 
-      for (int i = 0; i < children.count(); ++i)
-      {
-        children[i]->getEntry()->setConsoleAddress(addr + fields[i]->getOffset());
-        if (GUICommon::isContainerType(children[i]->getEntry()->getType()))
-          updateContainerAddresses(children[i]);
-      }
+    for (int i = 0; i < children.count(); ++i)
+    {
+      children[i]->getEntry()->setConsoleAddress(addr + fields[i]->getOffset());
+      if (GUICommon::isContainerType(children[i]->getEntry()->getType()))
+        updateContainerAddresses(children[i]);
     }
   }
 }


### PR DESCRIPTION
This fixes #213 (for real this time).

When a struct's address changes, it will call `MemWatchModel::updateStructAddresses`. If we have an expanded struct in our watchlist, then we were skipping address updating due to faling the check for `if (def->getFields().count() != node->getChildren().count())`. If we have reached this function, then we want to update all struct member addresses. We do not want to restrict this updating to only scenarios where we are adding or removing members (I guess that's what the check was for?).