### PR TITLE
CI: Update Actions & MacOS Runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           path: dolphin-memory-engine.AppImage
 
   build-macos-intel:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     name: 🍎 macOS Intel
 
     steps:

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -143,7 +143,7 @@ jobs:
             dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-binary.tar.gz
 
   build-macos-intel:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     name: 🍎 macOS Intel (TAG)
 
     steps:


### PR DESCRIPTION
Updated all actions to latest.

Address removal of macOS 13 runner:
https://github.com/actions/runner-images/issues/13046


macos-15-intel is the last supported Intel runner for macOS runners.
Future runners will be ARM, so we'll need to add Rosetta configurations if the intel runner is deprecated in a few years.