### PR TITLE
Automatic detection of the memory size.

### DIFF
--- a/Source/Common/CommonUtils.h
+++ b/Source/Common/CommonUtils.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <bit>
+#include <sstream>
+#include <utility>
+#include <vector>
+
 #ifdef __linux__
 #include <byteswap.h>
 #elif _WIN32
@@ -63,6 +68,21 @@ inline u64 bSwap64(u64 data)
 }
 #endif
 
+inline u16 fromBigEndianToSystemEndian16(const u16 data)
+{
+  return std::endian::native == std::endian::big ? data : bSwap16(data);
+}
+
+inline u32 fromBigEndianToSystemEndian32(const u32 data)
+{
+  return std::endian::native == std::endian::big ? data : bSwap32(data);
+}
+
+inline u64 fromBigEndianToSystemEndian64(const u64 data)
+{
+  return std::endian::native == std::endian::big ? data : bSwap64(data);
+}
+
 constexpr u32 NextPowerOf2(u32 value)
 {
   --value;
@@ -75,6 +95,12 @@ constexpr u32 NextPowerOf2(u32 value)
 
   return value;
 };
+
+template <typename T>
+bool isInBounds(const T low, const T value, const T high)
+{
+  return low <= value && value <= high;
+}
 
 inline u32 dolphinAddrToOffset(u32 addr, bool considerAram)
 {
@@ -165,5 +191,17 @@ inline u32 cacheIndexToOffset(u32 cacheIndex, bool considerAram)
     }
   }
   return cacheIndex;
+}
+
+inline std::vector<std::string> splitBySpace(const std::string& str)
+{
+  std::vector<std::string> parts;
+  std::istringstream iss(str);
+  std::string token;
+  while (iss >> token)
+  {
+    parts.push_back(std::move(token));
+  }
+  return parts;
 }
 }  // namespace Common

--- a/Source/Common/MemoryCommon.cpp
+++ b/Source/Common/MemoryCommon.cpp
@@ -11,14 +11,11 @@
 #include "../Common/CommonUtils.h"
 #include "../Common/PPC/PowerPCAssembler.h"
 #include "../Common/PPC/PowerPCDisassembler.h"
-#include "../GUI/Settings/SConfig.h"
 
 namespace Common
 {
 static u32 s_mem1_size_real;
 static u32 s_mem2_size_real;
-static u32 s_mem1_size;
-static u32 s_mem2_size;
 static u32 s_mem1_end;
 static u32 s_mem2_end;
 
@@ -30,14 +27,6 @@ u32 GetMEM2SizeReal()
 {
   return s_mem2_size_real;
 }
-u32 GetMEM1Size()
-{
-  return s_mem1_size;
-}
-u32 GetMEM2Size()
-{
-  return s_mem2_size;
-}
 u32 GetMEM1End()
 {
   return s_mem1_end;
@@ -47,12 +36,10 @@ u32 GetMEM2End()
   return s_mem2_end;
 }
 
-void UpdateMemoryValues()
+void UpdateMemoryValues(const u32 mem1size, const u32 mem2size)
 {
-  s_mem1_size_real = SConfig::getInstance().getMEM1Size();
-  s_mem2_size_real = SConfig::getInstance().getMEM2Size();
-  s_mem1_size = NextPowerOf2(GetMEM1SizeReal());
-  s_mem2_size = NextPowerOf2(GetMEM2SizeReal());
+  s_mem1_size_real = mem1size;
+  s_mem2_size_real = mem2size;
   s_mem1_end = MEM1_START + GetMEM1SizeReal();
   s_mem2_end = MEM2_START + GetMEM2SizeReal();
 }

--- a/Source/Common/MemoryCommon.h
+++ b/Source/Common/MemoryCommon.h
@@ -10,8 +10,6 @@ namespace Common
 {
 u32 GetMEM1SizeReal();
 u32 GetMEM2SizeReal();
-u32 GetMEM1Size();
-u32 GetMEM2Size();
 u32 GetMEM1End();
 u32 GetMEM2End();
 constexpr u32 MEM1_START = 0x80000000;
@@ -23,7 +21,7 @@ constexpr u32 ARAM_FAKESIZE = 0x2000000;
 constexpr u32 ARAM_START = 0x7E000000;
 constexpr u32 ARAM_END = 0x7F000000;
 
-void UpdateMemoryValues();
+void UpdateMemoryValues(u32 mem1size, u32 mem2size);
 
 enum class MemType
 {

--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -20,7 +20,6 @@ DolphinAccessor::DolphinStatus DolphinAccessor::m_status = DolphinStatus::unHook
 
 void DolphinAccessor::init()
 {
-  Common::UpdateMemoryValues();
   if (m_instance == nullptr)
   {
 #ifdef __linux__
@@ -30,6 +29,10 @@ void DolphinAccessor::init()
 #elif __APPLE__
     m_instance = new MacDolphinProcess();
 #endif
+  }
+  else
+  {
+    m_instance->reset();
   }
 }
 
@@ -53,6 +56,8 @@ void DolphinAccessor::hook()
   {
     m_status = DolphinStatus::hooked;
   }
+
+  Common::UpdateMemoryValues(m_instance->getMEM1Size(), m_instance->getMEM2Size());
 }
 
 void DolphinAccessor::unHook()
@@ -102,6 +107,21 @@ u64 DolphinAccessor::getARAMAddressStart()
 bool DolphinAccessor::isMEM2Present()
 {
   return m_instance ? m_instance->isMEM2Present() : false;
+}
+
+u32 DolphinAccessor::getARAMSize()
+{
+  return m_instance ? m_instance->getARAMSize() : 0;
+}
+
+u32 DolphinAccessor::getMEM1Size()
+{
+  return m_instance ? m_instance->getMEM1Size() : 0;
+}
+
+u32 DolphinAccessor::getMEM2Size()
+{
+  return m_instance ? m_instance->getMEM2Size() : 0;
 }
 
 bool DolphinAccessor::isValidConsoleAddress(const u32 address)

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -30,6 +30,9 @@ public:
   static bool isARAMAccessible();
   static u64 getARAMAddressStart();
   static bool isMEM2Present();
+  static u32 getARAMSize();
+  static u32 getMEM1Size();
+  static u32 getMEM2Size();
   static size_t getRAMTotalSize();
   static Common::MemOperationReturnCode readEntireRAM(char* buffer);
   static std::string getFormattedValueFromMemory(u32 ramIndex, Common::MemType memType,

--- a/Source/DolphinProcess/IDolphinProcess.h
+++ b/Source/DolphinProcess/IDolphinProcess.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 
 #include "../Common/CommonTypes.h"
+#include "../Common/CommonUtils.h"
 
 namespace DolphinComm
 {
@@ -12,6 +13,19 @@ class IDolphinProcess
 public:
   IDolphinProcess() = default;
   virtual ~IDolphinProcess() = default;
+
+  void reset()
+  {
+    m_PID = -1;
+    m_emuRAMAddressStart = 0;
+    m_emuARAMAdressStart = 0;
+    m_MEM2AddressStart = 0;
+    m_ARAMAccessible = false;
+    m_MEM2Present = false;
+    m_ARAMSize = 0;
+    m_MEM1Size = 0;
+    m_MEM2Size = 0;
+  }
 
   IDolphinProcess(const IDolphinProcess&) = delete;
   IDolphinProcess(IDolphinProcess&&) = delete;
@@ -29,12 +43,10 @@ public:
   bool isARAMAccessible() const { return m_ARAMAccessible; };
   u64 getARAMAddressStart() const { return m_emuARAMAdressStart; };
   u64 getMEM2AddressStart() const { return m_MEM2AddressStart; };
-  u64 getMEM1ToMEM2Distance() const
-  {
-    if (!m_MEM2Present)
-      return 0;
-    return m_MEM2AddressStart - m_emuRAMAddressStart;
-  };
+
+  u32 getARAMSize() const { return m_ARAMSize; }
+  u32 getMEM1Size() const { return m_MEM1Size; }
+  u32 getMEM2Size() const { return m_MEM2Size; }
 
 protected:
   int m_PID = -1;
@@ -43,5 +55,96 @@ protected:
   u64 m_MEM2AddressStart = 0;
   bool m_ARAMAccessible = false;
   bool m_MEM2Present = false;
+  u32 m_ARAMSize = 0;
+  u32 m_MEM1Size = 0;
+  u32 m_MEM2Size = 0;
+};
+
+constexpr u32 SYSTEM_INFO_OFFSET{0x00000018};
+
+struct SystemInfo
+{
+  u8 discMagicWordWii[4];
+  u8 discMagicWordGC[4];
+  u8 bootCode[4];
+  u8 version[4];
+  u32 physicalMemorySize;
+
+  bool isNull() const
+  {
+    return !(discMagicWordWii[0] || discMagicWordWii[1] || discMagicWordWii[2] ||
+             discMagicWordWii[3] || discMagicWordGC[0] || discMagicWordGC[1] ||
+             discMagicWordGC[2] || discMagicWordGC[3] || bootCode[0] || bootCode[1] ||
+             bootCode[2] || bootCode[3] || version[0] || version[1] || version[2] || version[3]);
+  }
+
+  bool isDiscMagicWordWiiKnown() const
+  {
+    // Only known value is 0x5D1C9EA3 (Nintendo Wii Disc).
+    return discMagicWordWii[0] == 0x5D && discMagicWordWii[1] == 0x1C &&
+           discMagicWordWii[2] == 0x9E && discMagicWordWii[3] == 0xA3;
+  }
+
+  bool isDiscMagicWordGCKnown() const
+  {
+    // Only known value is 0xC2339F3D (Nintendo GameCube Disc).
+    return discMagicWordGC[0] == 0xC2 && discMagicWordGC[1] == 0x33 && discMagicWordGC[2] == 0x9F &&
+           discMagicWordGC[3] == 0x3D;
+  }
+
+  bool isBootCodeKnown() const
+  {
+    // Only known values are:
+    // - 0x0D15EA5E (normal boot)
+    // - 0xE5207C22 (booted from jtag)
+    return (bootCode[0] == 0x0D && bootCode[1] == 0x15 && bootCode[2] == 0xEA &&
+            bootCode[3] == 0x5E) ||
+           (bootCode[0] == 0xE5 && bootCode[1] == 0x20 && bootCode[2] == 0x7C &&
+            bootCode[3] == 0x22);
+  }
+
+  u32 getPhysicalMemorySize() const { return Common::bSwap32(physicalMemorySize); }
+};
+
+constexpr u32 DOLPHIN_OS_GLOBALS_OFFSET{0x00000084};
+
+struct DolphinOSGlobals
+{
+  u8 padding[60];
+  u8 currentOSContextPhysicalAddress[4];
+  u8 previousOSInterruptMask[4];
+  u8 currentOSInterruptMask[4];
+  u8 tvMode[4];
+  u32 aramSize;
+  u8 currentOSContext[4];
+  u8 defaultOSThread[4];
+  u8 activeThreadQueueHeadThread[4];
+  u8 activeThreadQueueTailThread[4];
+  u8 currentOSThread[4];
+  u8 debugMonitorSize[4];
+  u8 debugMonitorLocation[4];
+  u32 simulatedMemorySize;
+  u8 dvdBi2Location[4];
+  u8 busClockSpeed[4];
+  u8 cpuClockSpeed[4];
+
+  u32 getARAMSize() const { return Common::bSwap32(aramSize); }
+  u32 getSimulatedMemorySize() const { return Common::bSwap32(simulatedMemorySize); }
+};
+
+constexpr u32 WII_SPECIFIC_INFO_OFFSET{0x00003100};
+
+struct WiiSpecificInfo
+{
+  u32 physicalMEM1Size;
+  u32 simulatedMEM1Size;
+  u8 unknown[16];
+  u32 physicalMEM2Size;
+  u32 simulatedMEM2Size;
+
+  u32 getPhysicalMEM1Size() const { return Common::bSwap32(physicalMEM1Size); }
+  u32 getSimulatedMEM1Size() const { return Common::bSwap32(simulatedMEM1Size); }
+  u32 getPhysicalMEM2Size() const { return Common::bSwap32(physicalMEM2Size); }
+  u32 getSimulatedMEM2Size() const { return Common::bSwap32(simulatedMEM2Size); }
 };
 }  // namespace DolphinComm

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -4,6 +4,8 @@
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
 
+#include <array>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
@@ -14,90 +16,151 @@
 #include <sys/uio.h>
 #include <vector>
 
+namespace
+{
+bool readFromRAM(const pid_t pid, const u64 ramAddress, const u32 offset, char* const buffer,
+                 const size_t size)
+{
+  iovec local{};
+  local.iov_base = buffer;
+  local.iov_len = size;
+
+  iovec remote{};
+  remote.iov_base = reinterpret_cast<void*>(ramAddress + offset);
+  remote.iov_len = size;
+
+  const ssize_t nread{process_vm_readv(pid, &local, 1, &remote, 1, 0)};
+  if (nread == -1)
+  {
+    // A more specific error type should be available in `errno` (if ever interested).
+    return false;
+  }
+
+  if (static_cast<size_t>(nread) != size)
+    return false;
+
+  return true;
+}
+}  // namespace
+
 namespace DolphinComm
 {
 bool LinuxDolphinProcess::obtainEmuRAMInformations()
 {
-  std::ifstream theMapsFile("/proc/" + std::to_string(m_PID) + "/maps");
-  std::string line;
-  bool MEM1Found = false;
-  while (getline(theMapsFile, line))
+  struct MemoryMapLine
   {
-    std::vector<std::string> lineData;
-    std::string token;
-    std::stringstream ss(line);
-    while (getline(ss, token, ' '))
+    const std::string line;
+    const u64 firstAddress;
+    const u64 secondAddress;
+    const u32 offset;
+  };
+
+  // Parse memory map of the Dolphin process.
+  std::vector<MemoryMapLine> memoryMapLines;
+  {
+    std::ifstream mapsFile("/proc/" + std::to_string(m_PID) + "/maps");
+
+    std::string line;
+    while (getline(mapsFile, line))
     {
-      if (!token.empty())
-        lineData.push_back(token);
+      if (line.find("/dev/shm/dolphin-emu") == std::string::npos &&
+          line.find("/dev/shm/dolphinmem") == std::string::npos)
+        continue;
+
+      const std::vector<std::string> lineParts{Common::splitBySpace(line)};
+      if (lineParts.size() < 3)
+        continue;
+
+      const std::size_t indexDash{lineParts[0].find('-')};
+      const std::string firstAddressStr{"0x" + lineParts[0].substr(0, indexDash)};
+      const std::string secondAddressStr{"0x" + lineParts[0].substr(indexDash + 1)};
+      const u64 firstAddress{std::stoul(firstAddressStr, nullptr, 16)};
+      const u64 secondAddress{std::stoul(secondAddressStr, nullptr, 16)};
+      const std::string offsetStr("0x" + lineParts[2]);
+      const u32 offset{static_cast<u32>(std::stoul(offsetStr, nullptr, 16))};
+      memoryMapLines.push_back({line, firstAddress, secondAddress, offset});
+    }
+  }
+
+  SystemInfo systemInfo{};
+  DolphinOSGlobals dolphinOSGlobals{};
+  WiiSpecificInfo wiiSpecificInfo{};
+
+  // In a first pass, attempt to parse data structures from the top of the memory region.
+  for (const auto& [line, firstAddress, secondAddress, offset] : memoryMapLines)
+  {
+    if (offset)
+      continue;
+
+    if (!::readFromRAM(m_PID, firstAddress, SYSTEM_INFO_OFFSET,
+                       reinterpret_cast<char*>(&systemInfo), sizeof(systemInfo)) ||
+        !::readFromRAM(m_PID, firstAddress, DOLPHIN_OS_GLOBALS_OFFSET,
+                       reinterpret_cast<char*>(&dolphinOSGlobals), sizeof(dolphinOSGlobals)) ||
+        !::readFromRAM(m_PID, firstAddress, WII_SPECIFIC_INFO_OFFSET,
+                       reinterpret_cast<char*>(&wiiSpecificInfo), sizeof(wiiSpecificInfo)))
+      continue;
+
+    // GameCube or Triforce game.
+    if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
+    {
+      m_emuRAMAddressStart = firstAddress;
+      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      m_ARAMSize = dolphinOSGlobals.getARAMSize();
+      break;
     }
 
-    if (lineData.size() < 3)
-      continue;
-
-    bool foundDevShmDolphin = false;
-    for (const std::string& str : lineData)
+    // Wii game.
+    if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
-      if (str.substr(0, 19) == "/dev/shm/dolphinmem" || str.substr(0, 20) == "/dev/shm/dolphin-emu")
-      {
-        foundDevShmDolphin = true;
-        break;
-      }
+      m_emuRAMAddressStart = firstAddress;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
     }
 
-    if (!foundDevShmDolphin)
-      continue;
+    // WAD game.
+    // NOTE: All magic words happen to be null when a WAD game is running. One consistency check
+    // that can be performed is compare the physical and simulated memory in the two structures
+    // where they are written: if they match and have a reasonable size, it is likely a WAD game.
+    if (systemInfo.isNull() &&
+        Common::isInBounds(0x01800000U, systemInfo.getPhysicalMemorySize(), 0x08000000U) &&
+        systemInfo.getPhysicalMemorySize() == wiiSpecificInfo.getPhysicalMEM1Size() &&
+        Common::isInBounds(0x01800000U, dolphinOSGlobals.getSimulatedMemorySize(), 0x08000000U) &&
+        dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
+    {
+      m_emuRAMAddressStart = firstAddress;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
+    }
+  }
 
-    std::string offsetStr("0x" + lineData[2]);
-    const u32 offset{static_cast<u32>(std::stoul(offsetStr, nullptr, 16))};
-    if (offset != 0 && offset != Common::GetMEM1Size() + 0x40000)
-      continue;
+  // Second loop to find either the ARAM address (GameCube or Triforce) or the MEM2 address (Wii).
+  for (const auto& [line, firstAddress, secondAddress, offset] : memoryMapLines)
+  {
+    const u64 size{secondAddress - firstAddress};
 
-    u64 firstAddress = 0;
-    u64 SecondAddress = 0;
-    const std::size_t indexDash{lineData[0].find('-')};
-    std::string firstAddressStr("0x" + lineData[0].substr(0, indexDash));
-    std::string secondAddressStr("0x" + lineData[0].substr(indexDash + 1));
+    if (m_ARAMSize && size == Common::NextPowerOf2(m_MEM1Size) &&
+        (offset & 0x00040000) == 0x00040000)
+    {
+      m_emuARAMAdressStart = firstAddress;
+      m_ARAMAccessible = true;
+      break;
+    }
 
-    firstAddress = std::stoul(firstAddressStr, nullptr, 16);
-    SecondAddress = std::stoul(secondAddressStr, nullptr, 16);
-
-    if (SecondAddress - firstAddress == Common::GetMEM2Size() &&
-        offset == Common::GetMEM1Size() + 0x40000)
+    if (m_MEM2Size && size == Common::NextPowerOf2(m_MEM2Size) &&
+        (offset & 0x00040000) == 0x00040000)
     {
       m_MEM2AddressStart = firstAddress;
       m_MEM2Present = true;
-      if (MEM1Found)
-        break;
+      break;
     }
 
-    if (SecondAddress - firstAddress == Common::GetMEM1Size())
-    {
-      if (offset == 0x0)
-      {
-        m_emuRAMAddressStart = firstAddress;
-        MEM1Found = true;
-      }
-      else if (offset == Common::GetMEM1Size() + 0x40000)
-      {
-        m_emuARAMAdressStart = firstAddress;
-        m_ARAMAccessible = true;
-      }
-    }
+    // TODO(CA): Ideally, we'd inspect the memory to try to determine whether it's pointing to the
+    // expected data, as opposed to relying on these fragile size and offset checks.
   }
 
-  // On Wii, there is no concept of speedhack so act as if we couldn't find it
-  if (m_MEM2Present)
-  {
-    m_emuARAMAdressStart = 0;
-    m_ARAMAccessible = false;
-  }
-
-  if (m_emuRAMAddressStart != 0)
-    return true;
-
-  // Here, Dolphin appears to be running, but the emulator isn't started
-  return false;
+  return m_emuRAMAddressStart != 0;
 }
 
 bool LinuxDolphinProcess::findPID()
@@ -157,22 +220,7 @@ bool LinuxDolphinProcess::readFromRAM(const u32 offset, char* buffer, const size
     RAMAddress = m_emuRAMAddressStart + offset;
   }
 
-  iovec local{};
-  local.iov_base = buffer;
-  local.iov_len = size;
-
-  iovec remote{};
-  remote.iov_base = reinterpret_cast<void*>(RAMAddress);
-  remote.iov_len = size;
-
-  const ssize_t nread{process_vm_readv(m_PID, &local, 1, &remote, 1, 0)};
-  if (nread == -1)
-  {
-    // A more specific error type should be available in `errno` (if ever interested).
-    return false;
-  }
-
-  if (static_cast<size_t>(nread) != size)
+  if (!::readFromRAM(m_PID, RAMAddress, 0, buffer, size))
     return false;
 
   if (withBSwap)

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -50,69 +50,137 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
   if (error != KERN_SUCCESS)
     return false;
 
-  mach_vm_address_t regionAddr = 0;
-  mach_vm_size_t size = 0;
-  vm_region_extended_info_data_t regInfo;
-  vm_region_basic_info_data_64_t basInfo;
-  vm_region_top_info_data_t topInfo;
-  mach_msg_type_number_t cnt = VM_REGION_EXTENDED_INFO_COUNT;
-  mach_port_t obj;
-  bool MEM1Found = false;
-  unsigned int MEM1Obj = 0;
-  while (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_EXTENDED_INFO, (int*)&regInfo, &cnt,
-                        &obj) == KERN_SUCCESS)
+  struct MemoryMapLine
   {
-    cnt = VM_REGION_BASIC_INFO_COUNT_64;
-    if (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_BASIC_INFO_64, (int*)&basInfo, &cnt,
-                       &obj) != KERN_SUCCESS)
-      break;
-    cnt = VM_REGION_TOP_INFO_COUNT;
-    if (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_TOP_INFO, (int*)&topInfo, &cnt,
-                       &obj) != 0)
-      break;
+    const mach_vm_address_t regionAddr;
+    const mach_vm_size_t size;
+    const vm_region_extended_info_data_t regInfo;
+    const vm_region_basic_info_data_64_t basInfo;
+  };
 
-    if (!m_MEM2Present && size == Common::GetMEM2Size() &&
-        basInfo.offset == Common::GetMEM1Size() + 0x40000)
+  // Parse memory map of the Dolphin process.
+  std::vector<MemoryMapLine> memoryMapLines;
+  {
+    mach_vm_address_t regionAddr = 0;
+    mach_vm_size_t size = 0;
+    vm_region_extended_info_data_t regInfo;
+    vm_region_basic_info_data_64_t basInfo;
+    vm_region_top_info_data_t topInfo;
+    mach_msg_type_number_t cnt = VM_REGION_EXTENDED_INFO_COUNT;
+    mach_port_t obj;
+
+    while (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_EXTENDED_INFO, (int*)&regInfo, &cnt,
+                          &obj) == KERN_SUCCESS)
     {
-      m_MEM2Present = true;
+      cnt = VM_REGION_BASIC_INFO_COUNT_64;
+      if (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_BASIC_INFO_64, (int*)&basInfo, &cnt,
+                         &obj) != KERN_SUCCESS)
+        break;
+      cnt = VM_REGION_TOP_INFO_COUNT;
+      if (mach_vm_region(m_task, &regionAddr, &size, VM_REGION_TOP_INFO, (int*)&topInfo, &cnt,
+                         &obj) != 0)
+        break;
+
+      memoryMapLines.push_back({regionAddr, size, regInfo, basInfo});
+
+      regionAddr += size;
+      cnt = VM_REGION_EXTENDED_INFO_COUNT;
+    }
+  }
+
+  SystemInfo systemInfo{};
+  DolphinOSGlobals dolphinOSGlobals{};
+  WiiSpecificInfo wiiSpecificInfo{};
+
+  // In a first pass, attempt to parse data structures from the top of the memory region.
+  for (const auto& [regionAddr, size, regInfo, basInfo] : memoryMapLines)
+  {
+    if (basInfo.offset)
+      continue;
+
+    if (!(regInfo.share_mode == SM_TRUESHARED &&
+          basInfo.max_protection == (VM_PROT_READ | VM_PROT_WRITE)))
+      continue;
+
+    vm_size_t nread{};
+    if (vm_read_overwrite(m_task, regionAddr + SYSTEM_INFO_OFFSET, sizeof(systemInfo),
+                          reinterpret_cast<vm_address_t>(&systemInfo), &nread) != KERN_SUCCESS)
+      continue;
+    if (nread != sizeof(systemInfo))
+      continue;
+    if (vm_read_overwrite(m_task, regionAddr + DOLPHIN_OS_GLOBALS_OFFSET, sizeof(dolphinOSGlobals),
+                          reinterpret_cast<vm_address_t>(&dolphinOSGlobals),
+                          &nread) != KERN_SUCCESS)
+      continue;
+    if (nread != sizeof(dolphinOSGlobals))
+      continue;
+    if (vm_read_overwrite(m_task, regionAddr + WII_SPECIFIC_INFO_OFFSET, sizeof(wiiSpecificInfo),
+                          reinterpret_cast<vm_address_t>(&wiiSpecificInfo), &nread) != KERN_SUCCESS)
+      continue;
+    if (nread != sizeof(wiiSpecificInfo))
+      continue;
+
+    // GameCube or Triforce game.
+    if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
+    {
+      m_emuRAMAddressStart = regionAddr;
+      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      m_ARAMSize = dolphinOSGlobals.getARAMSize();
+      break;
+    }
+
+    // Wii game.
+    if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
+    {
+      m_emuRAMAddressStart = regionAddr;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
+    }
+
+    // WAD game.
+    // NOTE: All magic words happen to be null when a WAD game is running. One consistency check
+    // that can be performed is compare the physical and simulated memory in the two structures
+    // where they are written: if they match and have a reasonable size, it is likely a WAD game.
+    if (systemInfo.isNull() &&
+        Common::isInBounds(0x01800000U, systemInfo.getPhysicalMemorySize(), 0x08000000U) &&
+        systemInfo.getPhysicalMemorySize() == wiiSpecificInfo.getPhysicalMEM1Size() &&
+        Common::isInBounds(0x01800000U, dolphinOSGlobals.getSimulatedMemorySize(), 0x08000000U) &&
+        dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
+    {
+      m_emuRAMAddressStart = regionAddr;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
+    }
+  }
+
+  // Second loop to find either the ARAM address (GameCube or Triforce) or the MEM2 address (Wii).
+  for (const auto& [regionAddr, size, regInfo, basInfo] : memoryMapLines)
+  {
+    (void)regInfo;
+
+    if (m_ARAMSize && size == Common::NextPowerOf2(m_MEM1Size) &&
+        (basInfo.offset & 0x00040000) == 0x00040000)
+    {
+      m_emuARAMAdressStart = regionAddr;
+      m_ARAMAccessible = true;
+      break;
+    }
+
+    if (m_MEM2Size && size == Common::NextPowerOf2(m_MEM2Size) &&
+        (basInfo.offset & 0x00040000) == 0x00040000)
+    {
       m_MEM2AddressStart = regionAddr;
+      m_MEM2Present = true;
+      break;
     }
 
-    // if these are true, then it is very likely the correct region, but we cannot guarantee
-    if ((!MEM1Found || (MEM1Found && MEM1Obj == topInfo.obj_id)) && size == Common::GetMEM1Size() &&
-        regInfo.share_mode == SM_TRUESHARED &&
-        basInfo.max_protection == (VM_PROT_READ | VM_PROT_WRITE))
-    {
-      if (basInfo.offset == 0x0)
-      {
-        m_emuRAMAddressStart = regionAddr;
-        MEM1Found = true;
-      }
-      else if (basInfo.offset == Common::GetMEM1Size() + 0x40000)
-      {
-        m_emuARAMAdressStart = regionAddr;
-        m_ARAMAccessible = true;
-      }
-
-      MEM1Found = true;
-      MEM1Obj = topInfo.obj_id;
-    }
-
-    regionAddr += size;
-    cnt = VM_REGION_EXTENDED_INFO_COUNT;
+    // TODO(CA): Ideally, we'd inspect the memory to try to determine whether it's pointing to the
+    // expected data, as opposed to relying on these fragile size and offset checks.
   }
 
-  if (m_MEM2Present)
-  {
-    m_emuARAMAdressStart = 0;
-    m_ARAMAccessible = false;
-  }
-
-  if (m_emuRAMAddressStart != 0)
-    return true;
-
-  // Here, Dolphin appears to be running, but the emulator isn't started
-  return false;
+  return m_emuRAMAddressStart != 0;
 }
 
 bool MacDolphinProcess::readFromRAM(const u32 offset, char* buffer, size_t size,

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -78,78 +78,120 @@ bool WindowsDolphinProcess::findPID()
 
 bool WindowsDolphinProcess::obtainEmuRAMInformations()
 {
-  MEMORY_BASIC_INFORMATION info;
-  bool MEM1Found = false;
-  for (unsigned char* p = nullptr;
-       VirtualQueryEx(m_hDolphin, p, &info, sizeof(info)) == sizeof(info); p += info.RegionSize)
+  struct MemoryMapLine
   {
-    // Check region size so that we know it's MEM2
-    if (!m_MEM2Present && info.RegionSize == Common::GetMEM2Size())
+    const u64 baseAddress;
+    const u64 size;
+  };
+
+  // In a first pass, attempt to parse data structures from the top of the memory region.
+  std::vector<MemoryMapLine> memoryMapLines;
+  {
+    MEMORY_BASIC_INFORMATION info{};
+
+    for (unsigned char* p{nullptr};
+         VirtualQueryEx(m_hDolphin, p, &info, sizeof(info)) == sizeof(info); p += info.RegionSize)
     {
-      u64 regionBaseAddress = 0;
-      std::memcpy(&regionBaseAddress, &(info.BaseAddress), sizeof(info.BaseAddress));
-      if (MEM1Found && regionBaseAddress > m_emuRAMAddressStart + 0x10000000)
-      {
-        // In some cases MEM2 could actually be before MEM1. Once we find MEM1, ignore regions of
-        // this size that are too far away. There apparently are other non-MEM2 regions of 64 MiB.
-        break;
-      }
-      // View the comment for MEM1.
-      PSAPI_WORKING_SET_EX_INFORMATION wsInfo;
+      PSAPI_WORKING_SET_EX_INFORMATION wsInfo{};
       wsInfo.VirtualAddress = info.BaseAddress;
-      if (QueryWorkingSetEx(m_hDolphin, &wsInfo, sizeof(PSAPI_WORKING_SET_EX_INFORMATION)))
-      {
-        if (wsInfo.VirtualAttributes.Valid)
-        {
-          std::memcpy(&m_MEM2AddressStart, &(regionBaseAddress), sizeof(regionBaseAddress));
-          m_MEM2Present = true;
-        }
-      }
-    }
-    else if (info.RegionSize == Common::GetMEM1Size() && info.Type == MEM_MAPPED)
-    {
-      // Here, it's likely the right page, but it can happen that multiple pages with these criteria
-      // exists and have nothing to do with the emulated memory. Only the right page has valid
-      // working set information so an additional check is required that it is backed by physical
-      // memory.
-      PSAPI_WORKING_SET_EX_INFORMATION wsInfo;
-      wsInfo.VirtualAddress = info.BaseAddress;
-      if (QueryWorkingSetEx(m_hDolphin, &wsInfo, sizeof(PSAPI_WORKING_SET_EX_INFORMATION)))
-      {
-        if (wsInfo.VirtualAttributes.Valid)
-        {
-          if (!MEM1Found)
-          {
-            std::memcpy(&m_emuRAMAddressStart, &(info.BaseAddress), sizeof(info.BaseAddress));
-            MEM1Found = true;
-          }
-          else
-          {
-            u64 aramCandidate = 0;
-            std::memcpy(&aramCandidate, &(info.BaseAddress), sizeof(info.BaseAddress));
-            if (aramCandidate == m_emuRAMAddressStart + Common::GetMEM1Size())
-            {
-              m_emuARAMAdressStart = aramCandidate;
-              m_ARAMAccessible = true;
-            }
-          }
-        }
-      }
+      if (!QueryWorkingSetEx(m_hDolphin, &wsInfo, sizeof(PSAPI_WORKING_SET_EX_INFORMATION)) ||
+          !wsInfo.VirtualAttributes.Valid)
+        continue;
+
+      memoryMapLines.push_back({Common::bit_cast<u64>(info.BaseAddress), info.RegionSize});
     }
   }
 
-  if (m_MEM2Present)
+  SystemInfo systemInfo{};
+  DolphinOSGlobals dolphinOSGlobals{};
+  WiiSpecificInfo wiiSpecificInfo{};
+
+  // In a first pass, attempt to parse data structures from the top of the memory region.
+  for (const auto& [baseAddress, size] : memoryMapLines)
   {
-    m_emuARAMAdressStart = 0;
-    m_ARAMAccessible = false;
+    SIZE_T nread{};
+    if (!ReadProcessMemory(m_hDolphin, reinterpret_cast<void*>(baseAddress + SYSTEM_INFO_OFFSET),
+                           reinterpret_cast<char*>(&systemInfo), sizeof(systemInfo), &nread))
+      continue;
+    if (nread != sizeof(systemInfo))
+      continue;
+    if (!ReadProcessMemory(
+            m_hDolphin, reinterpret_cast<void*>(baseAddress + DOLPHIN_OS_GLOBALS_OFFSET),
+            reinterpret_cast<char*>(&dolphinOSGlobals), sizeof(dolphinOSGlobals), &nread))
+      continue;
+    if (nread != sizeof(dolphinOSGlobals))
+      continue;
+    if (!ReadProcessMemory(
+            m_hDolphin, reinterpret_cast<void*>(baseAddress + WII_SPECIFIC_INFO_OFFSET),
+            reinterpret_cast<char*>(&wiiSpecificInfo), sizeof(wiiSpecificInfo), &nread))
+      continue;
+    if (nread != sizeof(wiiSpecificInfo))
+      continue;
+
+    // GameCube or Triforce game.
+    if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
+    {
+      m_emuRAMAddressStart = baseAddress;
+      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      m_ARAMSize = dolphinOSGlobals.getARAMSize();
+      break;
+    }
+
+    // Wii game.
+    if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
+    {
+      m_emuRAMAddressStart = baseAddress;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
+    }
+
+    // WAD game.
+    // NOTE: All magic words happen to be null when a WAD game is running. One consistency check
+    // that can be performed is compare the physical and simulated memory in the two structures
+    // where they are written: if they match and have a reasonable size, it is likely a WAD game.
+    if (systemInfo.isNull() &&
+        Common::isInBounds(0x01800000U, systemInfo.getPhysicalMemorySize(), 0x08000000U) &&
+        systemInfo.getPhysicalMemorySize() == wiiSpecificInfo.getPhysicalMEM1Size() &&
+        Common::isInBounds(0x01800000U, dolphinOSGlobals.getSimulatedMemorySize(), 0x08000000U) &&
+        dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
+    {
+      m_emuRAMAddressStart = baseAddress;
+      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      break;
+    }
   }
 
-  if (m_emuRAMAddressStart == 0)
+  // Second loop to find either the ARAM address (GameCube or Triforce) or the MEM2 address (Wii).
+  for (const auto& [baseAddress, size] : memoryMapLines)
   {
-    // Here, Dolphin is running, but the emulation hasn't started
-    return false;
+    if (m_ARAMSize && size == Common::NextPowerOf2(m_MEM1Size) &&
+        baseAddress == m_emuRAMAddressStart + Common::NextPowerOf2(m_MEM1Size))
+    {
+      m_emuARAMAdressStart = baseAddress;
+      m_ARAMAccessible = true;
+      break;
+    }
+
+    if (m_MEM2Size && size == Common::NextPowerOf2(m_MEM2Size))
+    {
+      // In some cases, MEM2 can actually be before MEM1. Once MEM1 is found, regions of the
+      // expected size that are too far away are ignored: there apparently are other non-MEM2
+      // regions of 64 MiB.
+      if (baseAddress >= m_emuRAMAddressStart + 0x10000000)
+        continue;
+
+      m_MEM2AddressStart = baseAddress;
+      m_MEM2Present = true;
+      break;
+    }
+
+    // TODO(CA): Ideally, we'd inspect the memory to try to determine whether it's pointing to the
+    // expected data, as opposed to relying on these fragile size and offset checks.
   }
-  return true;
+
+  return m_emuRAMAddressStart != 0;
 }
 
 bool WindowsDolphinProcess::readFromRAM(const u32 offset, char* buffer, const size_t size,

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -100,40 +100,11 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
     }
   });
 
-  QGroupBox* grbMemorySizeSettings = new QGroupBox("Memory Size settings");
-
-  m_lblMEM1Size = new QLabel();
-  m_lblMEM2Size = new QLabel();
-  m_sldMEM1Size = new QSlider(Qt::Horizontal);
-  m_sldMEM2Size = new QSlider(Qt::Horizontal);
-  connect(m_sldMEM1Size, &QSlider::valueChanged, [this](int slider_value) {
-    m_lblMEM1Size->setText(tr("%1 MB (MEM1)").arg(QString::number(slider_value)));
-  });
-  connect(m_sldMEM2Size, &QSlider::valueChanged, [this](int slider_value) {
-    m_lblMEM2Size->setText(tr("%1 MB (MEM2)").arg(QString::number(slider_value)));
-  });
-  m_sldMEM1Size->setRange(24, 64);
-  m_sldMEM2Size->setRange(64, 128);
-
-  QHBoxLayout* MEM1Layout = new QHBoxLayout();
-  QHBoxLayout* MEM2Layout = new QHBoxLayout();
-  MEM1Layout->addWidget(m_sldMEM1Size);
-  MEM1Layout->addWidget(m_lblMEM1Size);
-  MEM2Layout->addWidget(m_sldMEM2Size);
-  MEM2Layout->addWidget(m_lblMEM2Size);
-
-  QVBoxLayout* memorySettingsInputLayout = new QVBoxLayout();
-  memorySettingsInputLayout->addLayout(MEM1Layout);
-  memorySettingsInputLayout->addLayout(MEM2Layout);
-
-  grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
-
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCoreSettings);
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbScannerSettings);
   mainLayout->addWidget(grbViewerSettings);
-  mainLayout->addWidget(grbMemorySizeSettings);
   mainLayout->addWidget(m_buttonsDlg);
   setLayout(mainLayout);
 
@@ -157,9 +128,6 @@ void DlgSettings::loadSettings()
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
   m_cmbTheme->setCurrentIndex(m_cmbTheme->findData(SConfig::getInstance().getTheme()));
-  // This erases fractional mebibyte sizes, but nobody should be using those anyway.
-  m_sldMEM1Size->setValue(static_cast<int>(SConfig::getInstance().getMEM1Size()) / 1024 / 1024);
-  m_sldMEM2Size->setValue(static_cast<int>(SConfig::getInstance().getMEM2Size()) / 1024 / 1024);
 }
 
 void DlgSettings::saveSettings() const
@@ -172,6 +140,4 @@ void DlgSettings::saveSettings() const
   SConfig::getInstance().setViewerNbrBytesSeparator(
       m_cmbViewerBytesSeparator->currentData().toInt());
   SConfig::getInstance().setTheme(m_cmbTheme->currentData().toInt());
-  SConfig::getInstance().setMEM1Size(m_sldMEM1Size->value() * 1024 * 1024);
-  SConfig::getInstance().setMEM2Size(m_sldMEM2Size->value() * 1024 * 1024);
 }

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -31,8 +31,4 @@ private:
   QSpinBox* m_spnScannerShowThreshold;
   QComboBox* m_cmbViewerBytesSeparator;
   QDialogButtonBox* m_buttonsDlg;
-  QSlider* m_sldMEM1Size;
-  QSlider* m_sldMEM2Size;
-  QLabel* m_lblMEM1Size;
-  QLabel* m_lblMEM2Size;
 };

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -128,16 +128,6 @@ int SConfig::getViewerNbrBytesSeparator() const
   return value("viewerSettings/nbrBytesSeparator", 1).toInt();
 }
 
-u32 SConfig::getMEM1Size() const
-{
-  return value("memorySettings/MEM1Size", 24u * 1024 * 1024).toUInt();
-}
-
-u32 SConfig::getMEM2Size() const
-{
-  return value("memorySettings/MEM2Size", 64u * 1024 * 1024).toUInt();
-}
-
 void SConfig::setWatchModel(const QString& json)
 {
   setValue("watchModel", json);
@@ -201,16 +191,6 @@ void SConfig::setScannerShowThreshold(const int scannerShowThreshold)
 void SConfig::setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator)
 {
   setValue("viewerSettings/nbrBytesSeparator", viewerNbrBytesSeparator);
-}
-
-void SConfig::setMEM1Size(const u32 mem1SizeReal)
-{
-  setValue("memorySettings/MEM1Size", mem1SizeReal);
-}
-
-void SConfig::setMEM2Size(const u32 mem2SizeReal)
-{
-  setValue("memorySettings/MEM2Size", mem2SizeReal);
 }
 
 bool SConfig::getAutoloadLastFile() const

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -39,8 +39,6 @@ public:
   int getScannerUpdateTimerMs() const;
   int getViewerUpdateTimerMs() const;
   int getScannerShowThreshold() const;
-  u32 getMEM1Size() const;
-  u32 getMEM2Size() const;
 
   int getViewerNbrBytesSeparator() const;
 
@@ -59,8 +57,6 @@ public:
   void setScannerUpdateTimerMs(int scannerUpdateTimerMs);
   void setViewerUpdateTimerMs(int viewerUpdateTimerMs);
   void setScannerShowThreshold(int scannerShowThreshold);
-  void setMEM1Size(u32 mem1SizeReal);
-  void setMEM2Size(u32 mem2SizeReal);
 
   void setViewerNbrBytesSeparator(int viewerNbrBytesSeparator);
 


### PR DESCRIPTION
Previously, settings were available that would allow the user to specify the same simulated memory size that had been configured in Dolphin. Failing to do this precisely would lead to Dolphin Memory Engine not being able to hook into Dolphin.

The settings have been removed from the GUI now and, instead, there is an attempt to parse the simulated memory size from the data structures present in the Dolphin OS headers.

Reference for the data structures:

- https://hitmen.c02.at/files/yagcd/yagcd/chap4.html
- https://wiibrew.org/wiki/Memory_map
- https://wiibrew.org/wiki/Wii_disc

To locate ARAM and MEM2, an unideal method that consists of some hardcoded offsets (which are hardcoded in Dolphin side too) is still in use. Ideally, a more reliable mechanism consisting of memory inspection would be used; this will implemented at a later time, once the current changes have been tested sufficiently.