### PR TITLE
Add CMake build dir to .gitignore, added memory size config back, fix ARAM detection for GC games on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Source/.idea/*
 .DS_Store
 .vs/
 .vscode/
+build/

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "LinuxDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../../GUI/Settings/SConfig.h"
 
 #include <array>
 #include <cctype>
@@ -63,8 +64,11 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     std::string line;
     while (getline(mapsFile, line))
     {
-      if (line.find("/dev/shm/dolphin-emu") == std::string::npos &&
-          line.find("/dev/shm/dolphinmem") == std::string::npos)
+      if (  // Shared mappings
+          (line.find("/dev/shm/dolphin-emu") == std::string::npos &&
+           line.find("/dev/shm/dolphinmem") == std::string::npos) &&
+          // Anonymous mappings
+          (line.find("rw-p") == std::string::npos && line.find("00:00 0") == std::string::npos))
         continue;
 
       const std::vector<std::string> lineParts{Common::splitBySpace(line)};
@@ -104,7 +108,20 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -113,8 +130,16 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -129,8 +154,16 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }
@@ -140,24 +173,49 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
   {
     const u64 size{secondAddress - firstAddress};
 
-    if (m_ARAMSize && size == Common::NextPowerOf2(m_MEM1Size) &&
-        (offset & 0x00040000) == 0x00040000)
+    if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown() &&
+        size == dolphinOSGlobals.getARAMSize())
     {
-      m_emuARAMAdressStart = firstAddress;
-      m_ARAMAccessible = true;
-      break;
+      // Gamecube uses an anonymous private mmap.
+      // https://github.com/dolphin-emu/dolphin/blob/1bc93fd16d5a452bedcc5437923abd0d9fcb8c52/Source/Core/Core/HW/DSP.cpp#L138
+      // https://github.com/dolphin-emu/dolphin/blob/1bc93fd16d5a452bedcc5437923abd0d9fcb8c52/Source/Core/Common/MemoryUtil.cpp#L128
+      // ARAM dumps start with a common pattern of 02 9F 00 10 but only if the game
+      // initializes ARAM (it's all zeroes otherwise). Unsure if this is reliable
+      // to look for. Without this, the very first 16MiB sized mapping may not be
+      // ARAM, leading to a false postivie.
+      // TODO: There may be edge cases where this may fail. Most likely solution is other heuristics
+      // to look for?
+      u32 probe = 0;
+      ::readFromRAM(m_PID, firstAddress, 0, reinterpret_cast<char*>(&probe), sizeof(probe));
+      if (probe == 0x10009F02 || probe == 0x00000000)
+      {
+        m_emuARAMAdressStart = firstAddress;
+        m_ARAMAccessible = true;
+        break;
+      }
     }
-
-    if (m_MEM2Size && size == Common::NextPowerOf2(m_MEM2Size) &&
-        (offset & 0x00040000) == 0x00040000)
+    else
     {
-      m_MEM2AddressStart = firstAddress;
-      m_MEM2Present = true;
-      break;
-    }
+      // Wii uses a shared map for MEM2 and ARAM (ExRAM)
+      // TODO: Better heuristics for wii? Validating the memory for common patterns?
+      if (m_ARAMSize && size == Common::NextPowerOf2(m_MEM1Size) &&
+          (offset & 0x00040000) == 0x00040000)
+      {
+        m_emuARAMAdressStart = firstAddress;
+        m_ARAMAccessible = true;
+        break;
+      }
 
-    // TODO(CA): Ideally, we'd inspect the memory to try to determine whether it's pointing to the
-    // expected data, as opposed to relying on these fragile size and offset checks.
+      if (m_MEM2Size && size == Common::NextPowerOf2(m_MEM2Size) &&
+          (offset & 0x00040000) == 0x00040000)
+      {
+        m_MEM2AddressStart = firstAddress;
+        m_MEM2Present = true;
+        break;
+      }
+      // TODO(CA): Ideally, we'd inspect the memory to try to determine whether it's pointing to the
+      // expected data, as opposed to relying on these fragile size and offset checks.
+    }
   }
 
   return m_emuRAMAddressStart != 0;

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "MacDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../GUI/Settings/SConfig.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -124,7 +125,20 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -133,8 +147,16 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -149,8 +171,16 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "WindowsDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../GUI/Settings/SConfig.h"
 
 #include <Psapi.h>
 #ifdef UNICODE
@@ -132,7 +133,20 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -141,8 +155,16 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -157,8 +179,16 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -100,11 +100,49 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
     }
   });
 
+  QGroupBox* grbMemorySizeSettings = new QGroupBox("Memory Size settings");
+
+  m_lblMEM1Size = new QLabel();
+  m_lblMEM2Size = new QLabel();
+  m_sldMEM1Size = new QSlider(Qt::Horizontal);
+  m_sldMEM2Size = new QSlider(Qt::Horizontal);
+  connect(m_sldMEM1Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM1Size->setText(tr("%1 MB (MEM1)").arg(QString::number(slider_value)));
+  });
+  connect(m_sldMEM2Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM2Size->setText(tr("%1 MB (MEM2)").arg(QString::number(slider_value)));
+  });
+  m_sldMEM1Size->setRange(24, 64);
+  m_sldMEM2Size->setRange(64, 128);
+
+  m_chkAutoDetectMemory = new QCheckBox("Automatically detect MEM1 and MEM2 size");
+  connect(m_chkAutoDetectMemory, &QCheckBox::toggled, [this](bool checked) {
+    m_sldMEM1Size->setEnabled(!checked);
+    m_sldMEM2Size->setEnabled(!checked);
+    m_lblMEM1Size->setEnabled(!checked);
+    m_lblMEM2Size->setEnabled(!checked);
+  });
+
+  QHBoxLayout* MEM1Layout = new QHBoxLayout();
+  QHBoxLayout* MEM2Layout = new QHBoxLayout();
+  MEM1Layout->addWidget(m_sldMEM1Size);
+  MEM1Layout->addWidget(m_lblMEM1Size);
+  MEM2Layout->addWidget(m_sldMEM2Size);
+  MEM2Layout->addWidget(m_lblMEM2Size);
+
+  QVBoxLayout* memorySettingsInputLayout = new QVBoxLayout();
+  memorySettingsInputLayout->addWidget(m_chkAutoDetectMemory);
+  memorySettingsInputLayout->addLayout(MEM1Layout);
+  memorySettingsInputLayout->addLayout(MEM2Layout);
+
+  grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
+
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCoreSettings);
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbScannerSettings);
   mainLayout->addWidget(grbViewerSettings);
+  mainLayout->addWidget(grbMemorySizeSettings);
   mainLayout->addWidget(m_buttonsDlg);
   setLayout(mainLayout);
 
@@ -128,6 +166,15 @@ void DlgSettings::loadSettings()
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
   m_cmbTheme->setCurrentIndex(m_cmbTheme->findData(SConfig::getInstance().getTheme()));
+  // This erases fractional mebibyte sizes, but nobody should be using those anyway.
+  m_sldMEM1Size->setValue(static_cast<int>(SConfig::getInstance().getMEM1Size()) / 1024 / 1024);
+  m_sldMEM2Size->setValue(static_cast<int>(SConfig::getInstance().getMEM2Size()) / 1024 / 1024);
+  bool autoDetect = SConfig::getInstance().getAutoDetectMemorySize();
+  m_chkAutoDetectMemory->setChecked(autoDetect);
+  m_sldMEM1Size->setEnabled(!autoDetect);
+  m_sldMEM2Size->setEnabled(!autoDetect);
+  m_lblMEM1Size->setEnabled(!autoDetect);
+  m_lblMEM2Size->setEnabled(!autoDetect);
 }
 
 void DlgSettings::saveSettings() const
@@ -140,4 +187,7 @@ void DlgSettings::saveSettings() const
   SConfig::getInstance().setViewerNbrBytesSeparator(
       m_cmbViewerBytesSeparator->currentData().toInt());
   SConfig::getInstance().setTheme(m_cmbTheme->currentData().toInt());
+  SConfig::getInstance().setMEM1Size(m_sldMEM1Size->value() * 1024 * 1024);
+  SConfig::getInstance().setMEM2Size(m_sldMEM2Size->value() * 1024 * 1024);
+  SConfig::getInstance().setAutoDetectMemorySize(m_chkAutoDetectMemory->isChecked());
 }

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
 #include <QLabel>
@@ -31,4 +32,9 @@ private:
   QSpinBox* m_spnScannerShowThreshold;
   QComboBox* m_cmbViewerBytesSeparator;
   QDialogButtonBox* m_buttonsDlg;
+  QSlider* m_sldMEM1Size;
+  QSlider* m_sldMEM2Size;
+  QLabel* m_lblMEM1Size;
+  QLabel* m_lblMEM2Size;
+  QCheckBox* m_chkAutoDetectMemory;
 };

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -128,6 +128,21 @@ int SConfig::getViewerNbrBytesSeparator() const
   return value("viewerSettings/nbrBytesSeparator", 1).toInt();
 }
 
+u32 SConfig::getMEM1Size() const
+{
+  return value("memorySettings/MEM1Size", 24u * 1024 * 1024).toUInt();
+}
+
+u32 SConfig::getMEM2Size() const
+{
+  return value("memorySettings/MEM2Size", 64u * 1024 * 1024).toUInt();
+}
+
+bool SConfig::getAutoDetectMemorySize() const
+{
+  return value("memorySettings/autoDetectMemorySize", true).toBool();
+}
+
 void SConfig::setWatchModel(const QString& json)
 {
   setValue("watchModel", json);
@@ -191,6 +206,21 @@ void SConfig::setScannerShowThreshold(const int scannerShowThreshold)
 void SConfig::setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator)
 {
   setValue("viewerSettings/nbrBytesSeparator", viewerNbrBytesSeparator);
+}
+
+void SConfig::setMEM1Size(const u32 mem1SizeReal)
+{
+  setValue("memorySettings/MEM1Size", mem1SizeReal);
+}
+
+void SConfig::setMEM2Size(const u32 mem2SizeReal)
+{
+  setValue("memorySettings/MEM2Size", mem2SizeReal);
+}
+
+void SConfig::setAutoDetectMemorySize(const bool enabled)
+{
+  setValue("memorySettings/autoDetectMemorySize", enabled);
 }
 
 bool SConfig::getAutoloadLastFile() const

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -39,6 +39,9 @@ public:
   int getScannerUpdateTimerMs() const;
   int getViewerUpdateTimerMs() const;
   int getScannerShowThreshold() const;
+  u32 getMEM1Size() const;
+  u32 getMEM2Size() const;
+  bool getAutoDetectMemorySize() const;
 
   int getViewerNbrBytesSeparator() const;
 
@@ -57,6 +60,9 @@ public:
   void setScannerUpdateTimerMs(int scannerUpdateTimerMs);
   void setViewerUpdateTimerMs(int viewerUpdateTimerMs);
   void setScannerShowThreshold(int scannerShowThreshold);
+  void setMEM1Size(u32 mem1SizeReal);
+  void setMEM2Size(u32 mem2SizeReal);
+  void setAutoDetectMemorySize(bool enabled);
 
   void setViewerNbrBytesSeparator(int viewerNbrBytesSeparator);
 


### PR DESCRIPTION
- Added build/ to .gitnore to exclude CMake build output (as per README.md).
- Brought back the manual memory configuration with an automatic detection setting thats checked by default (for backwards compatibility with the automatic detection changes).
- Fixed ARAM detection for GameCube games (Dolphin uses an anonymous private memory map for this unlike for Wii where it is in ExRAM which is in a shared memory map). Linux only for now. I don't have a Windows nor a Mac machine to write the necessary changes for thos platforms.

The reason for bringing manual memory configuration back is that bi2.bin can lie and the BAT registers can also lie. Custom configurations of these are edge cases automatic detection fails at. Bringing back manual override for these edge cases (as an option) is the best solution here, else it'd be a fight of who is the right source of truth for how much memory there is. The automatic detection is still on by default, but can be turned off with manual size sliders as like before.

Further more, the ARAM detection being fixed only for Linux is because I do not have the necessary resources nor know-how to write for these platforms. I am sure there can be similar approaches done on Windows and Mac but I cannot write for these.

The .gitignore change is most logical as it matches the other auxiliary files from vscode and etc. that should be ignored. README.md directly mentions this directory so its only logical to exclude it (its simply CMake build output).