### PR TITLE
Don't update collapsed/invisible entries

### DIFF
--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -75,17 +75,18 @@ bool MemWatchModel::updateNodeValueRecursive(MemWatchTreeNode* node, const QMode
     updateContainerAddresses(node);
 
   QVector<MemWatchTreeNode*> children = node->getChildren();
-  if (children.count() > 0)
+  for (MemWatchTreeNode* const child : children)
   {
-    for (MemWatchTreeNode* const child : children)
-    {
-      QModelIndex theIndex = index(child->getRow(), WATCH_COL_VALUE, parent);
-      readSucess = updateNodeValueRecursive(child, theIndex, readSucess);
-      if (!readSucess)
-        return false;
-      if (!GUICommon::g_valueEditing && !child->isGroup())
-        emit dataChanged(theIndex, theIndex);
-    }
+    // Don't bother update children that aren't visible
+    if (child->isGroup() && !child->isExpanded())
+      continue;
+
+    QModelIndex theIndex = index(child->getRow(), WATCH_COL_VALUE, parent);
+    readSucess = updateNodeValueRecursive(child, theIndex, readSucess);
+    if (!readSucess)
+      return false;
+    if (!GUICommon::g_valueEditing && !child->isGroup())
+      emit dataChanged(theIndex, theIndex);
   }
 
   MemWatchEntry* entry = node->getEntry();
@@ -99,15 +100,12 @@ bool MemWatchModel::freezeNodeValueRecursive(MemWatchTreeNode* node, const QMode
                                              bool writeSucess)
 {
   QVector<MemWatchTreeNode*> children = node->getChildren();
-  if (children.count() > 0)
+  for (MemWatchTreeNode* const child : children)
   {
-    for (MemWatchTreeNode* const child : children)
-    {
-      QModelIndex theIndex = index(child->getRow(), WATCH_COL_VALUE, parent);
-      writeSucess = freezeNodeValueRecursive(child, theIndex, writeSucess);
-      if (!writeSucess)
-        return false;
-    }
+    QModelIndex theIndex = index(child->getRow(), WATCH_COL_VALUE, parent);
+    writeSucess = freezeNodeValueRecursive(child, theIndex, writeSucess);
+    if (!writeSucess)
+      return false;
   }
 
   MemWatchEntry* entry = node->getEntry();


### PR DESCRIPTION
If a watch group is collapsed, we shouldn't waste CPU cycles updating these entries' values, since they cannot be seen by the user. For my system, when using a watch file containing >12,000 watches (Zephiles ported an existing Paper Mario: TTYD Cheat Engine watch file to DME with a lot of data points), this drops my peak CPU usage for DME from 4.1% to 2.7%.

`freezeNodeValueRecursive` is the next hotpath in terms of CPU usage, but obviously we want freezes to persist even if you collapse groups. I'd like to explore caching locked entries rather than performing entire tree traversals on every timer expiring, but that will be a bit more complex so I want to tackle that in a separate PR.