### PR TITLE
[BLOCKED - QT Upgrade Needed] CI: MacOS 26 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '19'
+          clang-format-version: '22'
           check-path: Source
 
   build-windows:
@@ -124,7 +124,7 @@ jobs:
           path: dolphin-memory-engine.AppImage
 
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     name: 🍎 macOS
 
     steps:

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: '19'
+          clang-format-version: '22'
           check-path: Source
 
   build-windows:
@@ -143,7 +143,7 @@ jobs:
             dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-binary.tar.gz
 
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     name: 🍎 macOS (TAG)
 
     steps:

--- a/Source/GUI/MemViewer/MemViewer.cpp
+++ b/Source/GUI/MemViewer/MemViewer.cpp
@@ -1285,7 +1285,7 @@ void MemViewer::renderSeparatorLines(QPainter& painter) const
   painter.drawLine(m_rowHeaderWidth - m_charWidthEm / 2, 0, m_rowHeaderWidth - m_charWidthEm / 2,
                    m_columnHeaderHeight + m_hexAreaHeight);
   painter.drawLine(0, m_columnHeaderHeight,
-                   m_hexAsciiSeparatorPosX + (std::max(m_numColumns, 13))*m_charWidthEm,
+                   m_hexAsciiSeparatorPosX + (std::max(m_numColumns, 13)) * m_charWidthEm,
                    m_columnHeaderHeight);
 
   int divide_amt = std::max(SConfig::getInstance().getViewerNbrBytesSeparator(), m_sizeOfType);


### PR DESCRIPTION
* Update the macOS runner 15 -> 26 (macOS 26)


AGL framework was removed in macOS 26.
The Qt version submodule expects it. We would need to upgrade the Qt module to resolve this.

> You need Qt 6.8.4 or 6.9.2 to compile on Tahoe.

Per:
https://forum.qt.io/topic/163262/ld-framework-agl-not-found-on-macos-tahoe/6
