### PR TITLE
Update build script to support macOS Universal Binary (Apple Silicon & x86_64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   clang-format-check:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,9 @@ jobs:
         run: |
           mkdir Source/build
           cd Source/build
-          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)"
-                   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+              cmake .. \
+                -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
+                -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,7 @@ jobs:
         run: |
           mkdir Source/build
           cd Source/build
-          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
-                   -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
+          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,8 @@ jobs:
         run: |
           mkdir Source/build
           cd Source/build
-          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
+          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)"
+                   -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,3 +168,50 @@ jobs:
         with:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS-intel
           path: Source/build/artifacts
+
+  build-macos-arm:
+    runs-on: macos-15
+    name: 🍎 macOS ARM64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # Current Runner has cmake we want by default; Omitting for now but restore if they stop bundling it
+      # - name: Install Dependencies
+      #   run: |
+      #     brew install --formula cmake
+      #   shell: bash
+
+      - name: Initialize submodules
+        run: git submodule update --init
+
+      - name: Build
+        run: |
+          mkdir Source/build
+          cd Source/build
+          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
+                   -DCMAKE_OSX_ARCHITECTURES=arm64
+          make
+          echo -e "\n" | ../../Tools/MacDeploy.sh
+        shell: bash
+
+      - name: Copy LICENSE, README, Prepare Artifacts
+        run: |
+          mkdir Source/build/artifacts
+          cp ./README.md ./Source/build/artifacts/
+          cp ./LICENSE ./Source/build/artifacts/
+          cp ./Tools/MacSetup.sh ./Source/build/artifacts/
+          cp ./Source/build/dolphin-memory-engine.dmg ./Source/build/artifacts/
+        shell: bash
+
+      - name: Get Short SHA
+        id: get-short-sha
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS-arm64
+          path: Source/build/artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,55 +124,9 @@ jobs:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-x86_64-appimage
           path: dolphin-memory-engine.AppImage
 
-  build-macos-intel:
-    runs-on: macos-15-intel
-    name: 🍎 macOS Intel
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      # Current Runner has cmake we want by default; Omitting for now but restore if they stop bundling it
-      # - name: Install Dependencies
-      #   run: |
-      #     brew install --formula cmake
-      #   shell: bash
-
-      - name: Initialize submodules
-        run: git submodule update --init
-
-      - name: Build
-        run: |
-          mkdir Source/build
-          cd Source/build
-          cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)"
-          make
-          echo -e "\n" | ../../Tools/MacDeploy.sh
-        shell: bash
-
-      - name: Copy LICENSE, README, Prepare Artifacts
-        run: |
-          mkdir Source/build/artifacts
-          cp ./README.md ./Source/build/artifacts/
-          cp ./LICENSE ./Source/build/artifacts/
-          cp ./Tools/MacSetup.sh ./Source/build/artifacts/
-          cp ./Source/build/dolphin-memory-engine.dmg ./Source/build/artifacts/
-        shell: bash
-
-      - name: Get Short SHA
-        id: get-short-sha
-        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Publish Artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS-intel
-          path: Source/build/artifacts
-
-  build-macos-arm:
+  build-macos:
     runs-on: macos-15
-    name: 🍎 macOS ARM64
+    name: 🍎 macOS
 
     steps:
       - name: Checkout code
@@ -192,7 +146,7 @@ jobs:
           mkdir Source/build
           cd Source/build
           cmake .. -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
-                   -DCMAKE_OSX_ARCHITECTURES=arm64
+                   -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh
         shell: bash
@@ -214,5 +168,5 @@ jobs:
       - name: Publish Artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS-arm64
+          name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS
           path: Source/build/artifacts


### PR DESCRIPTION
Updated the build script to support a macOS Universal Binary. All macOS builds should now run on Apple Silicon and Intel based Macs. Changes made to build.yml. Changes may need to be made to tag-build.yml but I did not feel comfortable making those changes.