### PR TITLE
Add 8 byte integer support

### DIFF
--- a/Source/CheatEngineParser/CheatEngineParser.cpp
+++ b/Source/CheatEngineParser/CheatEngineParser.cpp
@@ -161,6 +161,8 @@ void CheatEngineParser::parseCheatEntry(MemWatchTreeNode* node, const bool useDo
           type = Common::MemType::type_halfword;
         else if (strVarType == "4 Byte Big Endian")
           type = Common::MemType::type_word;
+        else if (strVarType == "8 Byte Big Endian")
+          type = Common::MemType::type_doubleword;
         else if (strVarType == "Float Big Endian")
           type = Common::MemType::type_float;
         else

--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -36,6 +36,7 @@ enum class MemType
   type_byteArray,
   type_struct,
   type_ppc,
+  type_doubleword,
   type_none  // Placeholder for the entry of a child node of a collapsed container
 };
 

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -12,6 +12,7 @@ QStringList g_memTypeNames =
     QStringList({QCoreApplication::translate("Common", "Byte"),
                  QCoreApplication::translate("Common", "2 bytes (Halfword)"),
                  QCoreApplication::translate("Common", "4 bytes (Word)"),
+                 QCoreApplication::translate("Common", "8 bytes (Doubleword)"),
                  QCoreApplication::translate("Common", "Float"),
                  QCoreApplication::translate("Common", "Double"),
                  QCoreApplication::translate("Common", "String"),
@@ -46,6 +47,7 @@ QString getStringFromType(const Common::MemType type, const size_t length)
   case Common::MemType::type_byte:
   case Common::MemType::type_halfword:
   case Common::MemType::type_word:
+  case Common::MemType::type_doubleword:
   case Common::MemType::type_float:
   case Common::MemType::type_double:
   case Common::MemType::type_struct:

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -543,6 +543,10 @@ MemScanner::compareMemoryAsNumbers(const char* first, const char* second, const 
     if (m_memIsSigned)
       return compareMemoryAsNumbersWithType<s32>(first, second, offset, offsetInvert, bswapSecond);
     return compareMemoryAsNumbersWithType<u32>(first, second, offset, offsetInvert, bswapSecond);
+  case Common::MemType::type_doubleword:
+    if (m_memIsSigned)
+      return compareMemoryAsNumbersWithType<s64>(first, second, offset, offsetInvert, bswapSecond);
+    return compareMemoryAsNumbersWithType<u64>(first, second, offset, offsetInvert, bswapSecond);
   case Common::MemType::type_float:
     return compareMemoryAsNumbersWithType<float>(first, second, offset, offsetInvert, bswapSecond);
   case Common::MemType::type_double:
@@ -649,8 +653,8 @@ int MemScanner::getTermsNumForFilter(const MemScanner::ScanFilter filter)
 bool MemScanner::typeSupportsAdditionalOptions(const Common::MemType type)
 {
   return (type == Common::MemType::type_byte || type == Common::MemType::type_halfword ||
-          type == Common::MemType::type_word || type == Common::MemType::type_float ||
-          type == Common::MemType::type_double);
+          type == Common::MemType::type_word || type == Common::MemType::type_doubleword ||
+          type == Common::MemType::type_float || type == Common::MemType::type_double);
 }
 
 std::vector<u32> MemScanner::getResultsConsoleAddr() const


### PR DESCRIPTION
For Paper Mario TTYD, we have an instance where the game stores an 8 byte timer in memory, so we would like to add support for this data type in DME. I added `type_doubleword` to the end of `MemType` so that it does not break support for existing watch files.