### PR TITLE
Re-attempt to hook to Dolphin if partial hook is detected.

### DIFF
--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -195,6 +195,11 @@ const std::string& DolphinAccessor::getGameID()
   return s_gameID;
 }
 
+bool DolphinAccessor::isGameIDValid()
+{
+  return s_gameID.size() == strlen("GM4P01") && s_gameID != "??????";
+}
+
 Common::MemOperationReturnCode DolphinAccessor::readEntireRAM(char* buffer)
 {
   // MEM2, if enabled, is read right after MEM1 in the buffer so both regions are contigous

--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -7,11 +7,42 @@
 #include "Mac/MacDolphinProcess.h"
 #endif
 
+#include <array>
 #include <cstring>
 #include <memory>
 
 #include "../Common/CommonUtils.h"
 #include "../Common/MemoryCommon.h"
+
+namespace
+{
+std::string s_gameID;
+
+std::string readGameID()
+{
+  const bool aram{DolphinComm::DolphinAccessor::isARAMAccessible()};
+
+  std::array<char, sizeof("GM4P01")> gameID{};
+
+  if (DolphinComm::DolphinAccessor::readFromRAM(
+          Common::dolphinAddrToOffset(Common::MEM1_START, aram), gameID.data(), gameID.size(),
+          false))
+  {
+    for (char& c : gameID)
+    {
+      if (!std::isprint(static_cast<int>(static_cast<unsigned char>(c))))
+      {
+        c = '?';
+      }
+    }
+
+    gameID.back() = '\0';
+    return {gameID.data(), gameID.size() - 1};
+  }
+
+  return {};
+}
+}  // namespace
 
 namespace DolphinComm
 {
@@ -20,6 +51,8 @@ DolphinAccessor::DolphinStatus DolphinAccessor::m_status = DolphinStatus::unHook
 
 void DolphinAccessor::init()
 {
+  s_gameID.clear();
+
   if (m_instance == nullptr)
   {
 #ifdef __linux__
@@ -55,6 +88,8 @@ void DolphinAccessor::hook()
   else
   {
     m_status = DolphinStatus::hooked;
+
+    s_gameID = readGameID();
   }
 
   Common::UpdateMemoryValues(m_instance->getMEM1Size(), m_instance->getMEM2Size());
@@ -153,6 +188,11 @@ size_t DolphinAccessor::getRAMTotalSize()
   }
 
   return Common::GetMEM1SizeReal();
+}
+
+const std::string& DolphinAccessor::getGameID()
+{
+  return s_gameID;
 }
 
 Common::MemOperationReturnCode DolphinAccessor::readEntireRAM(char* buffer)

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -37,6 +37,7 @@ public:
   static u32 getMEM2Size();
   static size_t getRAMTotalSize();
   static const std::string& getGameID();
+  static bool isGameIDValid();
   static Common::MemOperationReturnCode readEntireRAM(char* buffer);
   static std::string getFormattedValueFromMemory(u32 ramIndex, Common::MemType memType,
                                                  size_t memSize, Common::MemBase memBase,

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -1,6 +1,8 @@
 // Wrapper around IDolphinProcess
 #pragma once
 
+#include <string>
+
 #include "../Common/CommonTypes.h"
 #include "../Common/MemoryCommon.h"
 #include "IDolphinProcess.h"
@@ -34,6 +36,7 @@ public:
   static u32 getMEM1Size();
   static u32 getMEM2Size();
   static size_t getRAMTotalSize();
+  static const std::string& getGameID();
   static Common::MemOperationReturnCode readEntireRAM(char* buffer);
   static std::string getFormattedValueFromMemory(u32 ramIndex, Common::MemType memType,
                                                  size_t memSize, Common::MemBase memBase,

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -663,21 +663,7 @@ void MainWindow::updateStatusBar()
     const bool mem2{DolphinComm::DolphinAccessor::isMEM2Present()};
     const bool aram{!mem2 && DolphinComm::DolphinAccessor::isARAMAccessible()};
 
-    std::array<char, sizeof("GM4E01")> gameID{};
-    if (DolphinComm::DolphinAccessor::readFromRAM(
-            Common::dolphinAddrToOffset(Common::MEM1_START, aram), gameID.data(), gameID.size(),
-            false))
-    {
-      for (char& c : gameID)
-      {
-        if (!std::isprint(static_cast<int>(static_cast<unsigned char>(c))))
-        {
-          c = '?';
-        }
-      }
-      gameID.back() = '\0';
-      tags << QString(gameID.data());
-    }
+    tags << QString::fromStdString(DolphinComm::DolphinAccessor::getGameID());
 
     toolTipLines
         << tr("Hooked to Dolphin successfully. Current start address: ") +

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -379,6 +379,8 @@ void MainWindow::onUnhook()
   DolphinComm::DolphinAccessor::unHook();
   updateDolphinHookingStatus();
   m_watcher->update();
+
+  m_partialHookRehookAttempts = 0;
 }
 
 void MainWindow::onAutoLoadLastFileTriggered(const bool checked)
@@ -418,6 +420,19 @@ void MainWindow::onHookIfNotHooked()
       DolphinComm::DolphinAccessor::DolphinStatus::hooked)
   {
     onHookAttempt();
+  }
+  else
+  {
+    // Occasionally, DME can successfully hook to Dolphin before the game ID has been written to
+    // memory, leading to a partial hook status. To mitigate this scenario, there will be a few
+    // attempts to rehook.
+    static constexpr int MAX_PARTIAL_HOOK_REHOOK_ATTEMPTS{5};
+    if (m_partialHookRehookAttempts < MAX_PARTIAL_HOOK_REHOOK_ATTEMPTS &&
+        !DolphinComm::DolphinAccessor::isGameIDValid())
+    {
+      ++m_partialHookRehookAttempts;
+      onHookAttempt();
+    }
   }
 }
 

--- a/Source/GUI/MainWindow.h
+++ b/Source/GUI/MainWindow.h
@@ -78,6 +78,7 @@ private:
   StructEditorWidget* m_structEditor{};
 
   QTimer m_autoHookTimer;
+  int m_partialHookRehookAttempts{0};
 
   QMenu* m_menuFile{};
   QMenu* m_menuEdit{};


### PR DESCRIPTION
Shortly after the emulation starts in Dolphin, the game ID is written into the first 6 bytes in MEM1. However, there is a small window in which the shared memory that the Dolphin Memory Engine hooks into is made available by Dolphin, but the game ID has not been written yet. This can lead to a hooked status where the game ID is reported as "??????" in the status bar. It is also believed that wrong values can be seen in watched entries, but this needs verification.

To mitigate this scenario, a retry mechanism has been introduced when **Dolphin > Auto-hook** is enabled (default), which attempts to re-hook into Dolphin if the game ID is reported as invalid.