### PR TITLE
Update 'Clear' and 'Open' to account for Structs

### DIFF
--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -93,7 +93,7 @@ void MainWindow::makeMenus()
   m_actOpenWatchList = new QAction(tr("&Open..."), this);
   m_actSaveWatchList = new QAction(tr("&Save"), this);
   m_actSaveAsWatchList = new QAction(tr("&Save as..."), this);
-  m_actClearWatchList = new QAction(tr("&Clear the watch list"), this);
+  m_actClearWatchList = new QAction(tr("&Clear watchlist and structs"), this);
   m_actImportFromCT = new QAction(tr("&Import from Cheat Engine's CT file..."), this);
   m_actExportAsCSV = new QAction(tr("&Export as CSV..."), this);
   m_actAutoloadLastFile = new QAction(tr("Auto-load last file"), this);

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -913,17 +913,21 @@ bool MemWatchWidget::saveAsWatchFile()
 
 void MemWatchWidget::clearWatchList()
 {
-  m_watchListFile.clear();
-  if (!m_watchModel->hasAnyNodes())
+  if (!m_watchModel->hasAnyNodes() && !m_structDefs->hasChildren())
+  {
+    m_watchListFile.clear();
     return;
+  }
 
-  const QString msg{tr("Are you sure you want to delete these watches and/or groups?")};
-  QMessageBox box(QMessageBox::Question, tr("Clear watch list confirmation"), msg,
+  const QString msg{tr("Are you sure you want to delete all watches and structs?")};
+  QMessageBox box(QMessageBox::Question, tr("Clear confirmation"), msg,
                   QMessageBox::Yes | QMessageBox::Cancel, this);
   box.setDefaultButton(QMessageBox::Yes);
   if (box.exec() != QMessageBox::Yes)
     return;
 
+  m_watchListFile.clear();
+  m_structDefs->removeChildren();
   m_watchModel->clearRoot();
 }
 

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -805,7 +805,7 @@ void MemWatchWidget::openWatchFile(const QString& fileName)
   {
     bool structsOnly = false;
     bool clearStructTree = false;
-    if (m_watchModel->hasAnyNodes())
+    if (m_watchModel->hasAnyNodes() || m_structDefs->hasChildren())
     {
       QMessageBox* questionBox = new QMessageBox(
           QMessageBox::Question, "Asking to merge lists",


### PR DESCRIPTION
* Updates some language
* Checks structs as well as watchlist for any merge prompt
* Change the fileref to only clear if confirmed when confirmation prompt appears

Resolves https://github.com/aldelaro5/dolphin-memory-engine/issues/223