### PR TITLE
Fix type mismatch on JSON parsing

### DIFF
--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -12,13 +12,13 @@ QStringList g_memTypeNames =
     QStringList({QCoreApplication::translate("Common", "Byte"),
                  QCoreApplication::translate("Common", "2 bytes (Halfword)"),
                  QCoreApplication::translate("Common", "4 bytes (Word)"),
-                 QCoreApplication::translate("Common", "8 bytes (Doubleword)"),
                  QCoreApplication::translate("Common", "Float"),
                  QCoreApplication::translate("Common", "Double"),
                  QCoreApplication::translate("Common", "String"),
                  QCoreApplication::translate("Common", "Array of bytes"),
                  QCoreApplication::translate("Common", "Struct"),
-                 QCoreApplication::translate("Common", "Assembly (PowerPC)")});
+                 QCoreApplication::translate("Common", "Assembly (PowerPC)"),
+                 QCoreApplication::translate("Common", "8 bytes (Doubleword)")});
 
 QStringList g_memBaseNames = QStringList({QCoreApplication::translate("Common", "Decimal"),
                                           QCoreApplication::translate("Common", "Hexadecimal"),


### PR DESCRIPTION
Sorry I didn't catch this in initial testing. I didn't realize JSON parsing was reliant on mapping from `g_memTypeNames`. Saving a .dmw containing an 8 Byte Endian value will cause floats, doubles, etc. to map to the wrong type. 

This fix will change the "Change Type" GUI dropdown ordering such that 8 Byte Big Endian is awkwardly at the end. Maybe in a separate PR we could instead make JSON parsing reliant on `Common::MemType` enum values since they are already an integral type? This might be helpful: https://stackoverflow.com/a/34964802