### PR TITLE
Ubuntu24, Qt6.4.2 (Linux), Optimize Scan Result Actions, AppImage Scan Hang Fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           path: Source\bin\${{ matrix.configuration }}
 
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: 🐧 Linux x86_64
 
     steps:

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -68,7 +68,7 @@ jobs:
           files: dolphin-memory-engine-${{ github.ref_name }}-windows-amd64.zip
 
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: 🐧 Linux x86_64 (TAG)
 
     steps:

--- a/Source/GUI/MainWindow.cpp
+++ b/Source/GUI/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <string>
+#include <vector>
 
 #include "../DolphinProcess/DolphinAccessor.h"
 #include "../MemoryWatch/MemWatchEntry.h"
@@ -259,24 +260,30 @@ void MainWindow::addSelectedResultsToWatchList(Common::MemType type, size_t leng
                                                Common::MemBase base, bool isBranchAbsolute)
 {
   QModelIndexList selection = m_scanner->getSelectedResults();
+  std::vector<MemWatchEntry*> entries;
+  entries.reserve(selection.count());
   for (int i = 0; i < selection.count(); i++)
   {
     u32 address = m_scanner->getResultListModel()->getResultAddress(selection.at(i).row());
-    MemWatchEntry* newEntry = new MemWatchEntry(tr("No label"), address, type, base, isUnsigned,
-                                                length, false, isBranchAbsolute);
-    m_watcher->addWatchEntry(newEntry);
+    entries.push_back(new MemWatchEntry(tr("No label"), address, type, base, isUnsigned, length,
+                                        false, isBranchAbsolute));
   }
+  m_watcher->addWatchEntries(entries);
 }
 
 void MainWindow::addAllResultsToWatchList(Common::MemType type, size_t length, bool isUnsigned,
                                           Common::MemBase base, bool isBranchAbsolute)
 {
-  for (auto item : m_scanner->getAllResults())
+  const size_t count = m_scanner->getResultCount();
+  std::vector<MemWatchEntry*> entries;
+  entries.reserve(count);
+  for (size_t i = 0; i < count; ++i)
   {
-    MemWatchEntry* newEntry = new MemWatchEntry(tr("No label"), item, type, base, isUnsigned,
-                                                length, false, isBranchAbsolute);
-    m_watcher->addWatchEntry(newEntry);
+    u32 address = m_scanner->getResultAddressAt(static_cast<int>(i));
+    entries.push_back(new MemWatchEntry(tr("No label"), address, type, base, isUnsigned, length,
+                                        false, isBranchAbsolute));
   }
+  m_watcher->addWatchEntries(entries);
 }
 
 void MainWindow::addWatchRequested(u32 address, Common::MemType type, size_t length,

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -513,6 +513,7 @@ void MemScanWidget::onNextScan()
 
 void MemScanWidget::onUndoScan()
 {
+  m_tblResulstList->scrollToTop();
   if (m_memScanner->hasUndo())
   {
     m_memScanner->undoScan();
@@ -544,6 +545,7 @@ void MemScanWidget::onUndoScan()
 
 void MemScanWidget::onResetScan()
 {
+  m_tblResulstList->scrollToTop();
   m_memScanner->reset();
   m_lblResultCount->setText("");
   m_btnAddAll->setEnabled(false);

--- a/Source/GUI/MemScanner/MemScanWidget.cpp
+++ b/Source/GUI/MemScanner/MemScanWidget.cpp
@@ -11,6 +11,7 @@
 #include <QRegularExpression>
 #include <QShortcut>
 #include <QVBoxLayout>
+#include <algorithm>
 #include <cassert>
 #include <sstream>
 #include "../GUICommon.h"
@@ -236,6 +237,16 @@ ResultsListModel* MemScanWidget::getResultListModel() const
 std::vector<u32> MemScanWidget::getAllResults() const
 {
   return m_memScanner->getResultsConsoleAddr();
+}
+
+u32 MemScanWidget::getResultAddressAt(const int index) const
+{
+  return m_memScanner->getResultAddressAt(index);
+}
+
+size_t MemScanWidget::getResultCount() const
+{
+  return m_memScanner->getResultCount();
 }
 
 QModelIndexList MemScanWidget::getSelectedResults() const
@@ -509,7 +520,7 @@ void MemScanWidget::onUndoScan()
     const size_t resultsFound{m_memScanner->getResultCount()};
     m_lblResultCount->setText(tr("%1 result(s) found", "", static_cast<int>(resultsFound))
                                   .arg(QString::number(resultsFound)));
-    if (resultsFound <= 1000 && resultsFound != 0)
+    if (resultsFound <= m_showThreshold && resultsFound != 0)
     {
       m_btnAddAll->setEnabled(true);
       m_btnAddSelection->setEnabled(true);
@@ -565,11 +576,23 @@ void MemScanWidget::onAddSelection()
 
 void MemScanWidget::onRemoveSelection()
 {
-  if (!m_tblResulstList->selectionModel()->hasSelection())
+  QModelIndexList selection = m_tblResulstList->selectionModel()->selectedRows();
+  if (selection.isEmpty())
     return;
 
-  while (m_tblResulstList->selectionModel()->hasSelection())
-    m_resultsListModel->removeRow(m_tblResulstList->selectionModel()->selectedRows().at(0).row());
+  std::sort(selection.begin(), selection.end(),
+            [](const QModelIndex& a, const QModelIndex& b) { return a.row() > b.row(); });
+
+  int i = 0;
+  while (i < selection.count())
+  {
+    int endRow = selection[i].row();
+    int count = 1;
+    while (i + count < selection.count() && selection[i + count].row() == endRow - count)
+      count++;
+    m_resultsListModel->removeRows(endRow - count + 1, count, QModelIndex());
+    i += count;
+  }
 
   // The result count is already updated at the backend by this point
   const size_t resultsFound{m_memScanner->getResultCount()};

--- a/Source/GUI/MemScanner/MemScanWidget.h
+++ b/Source/GUI/MemScanner/MemScanWidget.h
@@ -31,6 +31,8 @@ public:
 
   ResultsListModel* getResultListModel() const;
   std::vector<u32> getAllResults() const;
+  u32 getResultAddressAt(int index) const;
+  size_t getResultCount() const;
   QModelIndexList getSelectedResults() const;
 
   void onScanFilterChanged();

--- a/Source/GUI/MemScanner/ResultsListModel.cpp
+++ b/Source/GUI/MemScanner/ResultsListModel.cpp
@@ -41,7 +41,7 @@ QVariant ResultsListModel::data(const QModelIndex& index, int role) const
     switch (index.column())
     {
     case RESULT_COL_ADDRESS:
-      return QString::number(m_scanner->getResultsConsoleAddr().at(index.row()), 16).toUpper();
+      return QString::number(m_scanner->getResultAddressAt(index.row()), 16).toUpper();
     case RESULT_COL_SCANNED:
       return QString::fromStdString(m_scanner->getFormattedScannedValueAt(index.row()));
     case RESULT_COL_CURRENT:
@@ -56,8 +56,8 @@ QVariant ResultsListModel::data(const QModelIndex& index, int role) const
 bool ResultsListModel::removeRows(int row, int count, const QModelIndex& parent)
 {
   beginRemoveRows(parent, row, row + count - 1);
-  for (int i = 0; i < count; i++)
-    m_scanner->removeResultAt(i + row);
+  for (int i = count - 1; i >= 0; i--)
+    m_scanner->removeResultAt(row + i);
   endRemoveRows();
 
   return true;
@@ -65,7 +65,7 @@ bool ResultsListModel::removeRows(int row, int count, const QModelIndex& parent)
 
 u32 ResultsListModel::getResultAddress(const int row) const
 {
-  return m_scanner->getResultsConsoleAddr().at(row);
+  return m_scanner->getResultAddressAt(row);
 }
 
 QVariant ResultsListModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -94,7 +94,8 @@ void ResultsListModel::updateScanner()
 
 void ResultsListModel::updateAfterScannerReset()
 {
-  emit layoutChanged();
+  beginResetModel();
+  endResetModel();
 }
 
 void ResultsListModel::setShowThreshold(const size_t showThreshold)

--- a/Source/GUI/MemWatcher/MemWatchWidget.cpp
+++ b/Source/GUI/MemWatcher/MemWatchWidget.cpp
@@ -669,6 +669,21 @@ void MemWatchWidget::addWatchEntry(MemWatchEntry* entry)
   m_hasUnsavedChanges = true;
 }
 
+void MemWatchWidget::addWatchEntries(const std::vector<MemWatchEntry*>& entries)
+{
+  if (entries.empty())
+    return;
+
+  std::vector<MemWatchTreeNode*> nodes;
+  nodes.reserve(entries.size());
+  for (MemWatchEntry* entry : entries)
+    nodes.push_back(new MemWatchTreeNode(entry));
+
+  const QModelIndexList selectedIndexes{m_watchView->selectionModel()->selectedIndexes()};
+  m_watchModel->addNodes(nodes, selectedIndexes.empty() ? QModelIndex{} : selectedIndexes.back());
+  m_hasUnsavedChanges = true;
+}
+
 QModelIndexList MemWatchWidget::simplifySelection() const
 {
   QModelIndexList simplifiedSelection;
@@ -787,7 +802,9 @@ void MemWatchWidget::onRowsInserted(const QModelIndex& parent, const int first, 
     {
       const MemWatchTreeNode* const node{
           MemWatchModel::getTreeNodeFromIndex(m_watchModel->index(i, 0, parent))};
-      updateExpansionState(node);
+      if (node && (node->isGroup() ||
+                   (node->getEntry() && GUICommon::isContainerType(node->getEntry()->getType()))))
+        updateExpansionState(node);
     }
 
     m_watchView->scrollTo(lastIndex);

--- a/Source/GUI/MemWatcher/MemWatchWidget.h
+++ b/Source/GUI/MemWatcher/MemWatchWidget.h
@@ -3,7 +3,9 @@
 #include <QPushButton>
 #include <QTimer>
 #include <QTreeView>
+#include <vector>
 
+#include "../../MemoryWatch/MemWatchEntry.h"
 #include "../../Structs/StructTreeNode.h"
 #include "MemWatchDelegate.h"
 #include "MemWatchModel.h"
@@ -28,6 +30,7 @@ public:
   void onAddGroup();
   void onAddWatchEntry();
   void addWatchEntry(MemWatchEntry* entry);
+  void addWatchEntries(const std::vector<MemWatchEntry*>& entries);
   void onLockSelection(bool lockStatus);
   void onDeleteSelection();
   void onDropSucceeded();

--- a/Source/MemoryScanner/MemoryScanner.cpp
+++ b/Source/MemoryScanner/MemoryScanner.cpp
@@ -376,15 +376,14 @@ Common::MemOperationReturnCode MemScanner::nextScan(const MemScanner::ScanFilter
 void MemScanner::reset()
 {
   m_resultsConsoleAddr.clear();
+  m_resultsConsoleAddr.shrink_to_fit();
   m_wasUnknownInitialValue = false;
   delete[] m_scanRAMCache;
   m_scanRAMCache = nullptr;
   m_resultCount = 0;
   m_scanStarted = false;
-  while (!m_UndoStack.empty())
-  {
-    m_UndoStack.pop();
-  }
+  std::stack<MemScannerUndoAction> empty;
+  std::swap(m_UndoStack, empty);
   m_undoCount = 0;
 }
 
@@ -626,6 +625,11 @@ bool MemScanner::typeSupportsAdditionalOptions(const Common::MemType type)
 std::vector<u32> MemScanner::getResultsConsoleAddr() const
 {
   return m_resultsConsoleAddr;
+}
+
+u32 MemScanner::getResultAddressAt(const int index) const
+{
+  return m_resultsConsoleAddr.at(index);
 }
 
 std::string MemScanner::getFormattedScannedValueAt(const int index) const

--- a/Source/MemoryScanner/MemoryScanner.h
+++ b/Source/MemoryScanner/MemoryScanner.h
@@ -137,6 +137,7 @@ public:
   bool setSearchRange(u32 beginRange, u32 endRange);
 
   std::vector<u32> getResultsConsoleAddr() const;
+  u32 getResultAddressAt(int index) const;
   size_t getResultCount() const;
   bool hasUndo() const;
   size_t getUndoCount() const;


### PR DESCRIPTION
Resolves https://github.com/aldelaro5/dolphin-memory-engine/issues/274

If a user was using a custom scan size > 1000 for displaying, it was easily possible to hang.
Undo was also hardcoded to 1000, this is now fixed.

Scan add/deletes are a lot quicker now - we are no longer re-drawing per cell change on a scan op.
A lot of O(n) -> O(1) 

* Bump CI to Ubuntu 24 since even Debian now uses Qt 6.4.2 (bump from Qt6.2)
* Force scrollbar on Reset/Undo because of a weird timing bug with AppImage