### PR TITLE
Memory Viewer; Adjust Size by Dragging Window Borders

### DIFF
--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -1284,7 +1284,8 @@ void MemViewer::renderSeparatorLines(QPainter& painter) const
                    m_columnHeaderHeight + m_hexAreaHeight);
   painter.drawLine(m_rowHeaderWidth - m_charWidthEm / 2, 0, m_rowHeaderWidth - m_charWidthEm / 2,
                    m_columnHeaderHeight + m_hexAreaHeight);
-  painter.drawLine(0, m_columnHeaderHeight, m_hexAsciiSeparatorPosX + 17 * m_charWidthEm,
+  painter.drawLine(0, m_columnHeaderHeight,
+                   m_hexAsciiSeparatorPosX + (std::max(m_numColumns, 13))*m_charWidthEm,
                    m_columnHeaderHeight);
 
   int divide_amt = std::max(SConfig::getInstance().getViewerNbrBytesSeparator(), m_sizeOfType);
@@ -1292,7 +1293,7 @@ void MemViewer::renderSeparatorLines(QPainter& painter) const
   if (SConfig::getInstance().getViewerNbrBytesSeparator() != 0)
   {
     int bytesSeparatorXPos = m_rowHeaderWidth - m_charWidthEm / 2 + m_charWidthEm / 4;
-    for (int i = 0; i < m_numColumns / divide_amt - 1; i++)
+    for (int i = 0; i < m_numColumns / divide_amt - 1 + (m_numColumns % divide_amt != 0); i++)
     {
       bytesSeparatorXPos += (m_charWidthEm * m_digitsPerBox) * (divide_amt / m_sizeOfType) +
                             (m_charWidthEm / 2) * (divide_amt / m_sizeOfType);
@@ -1320,8 +1321,9 @@ void MemViewer::renderColumnsHeaderText(QPainter& painter) const
     posXHeaderText += m_charWidthEm * m_digitsPerBox + m_charWidthEm / 2;
   }
 
+  double amtBuffer = std::max(0.5, (m_numColumns - 12.0) / 2.0 + 0.5);
   painter.drawText(m_hexAsciiSeparatorPosX +
-                       static_cast<int>(static_cast<double>(m_charWidthEm) * 2.5),
+                       static_cast<int>(static_cast<double>(m_charWidthEm) * amtBuffer),
                    m_charHeight, tr("Text (ASCII)"));
   painter.drawText(0, 0, 0, 0, 0, QString());
   painter.setPen(oldPenColor);

--- a/Source/GUI/MemViewer/MemViewer.h
+++ b/Source/GUI/MemViewer/MemViewer.h
@@ -28,6 +28,8 @@ public:
   MemViewer& operator=(MemViewer&&) = delete;
 
   QSize sizeHint() const override;
+  QSize minimumSizeHint() const override;
+  void calculateRowsAndCols();
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
   void contextMenuEvent(QContextMenuEvent* event) override;
@@ -44,6 +46,9 @@ public:
 signals:
   void memErrorOccured();
   void addWatch(MemWatchEntry* entry);
+
+protected:
+  void resizeEvent(QResizeEvent* event) override;
 
 private:
   enum class SelectionType
@@ -100,9 +105,9 @@ private:
   std::string memToStrFormatted(const int rowIndex, const int columnIndex) const;
   QString getEditAllText() const;
 
-  const int m_numRows = 16;
-  const int m_numColumns = 16;  // Should be a multiple of 16, or the header doesn't make much sense
-  const int m_numCells = m_numRows * m_numColumns;
+  int m_numRows = 16;
+  int m_numColumns = 16;  // Should be a multiple of 16, or the header doesn't make much sense
+  int m_numCells = m_numRows * m_numColumns;
   int m_memoryFontSize = -1;
   int m_StartBytesSelectionPosX = 0;
   int m_StartBytesSelectionPosY = 0;

--- a/Source/GUI/MemViewer/MemViewerWidget.cpp
+++ b/Source/GUI/MemViewer/MemViewerWidget.cpp
@@ -52,7 +52,6 @@ void MemViewerWidget::makeLayouts()
   main_layout->addLayout(controls_layout);
   main_layout->addWidget(m_memViewer);
   setLayout(main_layout);
-  layout()->setSizeConstraint(QLayout::SetFixedSize);
 }
 
 QTimer* MemViewerWidget::getUpdateTimer() const


### PR DESCRIPTION
# Memory Viewer; Adjust Size by Dragging Window Borders

Does as the title suggests. When enough space is present a new column/row will appear. Nothing should be hidden by the window being too small. All sizes work.

Solves #249

## What to test and look out for

- Making sure values shown are accurate (I made no adjustments to this, just changing the number of rows and columns made everything work just fine from my testing)
- Changing data types has no problem on the display
- Ensure nothing is hidden by the window. This usually means the last ASCII character is always visible. Logic is different for Double and Doubleword because they are 8 bytes in length and the "Text (ASCII)" part of the memory viewer requires a minimum of 12 characters to fit the "Text (ASCII)" text
- Adjusting zoom has it resize automatically
- Vertical Separators work properly
- Window size can't be smaller than properly showing 1 row and column no matter what

## Other

It's interesting to finally see an entire player struct at once. Makes it seem much smaller than what it was before with all the scrolling.