### PR TITLE
Fix crash on 'delete' with no fields in a struct

### DIFF
--- a/Source/GUI/StructEditor/StructDetailModel.cpp
+++ b/Source/GUI/StructEditor/StructDetailModel.cpp
@@ -273,6 +273,10 @@ void StructDetailModel::removePaddingFields(int count, int start)
 
 void StructDetailModel::removeFields(int start, int count)
 {
+  if (start == -1)
+  {
+    return;
+  }
   beginRemoveRows(QModelIndex(), start, start + count - 1);
 
   for (int i = start; i < start + count; ++i)


### PR DESCRIPTION
Resolves https://github.com/aldelaro5/dolphin-memory-engine/issues/244