### PR TITLE
Adding a generic array type

### DIFF
--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -37,6 +37,7 @@ enum class MemType
   type_struct,
   type_ppc,
   type_doubleword,
+  type_array,
   type_none  // Placeholder for the entry of a child node of a collapsed container
 };
 

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -17,12 +17,9 @@ QStringList g_memTypeNames =
                  QCoreApplication::translate("Common", "String"),
                  QCoreApplication::translate("Common", "Array of bytes"),
                  QCoreApplication::translate("Common", "Struct"),
-<<<<<<< HEAD
                  QCoreApplication::translate("Common", "Assembly (PowerPC)"),
-                 QCoreApplication::translate("Common", "8 bytes (Doubleword)")});
-=======
+                 QCoreApplication::translate("Common", "8 bytes (Doubleword)"),
                  QCoreApplication::translate("Common", "Array")});
->>>>>>> c043db8 (Common, GUICommon: Added array type and type string.)
 
 QStringList g_memBaseNames = QStringList({QCoreApplication::translate("Common", "Decimal"),
                                           QCoreApplication::translate("Common", "Hexadecimal"),

--- a/Source/GUI/GUICommon.cpp
+++ b/Source/GUI/GUICommon.cpp
@@ -17,8 +17,12 @@ QStringList g_memTypeNames =
                  QCoreApplication::translate("Common", "String"),
                  QCoreApplication::translate("Common", "Array of bytes"),
                  QCoreApplication::translate("Common", "Struct"),
+<<<<<<< HEAD
                  QCoreApplication::translate("Common", "Assembly (PowerPC)"),
                  QCoreApplication::translate("Common", "8 bytes (Doubleword)")});
+=======
+                 QCoreApplication::translate("Common", "Array")});
+>>>>>>> c043db8 (Common, GUICommon: Added array type and type string.)
 
 QStringList g_memBaseNames = QStringList({QCoreApplication::translate("Common", "Decimal"),
                                           QCoreApplication::translate("Common", "Hexadecimal"),
@@ -52,6 +56,7 @@ QString getStringFromType(const Common::MemType type, const size_t length)
   case Common::MemType::type_double:
   case Common::MemType::type_struct:
   case Common::MemType::type_ppc:
+  case Common::MemType::type_array:
     return GUICommon::g_memTypeNames.at(static_cast<int>(type));
   case Common::MemType::type_string:
     return QString::fromStdString("string[" + std::to_string(length) + "]");
@@ -83,6 +88,7 @@ bool isContainerType(const Common::MemType type)
 {
   switch (type)
   {
+  case Common::MemType::type_array:
   case Common::MemType::type_struct:
     return true;
   default:

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -622,6 +622,7 @@ void MemViewer::updateDigitsPerBox()
   case Common::MemType::type_string:
   case Common::MemType::type_byteArray:
   case Common::MemType::type_struct:
+  case Common::MemType::type_array:
   case Common::MemType::type_none:
     m_digitsPerBox = 2;  // Shouldn't ever reach here
   }
@@ -748,6 +749,7 @@ QString MemViewer::getEditAllText() const
   case Common::MemType::type_string:
   case Common::MemType::type_byteArray:
   case Common::MemType::type_struct:
+  case Common::MemType::type_array:
   case Common::MemType::type_none:
     break;
   }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -92,10 +92,10 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_structSelect = new QComboBox(this);
   m_structSelect->addItems(m_structNames);
 
-  m_spnContainerSize = new QSpinBox(this);
-  m_spnContainerSize->setPrefix("");
-  m_spnContainerSize->setMinimum(1);
-  m_spnContainerSize->setMaximum(9999);
+  m_spnContainerCount = new QSpinBox(this);
+  m_spnContainerCount->setPrefix("");
+  m_spnContainerCount->setMinimum(1);
+  m_spnContainerCount->setMaximum(9999);
 
   m_btnSetupContainerEntry = new QPushButton("Setup Contents");
   connect(m_btnSetupContainerEntry, &QPushButton::clicked, this,
@@ -118,8 +118,8 @@ void DlgAddWatchEntry::makeLayouts()
   layout_type->addWidget(m_cmbTypes, 1);
   layout_type->addWidget(m_spnLength);
   layout_type->addWidget(m_structSelect);
-  layout_type->addWidget(m_spnContainerSize);
-  
+  layout_type->addWidget(m_spnContainerCount);
+
   QVBoxLayout* super_layout_type = new QVBoxLayout;
   super_layout_type->addLayout(layout_type);
   super_layout_type->addWidget(m_btnSetupContainerEntry);
@@ -178,7 +178,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     m_pointerWidget->hide();
     m_structSelect->setCurrentIndex(0);
     m_structSelect->hide();
-    m_spnContainerSize->hide();
+    m_spnContainerCount->hide();
     m_btnSetupContainerEntry->hide();
   }
   else
@@ -187,13 +187,13 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 
     m_spnLength->setValue(static_cast<int>(m_entry->getLength()));
     m_cmbTypes->setCurrentIndex(static_cast<int>(m_entry->getType()));
-    m_spnContainerSize->setValue(static_cast<int>(m_entry->getContainerCount()));
+    m_spnContainerCount->setValue(static_cast<int>(m_entry->getContainerCount()));
     if (m_entry->getType() == Common::MemType::type_string ||
         m_entry->getType() == Common::MemType::type_byteArray)
     {
       m_spnLength->show();
       m_structSelect->hide();
-      m_spnContainerSize->hide();
+      m_spnContainerCount->hide();
       m_btnSetupContainerEntry->hide();
     }
     else if (m_entry->getType() == Common::MemType::type_struct)
@@ -204,12 +204,12 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 
       m_structSelect->show();
       m_spnLength->hide();
-      m_spnContainerSize->hide();
+      m_spnContainerCount->hide();
       m_btnSetupContainerEntry->hide();
     }
     else if (m_entry->getType() == Common::MemType::type_array)
     {
-      m_spnContainerSize->show();
+      m_spnContainerCount->show();
       m_btnSetupContainerEntry->show();
       m_spnLength->hide();
       m_structSelect->hide();
@@ -218,7 +218,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     {
       m_spnLength->hide();
       m_structSelect->hide();
-      m_spnContainerSize->hide();
+      m_spnContainerCount->hide();
       m_btnSetupContainerEntry->hide();
     }
     m_txbLabel->setText(m_entry->getLabel());
@@ -371,28 +371,28 @@ void DlgAddWatchEntry::onTypeChange(int index)
   {
     m_spnLength->show();
     m_structSelect->hide();
-    m_spnContainerSize->hide();
+    m_spnContainerCount->hide();
     m_btnSetupContainerEntry->hide();
   }
   else if (theType == Common::MemType::type_struct)
   {
     m_spnLength->hide();
     m_structSelect->show();
-    m_spnContainerSize->hide();
+    m_spnContainerCount->hide();
     m_btnSetupContainerEntry->hide();
   }
   else if (theType == Common::MemType::type_array)
   {
     m_spnLength->hide();
     m_structSelect->hide();
-    m_spnContainerSize->show();
+    m_spnContainerCount->show();
     m_btnSetupContainerEntry->show();
   }
   else
   {
     m_spnLength->hide();
     m_structSelect->hide();
-    m_spnContainerSize->hide();
+    m_spnContainerCount->hide();
     m_btnSetupContainerEntry->hide();
   }
   m_entry->setTypeAndLength(theType, m_spnLength->value());
@@ -462,7 +462,7 @@ void DlgAddWatchEntry::accept()
     else
       m_entry->setStructName(QString());
     if (m_entry->getType() == Common::MemType::type_array)
-      m_entry->setContainerCount(m_spnContainerSize->value());
+      m_entry->setContainerCount(m_spnContainerCount->value());
     else
       m_entry->setContainerCount(1);
     setResult(QDialog::Accepted);
@@ -592,7 +592,7 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
 
 void DlgAddWatchEntry::onSetupContainerContents()
 {
-  MemWatchEntry* curEntry = m_entry->getContainerEntry();
+  MemWatchEntry* curEntry = new MemWatchEntry(m_entry->getContainerEntry());
   bool isNewEntry = curEntry == nullptr;
 
   DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, true, m_curArrayDepth + 1);

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -17,13 +17,17 @@
 
 DlgAddWatchEntry::DlgAddWatchEntry(const bool newEntry, MemWatchEntry* const entry,
                                    QVector<QString> const structs, QWidget* const parent,
-                                   bool isForStructField)
+                                   bool isForStructField, int arrayDepth)
     : QDialog(parent)
 {
   m_isForStructField = isForStructField;
   m_structNames = structs;
   m_structNames.push_front(QString());
-  setWindowTitle(newEntry ? "Add Watch" : "Edit Watch");
+  m_curArrayDepth = arrayDepth;
+  QString title = newEntry ? "Add Watch" : "Edit Watch";
+  if (arrayDepth > 0)
+    title += " for Container at level " + arrayDepth;
+  setWindowTitle(title);
   initialiseWidgets();
   makeLayouts();
   fillFields(entry);
@@ -87,6 +91,15 @@ void DlgAddWatchEntry::initialiseWidgets()
 
   m_structSelect = new QComboBox(this);
   m_structSelect->addItems(m_structNames);
+
+  m_spnContainerSize = new QSpinBox(this);
+  m_spnContainerSize->setPrefix("");
+  m_spnContainerSize->setMinimum(1);
+  m_spnContainerSize->setMaximum(9999);
+
+  m_btnSetupContainerEntry = new QPushButton("Setup Contents");
+  connect(m_btnSetupContainerEntry, &QPushButton::clicked, this,
+          &DlgAddWatchEntry::onSetupContainerContents);
 }
 
 void DlgAddWatchEntry::makeLayouts()
@@ -105,8 +118,14 @@ void DlgAddWatchEntry::makeLayouts()
   layout_type->addWidget(m_cmbTypes, 1);
   layout_type->addWidget(m_spnLength);
   layout_type->addWidget(m_structSelect);
+  layout_type->addWidget(m_spnContainerSize);
+  
+  QVBoxLayout* super_layout_type = new QVBoxLayout;
+  super_layout_type->addLayout(layout_type);
+  super_layout_type->addWidget(m_btnSetupContainerEntry);
+
   QWidget* widget_type = new QWidget;
-  widget_type->setLayout(layout_type);
+  widget_type->setLayout(super_layout_type);
   widget_type->setContentsMargins(0, 0, 0, 0);
   formLayout->addRow("Type:", widget_type);
 
@@ -159,6 +178,8 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     m_pointerWidget->hide();
     m_structSelect->setCurrentIndex(0);
     m_structSelect->hide();
+    m_spnContainerSize->hide();
+    m_btnSetupContainerEntry->hide();
   }
   else
   {
@@ -166,11 +187,14 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 
     m_spnLength->setValue(static_cast<int>(m_entry->getLength()));
     m_cmbTypes->setCurrentIndex(static_cast<int>(m_entry->getType()));
+    m_spnContainerSize->setValue(static_cast<int>(m_entry->getContainerCount()));
     if (m_entry->getType() == Common::MemType::type_string ||
         m_entry->getType() == Common::MemType::type_byteArray)
     {
       m_spnLength->show();
       m_structSelect->hide();
+      m_spnContainerSize->hide();
+      m_btnSetupContainerEntry->hide();
     }
     else if (m_entry->getType() == Common::MemType::type_struct)
     {
@@ -180,11 +204,22 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
 
       m_structSelect->show();
       m_spnLength->hide();
+      m_spnContainerSize->hide();
+      m_btnSetupContainerEntry->hide();
+    }
+    else if (m_entry->getType() == Common::MemType::type_array)
+    {
+      m_spnContainerSize->show();
+      m_btnSetupContainerEntry->show();
+      m_spnLength->hide();
+      m_structSelect->hide();
     }
     else
     {
       m_spnLength->hide();
       m_structSelect->hide();
+      m_spnContainerSize->hide();
+      m_btnSetupContainerEntry->hide();
     }
     m_txbLabel->setText(m_entry->getLabel());
     if (!m_isForStructField)
@@ -336,16 +371,29 @@ void DlgAddWatchEntry::onTypeChange(int index)
   {
     m_spnLength->show();
     m_structSelect->hide();
+    m_spnContainerSize->hide();
+    m_btnSetupContainerEntry->hide();
   }
   else if (theType == Common::MemType::type_struct)
   {
     m_spnLength->hide();
     m_structSelect->show();
+    m_spnContainerSize->hide();
+    m_btnSetupContainerEntry->hide();
+  }
+  else if (theType == Common::MemType::type_array)
+  {
+    m_spnLength->hide();
+    m_structSelect->hide();
+    m_spnContainerSize->show();
+    m_btnSetupContainerEntry->show();
   }
   else
   {
     m_spnLength->hide();
     m_structSelect->hide();
+    m_spnContainerSize->hide();
+    m_btnSetupContainerEntry->hide();
   }
   m_entry->setTypeAndLength(theType, m_spnLength->value());
   if (!m_isForStructField && validateAndSetAddress())
@@ -536,4 +584,16 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
   }
 
   contextMenu->popup(lbl->mapToGlobal(pos));
+}
+
+void DlgAddWatchEntry::onSetupContainerContents()
+{
+  MemWatchEntry* curEntry = m_entry->getContainerEntry();
+  bool isNewEntry = curEntry == nullptr;
+
+  DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, m_isForStructField, m_curArrayDepth + 1);
+  if (dlg.exec() == QDialog::Accepted)
+  {
+    m_entry->setContainerEntry(dlg.stealEntry());
+  }
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -97,9 +97,12 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_spnContainerCount->setMinimum(1);
   m_spnContainerCount->setMaximum(9999);
 
-  m_btnSetupContainerEntry = new QPushButton("Setup Contents");
+  m_btnSetupContainerEntry = new QPushButton("Setup Contents", this);
   connect(m_btnSetupContainerEntry, &QPushButton::clicked, this,
           &DlgAddWatchEntry::onSetupContainerContents);
+
+  m_lblContainerType = new QLabel(this);
+  m_lblContainerType->setText(noContainerSetText);
 }
 
 void DlgAddWatchEntry::makeLayouts()
@@ -122,6 +125,7 @@ void DlgAddWatchEntry::makeLayouts()
 
   QVBoxLayout* super_layout_type = new QVBoxLayout;
   super_layout_type->addLayout(layout_type);
+  super_layout_type->addWidget(m_lblContainerType);
   super_layout_type->addWidget(m_btnSetupContainerEntry);
 
   QWidget* widget_type = new QWidget;
@@ -179,6 +183,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
     m_structSelect->setCurrentIndex(0);
     m_structSelect->hide();
     m_spnContainerCount->hide();
+    m_lblContainerType->hide();
     m_btnSetupContainerEntry->hide();
   }
   else
@@ -194,6 +199,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
       m_spnLength->show();
       m_structSelect->hide();
       m_spnContainerCount->hide();
+      m_lblContainerType->hide();
       m_btnSetupContainerEntry->hide();
     }
     else if (m_entry->getType() == Common::MemType::type_struct)
@@ -205,11 +211,14 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
       m_structSelect->show();
       m_spnLength->hide();
       m_spnContainerCount->hide();
+      m_lblContainerType->hide();
       m_btnSetupContainerEntry->hide();
     }
     else if (m_entry->getType() == Common::MemType::type_array)
     {
       m_spnContainerCount->show();
+      m_lblContainerType->show();
+      m_lblContainerType->setText(getContainerTypeText(m_entry));
       m_btnSetupContainerEntry->show();
       m_spnLength->hide();
       m_structSelect->hide();
@@ -219,6 +228,7 @@ void DlgAddWatchEntry::fillFields(MemWatchEntry* entry)
       m_spnLength->hide();
       m_structSelect->hide();
       m_spnContainerCount->hide();
+      m_lblContainerType->hide();
       m_btnSetupContainerEntry->hide();
     }
     m_txbLabel->setText(m_entry->getLabel());
@@ -372,6 +382,7 @@ void DlgAddWatchEntry::onTypeChange(int index)
     m_spnLength->show();
     m_structSelect->hide();
     m_spnContainerCount->hide();
+    m_lblContainerType->hide();
     m_btnSetupContainerEntry->hide();
   }
   else if (theType == Common::MemType::type_struct)
@@ -379,6 +390,7 @@ void DlgAddWatchEntry::onTypeChange(int index)
     m_spnLength->hide();
     m_structSelect->show();
     m_spnContainerCount->hide();
+    m_lblContainerType->hide();
     m_btnSetupContainerEntry->hide();
   }
   else if (theType == Common::MemType::type_array)
@@ -386,6 +398,7 @@ void DlgAddWatchEntry::onTypeChange(int index)
     m_spnLength->hide();
     m_structSelect->hide();
     m_spnContainerCount->show();
+    m_lblContainerType->show();
     m_btnSetupContainerEntry->show();
   }
   else
@@ -393,6 +406,7 @@ void DlgAddWatchEntry::onTypeChange(int index)
     m_spnLength->hide();
     m_structSelect->hide();
     m_spnContainerCount->hide();
+    m_lblContainerType->hide();
     m_btnSetupContainerEntry->hide();
   }
   m_entry->setTypeAndLength(theType, m_spnLength->value());
@@ -422,6 +436,14 @@ void DlgAddWatchEntry::accept()
     QString errorMsg =
         tr("A struct name must be selected with the struct type, it cannot be an empty string");
     QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid Struct Type"),
+                                            errorMsg, QMessageBox::Ok, this);
+    errorBox->exec();
+  }
+  else if (m_entry->getType() == Common::MemType::type_array &&
+           m_entry->getContainerEntry() == nullptr)
+  {
+    QString errorMsg = tr("Must define the array contents");
+    QMessageBox* errorBox = new QMessageBox(QMessageBox::Critical, tr("Invalid Array Type"),
                                             errorMsg, QMessageBox::Ok, this);
     errorBox->exec();
   }
@@ -590,14 +612,37 @@ void DlgAddWatchEntry::onPointerOffsetContextMenuRequested(const QPoint& pos)
   contextMenu->popup(lbl->mapToGlobal(pos));
 }
 
+QString DlgAddWatchEntry::getContainerTypeText(MemWatchEntry* entry)
+{
+  if (!GUICommon::isContainerType(entry->getType()))
+    return GUICommon::getStringFromType(entry->getType());
+
+  if (entry->getType() == Common::MemType::type_struct)
+  {
+    return "Struct<" + entry->getStructName() + ">";
+  }
+
+  if (entry->getContainerEntry() == nullptr)
+    return noContainerSetText;
+
+  return GUICommon::getStringFromType(entry->getType()) + "<" +
+         getContainerTypeText(entry->getContainerEntry()) + ">";
+}
+
 void DlgAddWatchEntry::onSetupContainerContents()
 {
-  MemWatchEntry* curEntry = new MemWatchEntry(m_entry->getContainerEntry());
-  bool isNewEntry = curEntry == nullptr;
+  bool isNewEntry = true;
+  MemWatchEntry* curEntry = nullptr;
+  if (m_entry->getContainerEntry())
+  {
+    curEntry = new MemWatchEntry(m_entry->getContainerEntry());
+    isNewEntry = false;
+  }
 
   DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, true, m_curArrayDepth + 1);
   if (dlg.exec() == QDialog::Accepted)
   {
     m_entry->setContainerEntry(dlg.stealEntry());
+    m_lblContainerType->setText(getContainerTypeText(m_entry));
   }
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -26,7 +26,7 @@ DlgAddWatchEntry::DlgAddWatchEntry(const bool newEntry, MemWatchEntry* const ent
   m_curArrayDepth = arrayDepth;
   QString title = newEntry ? "Add Watch" : "Edit Watch";
   if (arrayDepth > 0)
-    title += " for Container at level " + arrayDepth;
+    title += QString(" for Container at level ") + QString::number(arrayDepth);
   setWindowTitle(title);
   initialiseWidgets();
   makeLayouts();
@@ -461,6 +461,10 @@ void DlgAddWatchEntry::accept()
       m_entry->setStructName(m_structNames[m_structSelect->currentIndex()]);
     else
       m_entry->setStructName(QString());
+    if (m_entry->getType() == Common::MemType::type_array)
+      m_entry->setContainerCount(m_spnContainerSize->value());
+    else
+      m_entry->setContainerCount(1);
     setResult(QDialog::Accepted);
     hide();
   }
@@ -591,7 +595,7 @@ void DlgAddWatchEntry::onSetupContainerContents()
   MemWatchEntry* curEntry = m_entry->getContainerEntry();
   bool isNewEntry = curEntry == nullptr;
 
-  DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, m_isForStructField, m_curArrayDepth + 1);
+  DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, true, m_curArrayDepth + 1);
   if (dlg.exec() == QDialog::Accepted)
   {
     m_entry->setContainerEntry(dlg.stealEntry());

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -18,7 +18,7 @@ class DlgAddWatchEntry : public QDialog
 {
 public:
   DlgAddWatchEntry(bool newEntry, MemWatchEntry* entry, QVector<QString> structs, QWidget* parent,
-                   bool isForStructField = false);
+                   bool isForStructField = false, int containerDepth = 0);
   ~DlgAddWatchEntry() override;
 
   DlgAddWatchEntry(const DlgAddWatchEntry&) = delete;
@@ -46,6 +46,7 @@ private:
   void removePointerOffset();
   void removeAllPointerOffset();
   void onPointerOffsetContextMenuRequested(const QPoint& pos);
+  void onSetupContainerContents();
 
   MemWatchEntry* m_entry{};
   AddressInputWidget* m_txbAddress{};
@@ -63,4 +64,7 @@ private:
   QComboBox* m_structSelect{};
   QVector<QString> m_structNames{};
   bool m_isForStructField;
+  QPushButton* m_btnSetupContainerEntry{};
+  QSpinBox* m_spnContainerSize{};
+  int m_curArrayDepth = 0;
 };

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -65,6 +65,6 @@ private:
   QVector<QString> m_structNames{};
   bool m_isForStructField;
   QPushButton* m_btnSetupContainerEntry{};
-  QSpinBox* m_spnContainerSize{};
+  QSpinBox* m_spnContainerCount{};
   int m_curArrayDepth = 0;
 };

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.h
@@ -46,6 +46,7 @@ private:
   void removePointerOffset();
   void removeAllPointerOffset();
   void onPointerOffsetContextMenuRequested(const QPoint& pos);
+  QString getContainerTypeText(MemWatchEntry* entry);
   void onSetupContainerContents();
 
   MemWatchEntry* m_entry{};
@@ -64,7 +65,10 @@ private:
   QComboBox* m_structSelect{};
   QVector<QString> m_structNames{};
   bool m_isForStructField;
-  QPushButton* m_btnSetupContainerEntry{};
   QSpinBox* m_spnContainerCount{};
+  QPushButton* m_btnSetupContainerEntry{};
+  QLabel* m_lblContainerType{};
   int m_curArrayDepth = 0;
+
+  const QString noContainerSetText = "Container Type Not Set";
 };

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -12,8 +12,8 @@
 DlgChangeType::DlgChangeType(QWidget* parent, const int typeIndex, const size_t length,
                              QVector<QString> structNames, QString curStructName,
                              size_t containerCount, MemWatchEntry* containerEntry)
-    : QDialog(parent), m_typeIndex(typeIndex), m_length(length), m_structNames(structNames),
-      m_containerCount(containerCount)
+    : QDialog(parent), m_typeIndex(typeIndex), m_length(length), m_containerCount(containerCount),
+      m_structNames(structNames)
 {
   m_structNames.push_front(QString());
   setWindowTitle("Change Type");
@@ -47,7 +47,7 @@ void DlgChangeType::initialiseWidgets()
   m_spnContainerCount->setPrefix("");
   m_spnContainerCount->setMinimum(1);
   m_spnContainerCount->setMaximum(9999);
-  m_spnContainerCount->setValue(m_containerCount);
+  m_spnContainerCount->setValue(static_cast<int>(m_containerCount));
 
   m_btnSetupContainerEntry = new QPushButton("Setup Contents");
   connect(m_btnSetupContainerEntry, &QPushButton::clicked, this,

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.cpp
@@ -7,10 +7,13 @@
 #include <QVBoxLayout>
 
 #include "../../GUICommon.h"
+#include "DlgAddWatchEntry.h"
 
 DlgChangeType::DlgChangeType(QWidget* parent, const int typeIndex, const size_t length,
-                             QVector<QString> structNames, QString curStructName)
-    : QDialog(parent), m_typeIndex(typeIndex), m_length(length), m_structNames(structNames)
+                             QVector<QString> structNames, QString curStructName,
+                             size_t containerCount, MemWatchEntry* containerEntry)
+    : QDialog(parent), m_typeIndex(typeIndex), m_length(length), m_structNames(structNames),
+      m_containerCount(containerCount)
 {
   m_structNames.push_front(QString());
   setWindowTitle("Change Type");
@@ -19,6 +22,9 @@ DlgChangeType::DlgChangeType(QWidget* parent, const int typeIndex, const size_t 
 
   if (m_structNames.contains(curStructName))
     m_structSelect->setCurrentIndex(static_cast<int>(m_structNames.indexOf(curStructName)));
+
+  if (containerEntry)
+    m_containerEntry = new MemWatchEntry(containerEntry);
 }
 
 void DlgChangeType::initialiseWidgets()
@@ -37,6 +43,16 @@ void DlgChangeType::initialiseWidgets()
   m_structSelect->addItems(m_structNames);
   m_structSelect->setCurrentIndex(0);
 
+  m_spnContainerCount = new QSpinBox(this);
+  m_spnContainerCount->setPrefix("");
+  m_spnContainerCount->setMinimum(1);
+  m_spnContainerCount->setMaximum(9999);
+  m_spnContainerCount->setValue(m_containerCount);
+
+  m_btnSetupContainerEntry = new QPushButton("Setup Contents");
+  connect(m_btnSetupContainerEntry, &QPushButton::clicked, this,
+          &DlgChangeType::onSetupContainerContents);
+
   connect(m_cmbTypes, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &DlgChangeType::onTypeChange);
 }
@@ -49,8 +65,14 @@ void DlgChangeType::makeLayouts()
   layout_type->addWidget(m_cmbTypes, 1);
   layout_type->addWidget(m_spnLength);
   layout_type->addWidget(m_structSelect);
+  layout_type->addWidget(m_spnContainerCount);
+
+  QVBoxLayout* super_layout_type = new QVBoxLayout;
+  super_layout_type->addLayout(layout_type);
+  super_layout_type->addWidget(m_btnSetupContainerEntry);
+
   QWidget* widget_type = new QWidget;
-  widget_type->setLayout(layout_type);
+  widget_type->setLayout(super_layout_type);
   widget_type->setContentsMargins(0, 0, 0, 0);
 
   QFormLayout* formLayout = new QFormLayout;
@@ -62,6 +84,11 @@ void DlgChangeType::makeLayouts()
     m_spnLength->hide();
   if (theType != Common::MemType::type_struct)
     m_structSelect->hide();
+  if (theType != Common::MemType::type_array)
+  {
+    m_btnSetupContainerEntry->hide();
+    m_spnContainerCount->hide();
+  }
 
   QDialogButtonBox* buttonBox =
       new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
@@ -73,6 +100,18 @@ void DlgChangeType::makeLayouts()
   main_layout->addStretch();
   main_layout->addWidget(buttonBox);
   setLayout(main_layout);
+}
+
+void DlgChangeType::onSetupContainerContents()
+{
+  MemWatchEntry* curEntry = m_containerEntry;
+  bool isNewEntry = curEntry == nullptr;
+
+  DlgAddWatchEntry dlg(isNewEntry, curEntry, m_structNames, this, true, m_curArrayDepth + 1);
+  if (dlg.exec() == QDialog::Accepted)
+  {
+    m_containerEntry = dlg.stealEntry();
+  }
 }
 
 int DlgChangeType::getTypeIndex() const
@@ -90,10 +129,23 @@ QString DlgChangeType::getStructName() const
   return m_structNames[m_structSelect->currentIndex()];
 }
 
+size_t DlgChangeType::getContainerCount() const
+{
+  return m_containerCount;
+}
+
+MemWatchEntry* DlgChangeType::getContainerEntry()
+{
+  MemWatchEntry* entry{m_containerEntry};
+  m_containerEntry = nullptr;
+  return entry;
+}
+
 void DlgChangeType::accept()
 {
   m_typeIndex = m_cmbTypes->currentIndex();
   m_length = m_spnLength->value();
+  m_containerCount = m_spnContainerCount->value();
   setResult(QDialog::Accepted);
   hide();
 }
@@ -105,16 +157,29 @@ void DlgChangeType::onTypeChange(int index)
   {
     m_structSelect->hide();
     m_spnLength->show();
+    m_btnSetupContainerEntry->hide();
+    m_spnContainerCount->hide();
   }
   else if (theType == Common::MemType::type_struct)
   {
     m_structSelect->show();
     m_spnLength->hide();
+    m_btnSetupContainerEntry->hide();
+    m_spnContainerCount->hide();
+  }
+  else if (theType == Common::MemType::type_array)
+  {
+    m_structSelect->hide();
+    m_spnLength->hide();
+    m_btnSetupContainerEntry->show();
+    m_spnContainerCount->show();
   }
   else
   {
     m_structSelect->hide();
     m_spnLength->hide();
+    m_btnSetupContainerEntry->hide();
+    m_spnContainerCount->hide();
   }
   adjustSize();
 }

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
@@ -4,28 +4,38 @@
 #include <QDialog>
 #include <QSpinBox>
 
+#include <MemoryWatch/MemWatchEntry.h>
+
 class DlgChangeType : public QDialog
 {
   Q_OBJECT
 
 public:
   DlgChangeType(QWidget* parent, int typeIndex, size_t length, QVector<QString> structNames,
-                QString curStructName);
+                QString curStructName, size_t containerCount, MemWatchEntry* containerEntry);
   int getTypeIndex() const;
   size_t getLength() const;
   QString getStructName() const;
+  size_t getContainerCount() const;
+  MemWatchEntry* getContainerEntry();
   void accept() override;
   void onTypeChange(int index);
 
 private:
   void initialiseWidgets();
   void makeLayouts();
+  void onSetupContainerContents();
 
   int m_typeIndex;
   size_t m_length;
+  size_t m_containerCount;
+  MemWatchEntry* m_containerEntry;
   QComboBox* m_cmbTypes{};
   QSpinBox* m_spnLength{};
   QWidget* m_lengthSelection{};
   QComboBox* m_structSelect{};
   QVector<QString> m_structNames{};
+  QPushButton* m_btnSetupContainerEntry{};
+  QSpinBox* m_spnContainerCount{};
+  int m_curArrayDepth = 0;
 };

--- a/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
+++ b/Source/GUI/MemWatcher/Dialogs/DlgChangeType.h
@@ -29,7 +29,7 @@ private:
   int m_typeIndex;
   size_t m_length;
   size_t m_containerCount;
-  MemWatchEntry* m_containerEntry;
+  MemWatchEntry* m_containerEntry{};
   QComboBox* m_cmbTypes{};
   QSpinBox* m_spnLength{};
   QWidget* m_lengthSelection{};

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1039,9 +1039,8 @@ void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
     deleteNode(getIndexFromTreeNode(child));
 
   MemWatchEntry* entry = node->getEntry();
-  u32 addr = entry->getActualAddress();
   std::vector<MemWatchTreeNode*> childNodes{};
-  for (int i = 0; i < node->getEntry()->getContainerCount(); i++)
+  for (size_t i = 0; i < node->getEntry()->getContainerCount(); i++)
   {
     MemWatchEntry* childEntry = new MemWatchEntry(node->getEntry()->getContainerEntry());
     QString childLabel = QString("[%1]").arg(i);
@@ -1070,12 +1069,13 @@ int MemWatchModel::getTotalContainerLength(MemWatchEntry* entry)
   if (entry->isBoundToPointer())
     return 4;
   if (!GUICommon::isContainerType(entry->getType()))
-    return Common::getSizeForType(entry->getType(), entry->getLength());
+    return static_cast<int>(Common::getSizeForType(entry->getType(), entry->getLength()));
   if (entry->getType() == Common::MemType::type_array && entry->getContainerEntry() != nullptr)
-    return entry->getContainerCount() * getTotalContainerLength(entry->getContainerEntry());
+    return static_cast<int>(entry->getContainerCount() *
+                            getTotalContainerLength(entry->getContainerEntry()));
   else if (entry->getType() == Common::MemType::type_struct &&
            m_structDefMap.contains(entry->getStructName()))
-    return m_structDefMap.find(entry->getStructName()).value()->getLength();
+    return static_cast<int>(m_structDefMap.find(entry->getStructName()).value()->getLength());
   return 0;
 }
 

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1001,6 +1001,8 @@ void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
   for (int i = 0; i < node->getEntry()->getContainerCount(); i++)
   {
     MemWatchEntry* childEntry = new MemWatchEntry(node->getEntry()->getContainerEntry());
+    childEntry->setLabel(QString("[%1] ").arg(i) + childEntry->getLabel());
+
     MemWatchTreeNode* child = new MemWatchTreeNode(childEntry, node);
     childNodes.push_back(child);
   }

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -415,6 +415,10 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
           else
             return QString();
         }
+        else if (entry->getType() == Common::MemType::type_array)
+        {
+          return QString("%1 entries in array.").arg(entry->getContainerCount());
+        }
         break;
       }
       default:
@@ -988,21 +992,19 @@ void MemWatchModel::expandStructNode(MemWatchTreeNode* node)
 
 void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
 {
+  for (MemWatchTreeNode* child : node->getChildren())
+    deleteNode(getIndexFromTreeNode(child));
+
   MemWatchEntry* entry = node->getEntry();
   u32 addr = entry->getActualAddress();
   std::vector<MemWatchTreeNode*> childNodes{};
-  for (int i = 0; i < node->getEntry()->getCollectionCount(); i++)
+  for (int i = 0; i < node->getEntry()->getContainerCount(); i++)
   {
     MemWatchEntry* childEntry = new MemWatchEntry(node->getEntry()->getContainerEntry());
     MemWatchTreeNode* child = new MemWatchTreeNode(childEntry, node);
     childNodes.push_back(child);
-
-    if (child->getEntry()->getType() == Common::MemType::type_struct)
-      setupStructNode(child);
-    else if (child->getEntry()->getType() == Common::MemType::type_array)
-      setupArrayNode(child);
   }
-
+  addNodes(childNodes, getIndexFromTreeNode(node), true);
   updateArrayAddresses(node);
 }
 
@@ -1010,6 +1012,23 @@ void MemWatchModel::collapseArrayNode(MemWatchTreeNode* node)
 {
   while (node->hasChildren())
     deleteNode(getIndexFromTreeNode(node->getChildren()[0]));
+
+  addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
+           getIndexFromTreeNode(node), true);
+}
+
+int MemWatchModel::getTotalContainerLength(MemWatchEntry* entry)
+{
+  if (entry->isBoundToPointer())
+    return 4;
+  if (!GUICommon::isContainerType(entry->getType()))
+    return Common::getSizeForType(entry->getType(), entry->getLength());
+  if (entry->getType() == Common::MemType::type_array && entry->getContainerEntry() != nullptr)
+    return entry->getContainerCount() * getTotalContainerLength(entry->getContainerEntry());
+  else if (entry->getType() == Common::MemType::type_struct &&
+           m_structDefMap.contains(entry->getStructName()))
+    return m_structDefMap.find(entry->getStructName()).value()->getLength();
+  return 0;
 }
 
 void MemWatchModel::collapseContainerNode(MemWatchTreeNode* node)
@@ -1073,15 +1092,15 @@ void MemWatchModel::updateStructAddresses(MemWatchTreeNode* node)
 
 void MemWatchModel::updateArrayAddresses(MemWatchTreeNode* node)
 {
-  if (!node->getEntry()->hasAddressChanged())
+  if (!node->isExpanded())
     return;
 
   u32 addr = node->getEntry()->getActualAddress();
   node->getEntry()->updateActualAddress(addr);
   QVector<MemWatchTreeNode*> children = node->getChildren();
-  u32 entrySize =
-      Common::getSizeForType(node->getEntry()->getType(), node->getEntry()->getLength());
 
+  MemWatchEntry* containerEntry = node->getEntry()->getContainerEntry();
+  u32 entrySize = getTotalContainerLength(containerEntry);
 
   for (int i = 0; i < children.count(); i++)
   {

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -434,6 +434,11 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
         static const QIcon s_structIcon(":/struct2.svg");
         return s_structIcon;
       }
+      else if (entry->getType() == Common::MemType::type_array)
+      {
+        static const QIcon s_arrayIcon(":/array.svg");
+        return s_arrayIcon;
+      }
     }
   }
   else
@@ -825,12 +830,21 @@ QModelIndex MemWatchModel::getIndexFromTreeNode(const MemWatchTreeNode* const no
 
 void MemWatchModel::setupStructNode(MemWatchTreeNode* node)
 {
+  bool wasExpanded = node->isExpanded();
+  collapseStructNode(node);
+  removeNodeFromStructNodeMap(node, true);
+
   if (m_structDefMap.contains(node->getEntry()->getStructName()))
   {
     addNodeToStructNodeMap(node);
     if (!m_structDefMap[node->getEntry()->getStructName()]->getFields().isEmpty())
-      addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
-               getIndexFromTreeNode(node), true);
+    {
+      if (wasExpanded)
+        expandStructNode(node);
+      else
+        addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
+                 getIndexFromTreeNode(node), true);
+    }
   }
 }
 
@@ -841,11 +855,11 @@ void MemWatchModel::addNodeToStructNodeMap(MemWatchTreeNode* node)
     return;
   if (!m_structNodes.contains(name))
     m_structNodes.insert(name, {node});
-  else
+  else if (!m_structNodes[name].contains(node))
     m_structNodes[name].push_back(node);
 }
 
-void MemWatchModel::removeNodeFromStructNodeMap(MemWatchTreeNode* node)
+void MemWatchModel::removeNodeFromStructNodeMap(MemWatchTreeNode* node, bool allEntries)
 {
   QList<MemWatchTreeNode*> queue{node};
 
@@ -860,13 +874,22 @@ void MemWatchModel::removeNodeFromStructNodeMap(MemWatchTreeNode* node)
     if (!curNode->isGroup() && curNode->getEntry() &&
         curNode->getEntry()->getType() == Common::MemType::type_struct)
     {
-      QString name = curNode->getEntry()->getStructName();
-      if (name.isEmpty() || m_structNodes.isEmpty() || !m_structNodes.contains(name) ||
-          m_structNodes[name].isEmpty() || !m_structNodes[name].contains(node))
-        return;
-      m_structNodes[name].remove(m_structNodes[name].indexOf(node));
-      if (m_structNodes[name].isEmpty())
-        m_structNodes.remove(name);
+      QStringList names{};
+      if (allEntries)
+        names.append(m_structNodes.keys());
+      else
+        names.append(node->getEntry()->getStructName());
+
+      for (QString name : names)
+      {
+        if (name.isEmpty() || m_structNodes.isEmpty() || !m_structNodes.contains(name) ||
+            m_structNodes[name].isEmpty() || !m_structNodes[name].contains(node))
+          continue;
+
+        m_structNodes[name].remove(m_structNodes[name].indexOf(node));
+        if (m_structNodes[name].isEmpty())
+          m_structNodes.remove(name);
+      }
     }
   }
 }
@@ -1131,8 +1154,23 @@ void MemWatchModel::setupContainersRecursive(MemWatchTreeNode* node)
   }
 }
 
+void MemWatchModel::setContainerCount(MemWatchTreeNode* node, size_t count)
+{
+  node->getEntry()->setContainerCount(count);
+  setupArrayNode(node);
+}
+
 void MemWatchModel::setupArrayNode(MemWatchTreeNode* node)
 {
-  addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
-            getIndexFromTreeNode(node), true);
+  if (node->childrenCount() == 0)
+  {
+    addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
+             getIndexFromTreeNode(node), true);
+    return;
+  }
+  else if (node->isExpanded())
+  {
+    collapseArrayNode(node);
+    expandArrayNode(node);
+  }
 }

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -1038,7 +1038,6 @@ void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
   for (MemWatchTreeNode* child : node->getChildren())
     deleteNode(getIndexFromTreeNode(child));
 
-  MemWatchEntry* entry = node->getEntry();
   std::vector<MemWatchTreeNode*> childNodes{};
   for (size_t i = 0; i < node->getEntry()->getContainerCount(); i++)
   {

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -129,6 +129,8 @@ void MemWatchModel::changeType(const QModelIndex& index, Common::MemType type, s
     MemWatchTreeNode* node = static_cast<MemWatchTreeNode*>(index.internalPointer());
     if (entry->getType() == Common::MemType::type_struct)
       setupStructNode(node);
+    else if (entry->getType() == Common::MemType::type_array)
+      setupArrayNode(node);
   }
   emit dataChanged(index, index);
 }
@@ -191,8 +193,13 @@ void MemWatchModel::addNodes(const std::vector<MemWatchTreeNode*>& nodes,
   for (size_t i = 0; i < nodes.size(); i++)
   {
     MemWatchTreeNode* node = nodes[i];
-    if (!node->isGroup() && node->getEntry()->getType() == Common::MemType::type_struct)
-      setupStructNode(node);
+    if (!node->isGroup())
+    {
+      if (node->getEntry()->getType() == Common::MemType::type_struct)
+        setupStructNode(node);
+      else if (node->getEntry()->getType() == Common::MemType::type_array)
+        setupArrayNode(node);
+    }
   }
 }
 
@@ -234,6 +241,8 @@ void MemWatchModel::editEntry(MemWatchEntry* entry, const QModelIndex& index)
     {
       if (entry->getType() == Common::MemType::type_struct)
         setupStructNode(node);
+      else if (entry->getType() == Common::MemType::type_array)
+        setupArrayNode(node);
     }
     else if (node->isExpanded())
     {
@@ -942,6 +951,8 @@ void MemWatchModel::expandContainerNode(MemWatchTreeNode* node)
 {
   if (node->getEntry()->getType() == Common::MemType::type_struct)
     expandStructNode(node);
+  if (node->getEntry()->getType() == Common::MemType::type_array)
+    expandArrayNode(node);
 }
 
 void MemWatchModel::expandStructNode(MemWatchTreeNode* node)
@@ -975,10 +986,38 @@ void MemWatchModel::expandStructNode(MemWatchTreeNode* node)
   addNodes(childNodes, getIndexFromTreeNode(node), true);
 }
 
+void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
+{
+  MemWatchEntry* entry = node->getEntry();
+  u32 addr = entry->getActualAddress();
+  std::vector<MemWatchTreeNode*> childNodes{};
+  for (int i = 0; i < node->getEntry()->getCollectionCount(); i++)
+  {
+    MemWatchEntry* childEntry = new MemWatchEntry(node->getEntry()->getContainerEntry());
+    MemWatchTreeNode* child = new MemWatchTreeNode(childEntry, node);
+    childNodes.push_back(child);
+
+    if (child->getEntry()->getType() == Common::MemType::type_struct)
+      setupStructNode(child);
+    else if (child->getEntry()->getType() == Common::MemType::type_array)
+      setupArrayNode(child);
+  }
+
+  updateArrayAddresses(node);
+}
+
+void MemWatchModel::collapseArrayNode(MemWatchTreeNode* node)
+{
+  while (node->hasChildren())
+    deleteNode(getIndexFromTreeNode(node->getChildren()[0]));
+}
+
 void MemWatchModel::collapseContainerNode(MemWatchTreeNode* node)
 {
   if (node->getEntry()->getType() == Common::MemType::type_struct)
     collapseStructNode(node);
+  else if (node->getEntry()->getType() == Common::MemType::type_array)
+    collapseArrayNode(node);
 }
 
 void MemWatchModel::collapseStructNode(MemWatchTreeNode* node)
@@ -997,6 +1036,8 @@ void MemWatchModel::updateContainerAddresses(MemWatchTreeNode* node)
 {
   if (node->getEntry()->getType() == Common::MemType::type_struct)
     updateStructAddresses(node);
+  else if (node->getEntry()->getType() == Common::MemType::type_array)
+    updateArrayAddresses(node);
 }
 
 void MemWatchModel::updateStructAddresses(MemWatchTreeNode* node)
@@ -1030,6 +1071,26 @@ void MemWatchModel::updateStructAddresses(MemWatchTreeNode* node)
   }
 }
 
+void MemWatchModel::updateArrayAddresses(MemWatchTreeNode* node)
+{
+  if (!node->getEntry()->hasAddressChanged())
+    return;
+
+  u32 addr = node->getEntry()->getActualAddress();
+  node->getEntry()->updateActualAddress(addr);
+  QVector<MemWatchTreeNode*> children = node->getChildren();
+  u32 entrySize =
+      Common::getSizeForType(node->getEntry()->getType(), node->getEntry()->getLength());
+
+
+  for (int i = 0; i < children.count(); i++)
+  {
+    children[i]->getEntry()->setConsoleAddress(addr + (entrySize * i));
+    if (GUICommon::isContainerType(children[i]->getEntry()->getType()))
+      updateContainerAddresses(children[i]);
+  }
+}
+
 void MemWatchModel::setupContainersRecursive(MemWatchTreeNode* node)
 {
   if (node->getChildren().isEmpty())
@@ -1040,7 +1101,17 @@ void MemWatchModel::setupContainersRecursive(MemWatchTreeNode* node)
     if (child->getParent() == nullptr || child->isGroup())
       setupContainersRecursive(child);
     else if (GUICommon::isContainerType(child->getEntry()->getType()))
+    {
       if (child->getEntry()->getType() == Common::MemType::type_struct)
         setupStructNode(child);
+      if (child->getEntry()->getType() == Common::MemType::type_array)
+        setupArrayNode(child);
+    }
   }
+}
+
+void MemWatchModel::setupArrayNode(MemWatchTreeNode* node)
+{
+  addNodes({new MemWatchTreeNode(new MemWatchEntry(m_placeholderEntry))},
+            getIndexFromTreeNode(node), true);
 }

--- a/Source/GUI/MemWatcher/MemWatchModel.cpp
+++ b/Source/GUI/MemWatcher/MemWatchModel.cpp
@@ -394,6 +394,30 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
         if (type == Common::MemType::type_struct && !entry->getStructName().isEmpty())
           return entry->getStructName();
         size_t length = entry->getLength();
+        if (type == Common::MemType::type_array && entry->getContainerEntry() != nullptr)
+        {
+          std::stringstream prefix = {};
+          std::stringstream suffix = {};
+          prefix << GUICommon::getStringFromType(type, length).toStdString() + "<";
+          while (entry->getContainerEntry() != nullptr &&
+                 entry->getType() == Common::MemType::type_array)
+          {
+            suffix.seekp(0);
+            suffix << ">[" + std::to_string(entry->getContainerCount()) + "]";
+            entry = entry->getContainerEntry();
+            if (entry->getType() == Common::MemType::type_struct)
+              prefix << entry->getStructName().toStdString();
+            else if (entry->getType() == Common::MemType::type_array)
+            {
+              prefix << entry->getStructName().toStdString() + "<";
+            }
+            else
+              prefix << GUICommon::getStringFromType(entry->getType(), entry->getLength())
+                            .toStdString();
+          }
+          std::string typeOut = prefix.str() + suffix.str();
+          return QString().fromStdString(typeOut);
+        }
         return GUICommon::getStringFromType(type, length);
       }
       case WATCH_COL_ADDRESS:
@@ -414,10 +438,6 @@ QVariant MemWatchModel::data(const QModelIndex& index, int role) const
             return QString("???");
           else
             return QString();
-        }
-        else if (entry->getType() == Common::MemType::type_array)
-        {
-          return QString("%1 entries in array.").arg(entry->getContainerCount());
         }
         break;
       }
@@ -1024,7 +1044,10 @@ void MemWatchModel::expandArrayNode(MemWatchTreeNode* node)
   for (int i = 0; i < node->getEntry()->getContainerCount(); i++)
   {
     MemWatchEntry* childEntry = new MemWatchEntry(node->getEntry()->getContainerEntry());
-    childEntry->setLabel(QString("[%1] ").arg(i) + childEntry->getLabel());
+    QString childLabel = QString("[%1]").arg(i);
+    if (childEntry->getLabel() != "No label")
+      childLabel += childEntry->getLabel();
+    childEntry->setLabel(childLabel);
 
     MemWatchTreeNode* child = new MemWatchTreeNode(childEntry, node);
     childNodes.push_back(child);

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -103,11 +103,15 @@ private:
 
   void updateContainerAddresses(MemWatchTreeNode* node);
   void updateStructAddresses(MemWatchTreeNode* node);
+  void updateArrayAddresses(MemWatchTreeNode* node);
   void setupStructNode(MemWatchTreeNode* node);
   void addNodeToStructNodeMap(MemWatchTreeNode* node);
   void removeNodeFromStructNodeMap(MemWatchTreeNode* node);
   void expandStructNode(MemWatchTreeNode* node);
   void collapseStructNode(MemWatchTreeNode* node);
+  void setupArrayNode(MemWatchTreeNode* node);
+  void expandArrayNode(MemWatchTreeNode* node);
+  void collapseArrayNode(MemWatchTreeNode* node);
 
   MemWatchTreeNode* m_rootNode;
   MemWatchEntry* m_placeholderEntry;

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -86,6 +86,7 @@ public:
   void expandContainerNode(MemWatchTreeNode* node);
   void collapseContainerNode(MemWatchTreeNode* node);
   void setupContainersRecursive(MemWatchTreeNode* node);
+  void setContainerCount(MemWatchTreeNode* node, size_t count);
 
 signals:
   void dataEdited(const QModelIndex& index, const QVariant& value, int role);
@@ -106,7 +107,7 @@ private:
   void updateArrayAddresses(MemWatchTreeNode* node);
   void setupStructNode(MemWatchTreeNode* node);
   void addNodeToStructNodeMap(MemWatchTreeNode* node);
-  void removeNodeFromStructNodeMap(MemWatchTreeNode* node);
+  void removeNodeFromStructNodeMap(MemWatchTreeNode* node, bool allEntries = false);
   void expandStructNode(MemWatchTreeNode* node);
   void collapseStructNode(MemWatchTreeNode* node);
   void setupArrayNode(MemWatchTreeNode* node);

--- a/Source/GUI/MemWatcher/MemWatchModel.h
+++ b/Source/GUI/MemWatcher/MemWatchModel.h
@@ -112,6 +112,7 @@ private:
   void setupArrayNode(MemWatchTreeNode* node);
   void expandArrayNode(MemWatchTreeNode* node);
   void collapseArrayNode(MemWatchTreeNode* node);
+  int getTotalContainerLength(MemWatchEntry* entry);
 
   MemWatchTreeNode* m_rootNode;
   MemWatchEntry* m_placeholderEntry;

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -497,14 +497,19 @@ void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)
     {
       MemWatchEntry* entry = node->getEntry();
       int typeIndex = static_cast<int>(entry->getType());
-      DlgChangeType* dlg =
-          new DlgChangeType(this, typeIndex, entry->getLength(), m_structDefs->getStructNames(),
-                            entry->getStructName());
+      DlgChangeType* dlg = new DlgChangeType(
+          this, typeIndex, entry->getLength(), m_structDefs->getStructNames(),
+          entry->getStructName(), entry->getContainerCount(), entry->getContainerEntry());
       if (dlg->exec() == QDialog::Accepted)
       {
         Common::MemType theType = static_cast<Common::MemType>(dlg->getTypeIndex());
         if (theType == Common::MemType::type_struct && dlg->getStructName() != QString())
           entry->setStructName(dlg->getStructName());
+        if (theType == Common::MemType::type_array)
+        {
+          entry->setContainerCount(dlg->getContainerCount());
+          entry->setContainerEntry(dlg->getContainerEntry());
+        }
 
         m_watchModel->changeType(index, theType, dlg->getLength());
         m_hasUnsavedChanges = true;
@@ -519,6 +524,17 @@ void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)
         m_watchModel->editEntry(dlg.stealEntry(), index);
         m_hasUnsavedChanges = true;
       }
+    }
+
+    if (index.column() == MemWatchModel::WATCH_COL_VALUE &&
+        node->getEntry()->getType() == Common::MemType::type_array)
+    {
+      bool ok{};
+      size_t newCount =
+          QInputDialog::getInt(this, tr("Set Array Count"), tr("Array Count:"),
+                               node->getEntry()->getContainerCount(), 1, 9999, 1, &ok, Qt::Dialog);
+      if (ok)
+        m_watchModel->setContainerCount(node, newCount);
     }
   }
 }

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -530,9 +530,9 @@ void MemWatchWidget::onWatchDoubleClicked(const QModelIndex& index)
         node->getEntry()->getType() == Common::MemType::type_array)
     {
       bool ok{};
-      size_t newCount =
-          QInputDialog::getInt(this, tr("Set Array Count"), tr("Array Count:"),
-                               node->getEntry()->getContainerCount(), 1, 9999, 1, &ok, Qt::Dialog);
+      size_t newCount = QInputDialog::getInt(
+          this, tr("Set Array Count"), tr("Array Count:"),
+          static_cast<int>(node->getEntry()->getContainerCount()), 1, 9999, 1, &ok, Qt::Dialog);
       if (ok)
         m_watchModel->setContainerCount(node, newCount);
     }

--- a/Source/GUI/StructEditor/StructDetailModel.cpp
+++ b/Source/GUI/StructEditor/StructDetailModel.cpp
@@ -588,6 +588,27 @@ bool StructDetailModel::updateFieldEntry(MemWatchEntry* entry, const QModelIndex
         return false;
     }
   }
+  else if (oldEntry != nullptr && oldEntry->getType() == Common::MemType::type_array)
+  {
+    MemWatchEntry* oldContainerEntry = oldEntry->getContainerEntry();
+    while (oldContainerEntry && oldContainerEntry->getType() == Common::MemType::type_array)
+      oldContainerEntry = oldContainerEntry->getContainerEntry();
+
+    if (oldContainerEntry != nullptr && oldEntry->getType() == Common::MemType::type_struct)
+    {
+      if (oldContainerEntry->isBoundToPointer())
+        emit modifyStructPointerReference(m_baseNode->getNameSpace(),
+                                          oldContainerEntry->getStructName(), false);
+      else
+      {
+        bool ok = true;
+        emit modifyStructReference(m_baseNode->getNameSpace(), oldContainerEntry->getStructName(),
+                                   false, ok);
+        if (!ok)
+          return false;
+      }
+    }
+  }
 
   u32 fieldLen = 0;
   if (entry->isBoundToPointer())
@@ -613,6 +634,30 @@ bool StructDetailModel::updateFieldEntry(MemWatchEntry* entry, const QModelIndex
         return false;
     }
   }
+  else if (entry->getType() == Common::MemType::type_array)
+  {
+    fieldLen = getTotalContainerLength(entry);
+
+    MemWatchEntry* containerEntry = entry->getContainerEntry();
+    while (containerEntry != nullptr && containerEntry->getType() == Common::MemType::type_array)
+      containerEntry = containerEntry->getContainerEntry();
+
+    if (containerEntry != nullptr && containerEntry->getType() == Common::MemType::type_struct)
+    {
+      if (containerEntry->getStructName() == m_baseNode->getNameSpace())
+      {
+        return false;
+      }
+      else
+      {
+        bool ok = true;
+        emit modifyStructReference(m_baseNode->getNameSpace(), containerEntry->getStructName(),
+                                   true, ok);
+        if (!ok)
+          return false;
+      }
+    }
+  }
   else
     fieldLen = static_cast<u32>(Common::getSizeForType(entry->getType(), entry->getLength()));
 
@@ -629,6 +674,24 @@ bool StructDetailModel::updateFieldEntry(MemWatchEntry* entry, const QModelIndex
   updateFieldOffsets();
 
   return true;
+}
+
+int StructDetailModel::getTotalContainerLength(MemWatchEntry* entry)
+{
+  if (entry->isBoundToPointer())
+    return 4;
+  else if (entry->getType() != Common::MemType::type_array &&
+           entry->getType() != Common::MemType::type_struct)
+    return Common::getSizeForType(entry->getType(), entry->getLength());
+  else if (entry->getType() == Common::MemType::type_array && entry->getContainerEntry() != nullptr)
+    return entry->getContainerCount() * getTotalContainerLength(entry->getContainerEntry());
+  else if (entry->getType() == Common::MemType::type_struct)
+  {
+    int len = 0;
+    emit getStructLength(entry->getStructName(), len);
+    return len;
+  }
+  return 0;
 }
 
 FieldDef* StructDetailModel::getFieldByRow(int row)

--- a/Source/GUI/StructEditor/StructDetailModel.cpp
+++ b/Source/GUI/StructEditor/StructDetailModel.cpp
@@ -682,9 +682,10 @@ int StructDetailModel::getTotalContainerLength(MemWatchEntry* entry)
     return 4;
   else if (entry->getType() != Common::MemType::type_array &&
            entry->getType() != Common::MemType::type_struct)
-    return Common::getSizeForType(entry->getType(), entry->getLength());
+    return static_cast<int>(Common::getSizeForType(entry->getType(), entry->getLength()));
   else if (entry->getType() == Common::MemType::type_array && entry->getContainerEntry() != nullptr)
-    return entry->getContainerCount() * getTotalContainerLength(entry->getContainerEntry());
+    return static_cast<int>(entry->getContainerCount() *
+                            getTotalContainerLength(entry->getContainerEntry()));
   else if (entry->getType() == Common::MemType::type_struct)
   {
     int len = 0;

--- a/Source/GUI/StructEditor/StructDetailModel.h
+++ b/Source/GUI/StructEditor/StructDetailModel.h
@@ -47,6 +47,7 @@ public:
   void removeLastField();
   void clearFields(QModelIndexList indices);
   bool updateFieldEntry(MemWatchEntry* entry, const QModelIndex& index);
+  int getTotalContainerLength(MemWatchEntry* entry);
   FieldDef* getFieldByRow(int row);
   QModelIndex getLastIndex(int col = 0);
   QModelIndex getIndexAt(int row, int col = 0);
@@ -67,6 +68,7 @@ signals:
   void lengthChanged(u32 newLength);
   void modifyStructReference(QString nodeName, QString target, bool addIt, bool& ok);
   void modifyStructPointerReference(QString nodeName, QString target, bool addIt);
+  void getStructLength(const QString name, int& len);
 
 private:
   QString getFieldDetails(FieldDef* field) const;

--- a/Source/GUI/StructEditor/StructEditorWidget.cpp
+++ b/Source/GUI/StructEditor/StructEditorWidget.cpp
@@ -105,6 +105,8 @@ void StructEditorWidget::initialiseWidgets()
           &StructEditorWidget::onLengthChange);
   connect(m_structDetailModel, &StructDetailModel::modifyStructReference, this,
           &StructEditorWidget::onModifyStructReference);
+  connect(m_structDetailModel, &StructDetailModel::getStructLength, this,
+          &StructEditorWidget::getStructLength);
 
   m_structDetailView = new QTableView;
   m_structDetailView->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
@@ -638,6 +640,11 @@ void StructEditorWidget::checkStructDetailSave()
       onSaveStruct();
     }
   }
+}
+
+void StructEditorWidget::getStructLength(QString name, int& len)
+{
+  len = getStructMap().find(name).value()->getLength();
 }
 
 QStringList StructEditorWidget::checkForMapCycles(QMap<QString, QStringList> map, QString curName,

--- a/Source/GUI/StructEditor/StructEditorWidget.h
+++ b/Source/GUI/StructEditor/StructEditorWidget.h
@@ -81,6 +81,7 @@ private:
   void updateStructReferenceNames(QString old_name, QString new_name);
   void updateStructReferenceFieldSize(StructTreeNode* node);
   void checkStructDetailSave();
+  void getStructLength(QString name, int& len);
 
   void readStructDefTreeFromJson(const QJsonObject& json, QMap<QString, QString>& map);
 

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -44,21 +44,20 @@ MemWatchEntry::MemWatchEntry(MemWatchEntry* entry)
       m_absoluteBranch(entry->m_absoluteBranch), m_boundToPointer(entry->m_boundToPointer),
       m_pointerOffsets(entry->m_pointerOffsets), m_isValidPointer(entry->m_isValidPointer),
       m_length(entry->m_length), m_structName(entry->m_structName),
-      m_curActualAddress(entry->m_curActualAddress), 
-      m_collectionCount(entry->m_collectionCount)
+      m_curActualAddress(entry->m_curActualAddress), m_collectionCount(entry->m_collectionCount)
 {
   m_memory = new char[getSizeForType(entry->getType(), entry->getLength())];
   std::memcpy(m_memory, entry->getMemory(), getSizeForType(entry->getType(), entry->getLength()));
 
   if (entry->getContainerEntry() != nullptr)
-    m_collectionEntry = new MemWatchEntry(entry->m_collectionEntry);
+    m_containerEntry = new MemWatchEntry(entry->m_containerEntry);
 }
 
 MemWatchEntry::~MemWatchEntry()
 {
   delete[] m_memory;
   delete[] m_freezeMemory;
-  delete m_collectionEntry;
+  delete m_containerEntry;
 }
 
 QString MemWatchEntry::getLabel() const
@@ -213,13 +212,13 @@ void MemWatchEntry::setStructName(QString structName)
 
 MemWatchEntry* MemWatchEntry::getContainerEntry() const
 {
-  return m_collectionEntry;
+  return m_containerEntry;
 }
 
 void MemWatchEntry::setContainerEntry(MemWatchEntry* elementEntry)
 {
-  delete m_collectionEntry;
-  m_collectionEntry = elementEntry;
+  delete m_containerEntry;
+  m_containerEntry = elementEntry;
 }
 
 size_t MemWatchEntry::getContainerCount() const

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -44,7 +44,8 @@ MemWatchEntry::MemWatchEntry(MemWatchEntry* entry)
       m_absoluteBranch(entry->m_absoluteBranch), m_boundToPointer(entry->m_boundToPointer),
       m_pointerOffsets(entry->m_pointerOffsets), m_isValidPointer(entry->m_isValidPointer),
       m_length(entry->m_length), m_structName(entry->m_structName),
-      m_curActualAddress(entry->m_curActualAddress), m_collectionCount(m_collectionCount)
+      m_curActualAddress(entry->m_curActualAddress), 
+      m_collectionCount(entry->m_collectionCount)
 {
   m_memory = new char[getSizeForType(entry->getType(), entry->getLength())];
   std::memcpy(m_memory, entry->getMemory(), getSizeForType(entry->getType(), entry->getLength()));
@@ -57,6 +58,7 @@ MemWatchEntry::~MemWatchEntry()
 {
   delete[] m_memory;
   delete[] m_freezeMemory;
+  delete m_collectionEntry;
 }
 
 QString MemWatchEntry::getLabel() const
@@ -216,6 +218,7 @@ MemWatchEntry* MemWatchEntry::getContainerEntry() const
 
 void MemWatchEntry::setContainerEntry(MemWatchEntry* elementEntry)
 {
+  delete m_collectionEntry;
   m_collectionEntry = elementEntry;
 }
 
@@ -428,6 +431,14 @@ void MemWatchEntry::readFromJson(const QJsonObject& json)
   if (json["structName"] != QJsonValue::Undefined)
     setStructName(json["structName"].toString());
 
+  if (json["containerCount"] != QJsonValue::Undefined)
+  {
+    setContainerCount(static_cast<size_t>(json["containerCount"].toDouble()));
+    MemWatchEntry* containerEntry = new MemWatchEntry();
+    containerEntry->readFromJson(json["containerEntry"].toObject());
+    setContainerEntry(containerEntry);
+  }
+
   setSignedUnsigned(json["unsigned"].toBool());
   setBase(static_cast<Common::MemBase>(json["baseIndex"].toInt()));
   if (json["pointerOffsets"] != QJsonValue::Undefined)
@@ -463,6 +474,13 @@ void MemWatchEntry::writeToJson(QJsonObject& json) const
     json["length"] = static_cast<double>(getLength());
   else if (getType() == Common::MemType::type_struct)
     json["structName"] = getStructName();
+  else if (getType() == Common::MemType::type_array)
+  {
+    QJsonObject containerEntryJson{};
+    getContainerEntry()->writeToJson(containerEntryJson);
+    json["containerEntry"] = containerEntryJson;
+    json["containerCount"] = static_cast<double>(getContainerCount());
+  }
 
   json["baseIndex"] = static_cast<double>(getBase());
   if (isBoundToPointer())

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -44,7 +44,8 @@ MemWatchEntry::MemWatchEntry(MemWatchEntry* entry)
       m_absoluteBranch(entry->m_absoluteBranch), m_boundToPointer(entry->m_boundToPointer),
       m_pointerOffsets(entry->m_pointerOffsets), m_isValidPointer(entry->m_isValidPointer),
       m_length(entry->m_length), m_structName(entry->m_structName),
-      m_curActualAddress(entry->m_curActualAddress)
+      m_curActualAddress(entry->m_curActualAddress), 
+      m_collectionEntry(new MemWatchEntry(entry->m_collectionEntry)), m_collectionCount(m_collectionCount)
 {
   m_memory = new char[getSizeForType(entry->getType(), entry->getLength())];
   std::memcpy(m_memory, entry->getMemory(), getSizeForType(entry->getType(), entry->getLength()));
@@ -204,6 +205,26 @@ QString MemWatchEntry::getStructName() const
 void MemWatchEntry::setStructName(QString structName)
 {
   m_structName = structName;
+}
+
+MemWatchEntry* MemWatchEntry::getContainerEntry() const
+{
+  return m_collectionEntry;
+}
+
+void MemWatchEntry::setContainerEntry(MemWatchEntry* elementEntry)
+{
+  m_collectionEntry = elementEntry;
+}
+
+u32 MemWatchEntry::getCollectionCount()
+{
+  return m_collectionCount;
+}
+
+void MemWatchEntry::setCollectionCount(u32 size)
+{
+  m_collectionCount = size;
 }
 
 void MemWatchEntry::addOffset(const int offset)

--- a/Source/MemoryWatch/MemWatchEntry.cpp
+++ b/Source/MemoryWatch/MemWatchEntry.cpp
@@ -44,11 +44,13 @@ MemWatchEntry::MemWatchEntry(MemWatchEntry* entry)
       m_absoluteBranch(entry->m_absoluteBranch), m_boundToPointer(entry->m_boundToPointer),
       m_pointerOffsets(entry->m_pointerOffsets), m_isValidPointer(entry->m_isValidPointer),
       m_length(entry->m_length), m_structName(entry->m_structName),
-      m_curActualAddress(entry->m_curActualAddress), 
-      m_collectionEntry(new MemWatchEntry(entry->m_collectionEntry)), m_collectionCount(m_collectionCount)
+      m_curActualAddress(entry->m_curActualAddress), m_collectionCount(m_collectionCount)
 {
   m_memory = new char[getSizeForType(entry->getType(), entry->getLength())];
   std::memcpy(m_memory, entry->getMemory(), getSizeForType(entry->getType(), entry->getLength()));
+
+  if (entry->getContainerEntry() != nullptr)
+    m_collectionEntry = new MemWatchEntry(entry->m_collectionEntry);
 }
 
 MemWatchEntry::~MemWatchEntry()
@@ -217,12 +219,12 @@ void MemWatchEntry::setContainerEntry(MemWatchEntry* elementEntry)
   m_collectionEntry = elementEntry;
 }
 
-u32 MemWatchEntry::getCollectionCount()
+size_t MemWatchEntry::getContainerCount() const
 {
   return m_collectionCount;
 }
 
-void MemWatchEntry::setCollectionCount(u32 size)
+void MemWatchEntry::setContainerCount(size_t size)
 {
   m_collectionCount = size;
 }

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -53,6 +53,11 @@ public:
   QString getStructName() const;
   void setStructName(QString structName);
 
+  MemWatchEntry* getContainerEntry() const;
+  void setContainerEntry(MemWatchEntry* elementEntry);
+  u32 getCollectionCount();
+  void setCollectionCount(u32 size);
+
   Common::MemOperationReturnCode freeze();
 
   u32 getAddressForPointerLevel(int level) const;
@@ -87,4 +92,6 @@ private:
   size_t m_length = 1;
   QString m_structName;
   u32 m_curActualAddress;
+  MemWatchEntry* m_collectionEntry{};
+  u32 m_collectionCount = 0;
 };

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -55,8 +55,8 @@ public:
 
   MemWatchEntry* getContainerEntry() const;
   void setContainerEntry(MemWatchEntry* elementEntry);
-  u32 getCollectionCount();
-  void setCollectionCount(u32 size);
+  size_t getContainerCount() const;
+  void setContainerCount(size_t size);
 
   Common::MemOperationReturnCode freeze();
 
@@ -93,5 +93,5 @@ private:
   QString m_structName;
   u32 m_curActualAddress;
   MemWatchEntry* m_collectionEntry{};
-  u32 m_collectionCount = 0;
+  size_t m_collectionCount = 1;
 };

--- a/Source/MemoryWatch/MemWatchEntry.h
+++ b/Source/MemoryWatch/MemWatchEntry.h
@@ -92,6 +92,6 @@ private:
   size_t m_length = 1;
   QString m_structName;
   u32 m_curActualAddress;
-  MemWatchEntry* m_collectionEntry{};
+  MemWatchEntry* m_containerEntry{};
   size_t m_collectionCount = 1;
 };

--- a/Source/Resources/array.svg
+++ b/Source/Resources/array.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   version="1"
+   id="svg14"
+   sodipodi:docname="array.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="34"
+     inkscape:cx="11.75"
+     inkscape:cy="12"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" />
+  <defs
+     id="defs18">
+    <marker
+       style="overflow:visible"
+       id="marker6"
+       refX="0"
+       refY="0"
+       orient="auto"
+       markerWidth="0.35"
+       markerHeight="0.35"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:none"
+         d="M 5,0 C 5,2.76 2.76,5 0,5 -2.76,5 -5,2.76 -5,0 c 0,-2.76 2.3,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path6" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker5"
+       refX="0"
+       refY="0"
+       orient="auto"
+       markerWidth="0.35"
+       markerHeight="0.35"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:none"
+         d="M 5,0 C 5,2.76 2.76,5 0,5 -2.76,5 -5,2.76 -5,0 c 0,-2.76 2.3,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path5" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Dot"
+       refX="0"
+       refY="0"
+       orient="auto"
+       markerWidth="0.35"
+       markerHeight="0.35"
+       viewBox="0 0 1 1"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:none"
+         d="M 5,0 C 5,2.76 2.76,5 0,5 -2.76,5 -5,2.76 -5,0 c 0,-2.76 2.3,-5 5,-5 2.76,0 5,2.24 5,5 z"
+         id="path17" />
+    </marker>
+  </defs>
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0057ab;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.844436,2.833776 H 1.5294117 V 21.166224 H 5.861858"
+     id="path2"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0057ab;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="m 18.16448,21.136812 h 4.315024 V 2.8043642 h -4.332446"
+     id="path2-2"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0057ab;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="m 7.897367,7.5861753 h 8.145826"
+     id="path1" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0057ab;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7.8973673,12.028382 H 16.043193"
+     id="path1-2" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#0057ab;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7.8973671,16.470588 H 16.043193"
+     id="path1-6" />
+</svg>

--- a/Source/Resources/resource.qrc
+++ b/Source/Resources/resource.qrc
@@ -9,5 +9,6 @@
         <file>status_unhooked.svg</file>
         <file>struct.svg</file>
         <file>struct2.svg</file>
+        <file>array.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This pull request is to add a generic array type (might be a start for #222 ). It is a container type that stores a base MemWatchEntry and uses it to determine the size of each array entry, then sets the appropriate base address for each entry in the array using that size.

<img width="1287" height="493" alt="image" src="https://github.com/user-attachments/assets/e10ad756-b4e9-4237-b97d-01b1ae38d24f" />

A button has been added to the edit watch dialog to setup contents.

<img width="591" height="569" alt="image" src="https://github.com/user-attachments/assets/0123a25a-4620-4453-a12b-30ba1855f034" />

This opens a new dialog to edit the array content MemWatchEntry.

<img width="494" height="418" alt="image" src="https://github.com/user-attachments/assets/654300e9-f030-46f1-9b3d-d45f1d4ae514" />

I've been using it for a about a month while fixing some bugs, so I believe it is relatively stable.


