### PR TITLE
CI: Update actions to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Clang-Format Check
     steps:
       - uses: actions/checkout@v6
-      - uses: jidicula/clang-format-action@v4.16.0
+      - uses: jidicula/clang-format-action@v4.18.0
         with:
           clang-format-version: '19'
           check-path: Source
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Initialize submodules
         run: git submodule update --init
@@ -58,7 +58,7 @@ jobs:
         shell: pwsh
 
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-windows-${{ matrix.configuration }}-amd64
           path: Source\bin\${{ matrix.configuration }}
@@ -112,13 +112,13 @@ jobs:
         shell: bash
 
       - name: Publish Artifacts (Binary)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-x86_64-binary
           path: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-x86_64-binary.tar.gz
 
       - name: Publish Artifacts (AppImage)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-linux-x86_64-appimage
           path: dolphin-memory-engine.AppImage
@@ -166,7 +166,7 @@ jobs:
         shell: bash
 
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ steps.get-short-sha.outputs.short_sha }}-macOS
           path: Source/build/artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           $sha = '${{ github.sha }}'
           $short_sha = $sha.Substring(0, 7)
-          echo "::set-output name=short_sha::$short_sha"
+          echo "short_sha=$short_sha" >> $env:GITHUB_OUTPUT
         shell: pwsh
 
       - name: Publish Artifacts

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Clang-Format Check (TAG)
     steps:
       - uses: actions/checkout@v6
-      - uses: jidicula/clang-format-action@v4.16.0
+      - uses: jidicula/clang-format-action@v4.18.0
         with:
           clang-format-version: '19'
           check-path: Source
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Initialize submodules
         run: git submodule update --init
@@ -56,13 +56,13 @@ jobs:
         shell: powershell
 
       - name: Publish Workflow Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ github.ref_name }}-windows-amd64
           path: dolphin-memory-engine-${{ github.ref_name }}-windows-amd64.zip
 
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag'
         with:
           files: dolphin-memory-engine-${{ github.ref_name }}-windows-amd64.zip
@@ -123,19 +123,19 @@ jobs:
         shell: bash
 
       - name: Publish Workflow Artifact (Linux binary tarball)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-binary
           path: dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-binary.tar.gz
 
       - name: Publish Workflow Artifact (AppImage)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-appimage
           path: ${{ steps.rename_appimage.outputs.appimage_name }}
 
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag'
         with:
           files: |
@@ -182,13 +182,13 @@ jobs:
         shell: bash
 
       - name: Publish Workflow Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dolphin-memory-engine-${{ github.ref_name }}-macOS
           path: dolphin-memory-engine-${{ github.ref_name }}-macOS.zip
         
       - name: Upload to GitHub Releases
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag'
         with:
           files: dolphin-memory-engine-${{ github.ref_name }}-macOS.zip


### PR DESCRIPTION
* Resolve the deprecation/warnings about node 20 -> node 24 (actions update)
* Also resolve the set-output deprecation notice for windows artifacts (non tag)
* The v7 upload step may fail without an extra permission, so may need a fast follow commit in master if that happens.