### PR TITLE
Refactor: Reordered integer types logically in dropdowns (move Doubleword below Word)

### DIFF
--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -111,7 +111,25 @@ void MemScanWidget::initialiseWidgets()
   m_searchTerm2Widget->hide();
 
   m_cmbScanType = new QComboBox();
-  m_cmbScanType->addItems(GUICommon::g_memTypeNames);
+  // Manually add items in a logical order (Byte -> Halfword -> Word -> Doubleword -> Float...)
+  // The second number (0, 1, 2...) is the "UserData" which preserves the original ID.
+  
+  // Integers
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(0), 0); // Byte
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(1), 1); // 2 bytes (Halfword)
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(2), 2); // 4 bytes (Word)
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(9), 9); // 8 bytes (Doubleword) <-- MOVED UP!
+  
+  // Floating Point
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(3), 3); // Float
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(4), 4); // Double
+  
+  // Others
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(5), 5); // String
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(6), 6); // Array of bytes
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(7), 7); // Struct
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(8), 8); // Assembly
+  m_cmbScanType->addItem(GUICommon::g_memTypeNames.at(10), 10); // Array
   m_cmbScanType->setCurrentIndex(0);
   connect(m_cmbScanType, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &MemScanWidget::onScanMemTypeChanged);
@@ -252,7 +270,7 @@ MemScanner::ScanFilter MemScanWidget::getSelectedFilter() const
 
 void MemScanWidget::updateScanFilterChoices()
 {
-  Common::MemType newType = static_cast<Common::MemType>(m_cmbScanType->currentIndex());
+  Common::MemType newType = static_cast<Common::MemType>(m_cmbScanType->currentData().toInt());
   m_cmbScanFilter->clear();
   if (newType == Common::MemType::type_byteArray || newType == Common::MemType::type_string)
   {
@@ -430,7 +448,7 @@ void MemScanWidget::onFirstScan()
     return;
   }
 
-  m_memScanner->setType(static_cast<Common::MemType>(m_cmbScanType->currentIndex()));
+  m_memScanner->setType(static_cast<Common::MemType>(m_cmbScanType->currentData().toInt()));
   m_memScanner->setIsSigned(m_chkSignedScan->isChecked());
   m_memScanner->setBranchIsAbsolute(m_chkAbsoluteBranch->isChecked());
   m_memScanner->setEnforceMemAlignment(m_chkEnforceMemAlignment->isChecked());

--- a/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
+++ b/Source/GUI/MemWatcher/Dialogs/DlgAddWatchEntry.cpp
@@ -82,7 +82,25 @@ void DlgAddWatchEntry::initialiseWidgets()
   m_txbLabel = new QLineEdit(this);
 
   m_cmbTypes = new QComboBox(this);
-  m_cmbTypes->addItems(GUICommon::g_memTypeNames);
+  // Manually add items in a logical order (Byte -> Halfword -> Word -> Doubleword -> Float...)
+  // The second number (0, 1, 2...) is the UserData to preserve the original ID.
+  
+  // Integers
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(0), 0); // Byte
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(1), 1); // 2 bytes (Halfword)
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(2), 2); // 4 bytes (Word)
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(9), 9); // 8 bytes (Doubleword) <-- Moved!
+  
+  // Floating Point
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(3), 3); // Float
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(4), 4); // Double
+  
+  // Others
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(5), 5); // String
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(6), 6); // Array of bytes
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(7), 7); // Struct
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(8), 8); // Assembly
+  m_cmbTypes->addItem(GUICommon::g_memTypeNames.at(10), 10); // Array
 
   m_spnLength = new QSpinBox(this);
   m_spnLength->setPrefix("Length: ");
@@ -560,7 +578,7 @@ void DlgAddWatchEntry::updatePreview()
 
 void DlgAddWatchEntry::onLengthChanged()
 {
-  Common::MemType theType = static_cast<Common::MemType>(m_cmbTypes->currentIndex());
+  Common::MemType theType = static_cast<Common::MemType>(m_cmbTypes->currentData().toInt());
   m_entry->setTypeAndLength(theType, m_spnLength->value());
   if (!m_isForStructField && validateAndSetAddress())
     updatePreview();


### PR DESCRIPTION
### Summary
This PR reorders the data type dropdowns in the Memory Scanner and "Add Watch" dialog to group integer types logically. specifically moving "8 bytes (Doubleword)" to sit immediately below "4 bytes (Word)".

### Changes
- Modified `MemScanWidget.cpp` and `DlgAddWatchEntry.cpp` to manually populate the `ComboBox` items.
- Moved "Doubleword" from position 9 to position 3 (visually).

### Technical Details (Compatibility)
To ensure **DMW compatibility is preserved** (as requested in the issue):
- I used `addItem(name, UserData)` to explicitly map each item to its original `Common::MemType` ID.
- Updated the logic to read `currentData().toInt()` instead of `currentIndex()`.

This ensures that selecting "Doubleword" still returns ID 9 to the backend, preventing any data corruption or save file issues.