### PR TITLE
Add CMake build dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Source/.idea/*
 .DS_Store
 .vs/
 .vscode/
+build/


### PR DESCRIPTION
Added build/ to .gitnore to exclude CMake build output (as per README.md).

This is a very logical change to make. CMake build output are auxiliary files as much as .vscode and such are. Excluding this directory makes sense.