### PR TITLE
Add memory size config back

### DIFF
--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "LinuxDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../../GUI/Settings/SConfig.h"
 
 #include <array>
 #include <cctype>
@@ -104,7 +105,20 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -113,8 +127,16 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -129,8 +151,16 @@ bool LinuxDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = firstAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }

--- a/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
+++ b/Source/DolphinProcess/Mac/MacDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "MacDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../GUI/Settings/SConfig.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -124,7 +125,20 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -133,8 +147,16 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -149,8 +171,16 @@ bool MacDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = regionAddr;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }

--- a/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
+++ b/Source/DolphinProcess/Windows/WindowsDolphinProcess.cpp
@@ -3,6 +3,7 @@
 #include "WindowsDolphinProcess.h"
 #include "../../Common/CommonUtils.h"
 #include "../../Common/MemoryCommon.h"
+#include "../GUI/Settings/SConfig.h"
 
 #include <Psapi.h>
 #ifdef UNICODE
@@ -132,7 +133,20 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordGCKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      // SConfig::getMEM1Size and SConfig::getMEM2Size are not entirely safe but
+      // there is no way to figure out the actual memory size at runtime, as bi2.bin
+      // can lie (delibrately modified while BAT#U/BAT#L can be something else) and
+      // dolphin only writes settings to its INIs when closing. The automatic detection
+      // using bi2.bin is a safe fallback but edge cases of customized bi2.bin and modified
+      // BAT registers leads to improper sizes (missing valid memory in the memory view).
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+      }
+      else
+      {
+        m_MEM1Size = dolphinOSGlobals.getSimulatedMemorySize();
+      }
       m_ARAMSize = dolphinOSGlobals.getARAMSize();
       break;
     }
@@ -141,8 +155,16 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
     if (systemInfo.isDiscMagicWordWiiKnown() && systemInfo.isBootCodeKnown())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
 
@@ -157,8 +179,16 @@ bool WindowsDolphinProcess::obtainEmuRAMInformations()
         dolphinOSGlobals.getSimulatedMemorySize() == wiiSpecificInfo.getSimulatedMEM1Size())
     {
       m_emuRAMAddressStart = baseAddress;
-      m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
-      m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      if (!SConfig::getInstance().getAutoDetectMemorySize())
+      {
+        m_MEM1Size = SConfig::getInstance().getMEM1Size();
+        m_MEM2Size = SConfig::getInstance().getMEM2Size();
+      }
+      else
+      {
+        m_MEM1Size = wiiSpecificInfo.getSimulatedMEM1Size();
+        m_MEM2Size = wiiSpecificInfo.getSimulatedMEM2Size();
+      }
       break;
     }
   }

--- a/Source/GUI/Settings/DlgSettings.cpp
+++ b/Source/GUI/Settings/DlgSettings.cpp
@@ -100,11 +100,49 @@ DlgSettings::DlgSettings(QWidget* parent) : QDialog(parent)
     }
   });
 
+  QGroupBox* grbMemorySizeSettings = new QGroupBox("Memory Size settings");
+
+  m_lblMEM1Size = new QLabel();
+  m_lblMEM2Size = new QLabel();
+  m_sldMEM1Size = new QSlider(Qt::Horizontal);
+  m_sldMEM2Size = new QSlider(Qt::Horizontal);
+  connect(m_sldMEM1Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM1Size->setText(tr("%1 MB (MEM1)").arg(QString::number(slider_value)));
+  });
+  connect(m_sldMEM2Size, &QSlider::valueChanged, [this](int slider_value) {
+    m_lblMEM2Size->setText(tr("%1 MB (MEM2)").arg(QString::number(slider_value)));
+  });
+  m_sldMEM1Size->setRange(24, 64);
+  m_sldMEM2Size->setRange(64, 128);
+
+  m_chkAutoDetectMemory = new QCheckBox("Automatically detect MEM1 and MEM2 size");
+  connect(m_chkAutoDetectMemory, &QCheckBox::toggled, [this](bool checked) {
+    m_sldMEM1Size->setEnabled(!checked);
+    m_sldMEM2Size->setEnabled(!checked);
+    m_lblMEM1Size->setEnabled(!checked);
+    m_lblMEM2Size->setEnabled(!checked);
+  });
+
+  QHBoxLayout* MEM1Layout = new QHBoxLayout();
+  QHBoxLayout* MEM2Layout = new QHBoxLayout();
+  MEM1Layout->addWidget(m_sldMEM1Size);
+  MEM1Layout->addWidget(m_lblMEM1Size);
+  MEM2Layout->addWidget(m_sldMEM2Size);
+  MEM2Layout->addWidget(m_lblMEM2Size);
+
+  QVBoxLayout* memorySettingsInputLayout = new QVBoxLayout();
+  memorySettingsInputLayout->addWidget(m_chkAutoDetectMemory);
+  memorySettingsInputLayout->addLayout(MEM1Layout);
+  memorySettingsInputLayout->addLayout(MEM2Layout);
+
+  grbMemorySizeSettings->setLayout(memorySettingsInputLayout);
+
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->addWidget(grbCoreSettings);
   mainLayout->addWidget(grbTimerSettings);
   mainLayout->addWidget(grbScannerSettings);
   mainLayout->addWidget(grbViewerSettings);
+  mainLayout->addWidget(grbMemorySizeSettings);
   mainLayout->addWidget(m_buttonsDlg);
   setLayout(mainLayout);
 
@@ -128,6 +166,15 @@ void DlgSettings::loadSettings()
   m_cmbViewerBytesSeparator->setCurrentIndex(
       m_cmbViewerBytesSeparator->findData(SConfig::getInstance().getViewerNbrBytesSeparator()));
   m_cmbTheme->setCurrentIndex(m_cmbTheme->findData(SConfig::getInstance().getTheme()));
+  // This erases fractional mebibyte sizes, but nobody should be using those anyway.
+  m_sldMEM1Size->setValue(static_cast<int>(SConfig::getInstance().getMEM1Size()) / 1024 / 1024);
+  m_sldMEM2Size->setValue(static_cast<int>(SConfig::getInstance().getMEM2Size()) / 1024 / 1024);
+  bool autoDetect = SConfig::getInstance().getAutoDetectMemorySize();
+  m_chkAutoDetectMemory->setChecked(autoDetect);
+  m_sldMEM1Size->setEnabled(!autoDetect);
+  m_sldMEM2Size->setEnabled(!autoDetect);
+  m_lblMEM1Size->setEnabled(!autoDetect);
+  m_lblMEM2Size->setEnabled(!autoDetect);
 }
 
 void DlgSettings::saveSettings() const
@@ -140,4 +187,7 @@ void DlgSettings::saveSettings() const
   SConfig::getInstance().setViewerNbrBytesSeparator(
       m_cmbViewerBytesSeparator->currentData().toInt());
   SConfig::getInstance().setTheme(m_cmbTheme->currentData().toInt());
+  SConfig::getInstance().setMEM1Size(m_sldMEM1Size->value() * 1024 * 1024);
+  SConfig::getInstance().setMEM2Size(m_sldMEM2Size->value() * 1024 * 1024);
+  SConfig::getInstance().setAutoDetectMemorySize(m_chkAutoDetectMemory->isChecked());
 }

--- a/Source/GUI/Settings/DlgSettings.h
+++ b/Source/GUI/Settings/DlgSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialog>
 #include <QLabel>
@@ -31,4 +32,9 @@ private:
   QSpinBox* m_spnScannerShowThreshold;
   QComboBox* m_cmbViewerBytesSeparator;
   QDialogButtonBox* m_buttonsDlg;
+  QSlider* m_sldMEM1Size;
+  QSlider* m_sldMEM2Size;
+  QLabel* m_lblMEM1Size;
+  QLabel* m_lblMEM2Size;
+  QCheckBox* m_chkAutoDetectMemory;
 };

--- a/Source/GUI/Settings/SConfig.cpp
+++ b/Source/GUI/Settings/SConfig.cpp
@@ -128,6 +128,21 @@ int SConfig::getViewerNbrBytesSeparator() const
   return value("viewerSettings/nbrBytesSeparator", 1).toInt();
 }
 
+u32 SConfig::getMEM1Size() const
+{
+  return value("memorySettings/MEM1Size", 24u * 1024 * 1024).toUInt();
+}
+
+u32 SConfig::getMEM2Size() const
+{
+  return value("memorySettings/MEM2Size", 64u * 1024 * 1024).toUInt();
+}
+
+bool SConfig::getAutoDetectMemorySize() const
+{
+  return value("memorySettings/autoDetectMemorySize", true).toBool();
+}
+
 void SConfig::setWatchModel(const QString& json)
 {
   setValue("watchModel", json);
@@ -191,6 +206,21 @@ void SConfig::setScannerShowThreshold(const int scannerShowThreshold)
 void SConfig::setViewerNbrBytesSeparator(const int viewerNbrBytesSeparator)
 {
   setValue("viewerSettings/nbrBytesSeparator", viewerNbrBytesSeparator);
+}
+
+void SConfig::setMEM1Size(const u32 mem1SizeReal)
+{
+  setValue("memorySettings/MEM1Size", mem1SizeReal);
+}
+
+void SConfig::setMEM2Size(const u32 mem2SizeReal)
+{
+  setValue("memorySettings/MEM2Size", mem2SizeReal);
+}
+
+void SConfig::setAutoDetectMemorySize(const bool enabled)
+{
+  setValue("memorySettings/autoDetectMemorySize", enabled);
 }
 
 bool SConfig::getAutoloadLastFile() const

--- a/Source/GUI/Settings/SConfig.h
+++ b/Source/GUI/Settings/SConfig.h
@@ -39,6 +39,9 @@ public:
   int getScannerUpdateTimerMs() const;
   int getViewerUpdateTimerMs() const;
   int getScannerShowThreshold() const;
+  u32 getMEM1Size() const;
+  u32 getMEM2Size() const;
+  bool getAutoDetectMemorySize() const;
 
   int getViewerNbrBytesSeparator() const;
 
@@ -57,6 +60,9 @@ public:
   void setScannerUpdateTimerMs(int scannerUpdateTimerMs);
   void setViewerUpdateTimerMs(int viewerUpdateTimerMs);
   void setScannerShowThreshold(int scannerShowThreshold);
+  void setMEM1Size(u32 mem1SizeReal);
+  void setMEM2Size(u32 mem2SizeReal);
+  void setAutoDetectMemorySize(bool enabled);
 
   void setViewerNbrBytesSeparator(int viewerNbrBytesSeparator);
 


### PR DESCRIPTION
Brings back the manual memory configuration with an automatic detection setting thats checked by default (for backwards compatibility with the automatic detection changes).

The reasoning: bi2.bin which contains osArenaLo and osArenaHi can be manipulated to report values that can differ from the BAT#U and BAT#L registers and vice versa. One would set Dolphin's memory override to match this. For example, the bi2.bin can set osArenaHi as 66060288 (63 MiB) where BAT0L/BAT0U and BAT2L/BAT2U can be 32 MiB + 32 MiB (64 MiB) and Dolphin memory override is set to 64 MiB. This leads to DME ending its memory view at 83F00000 (66060288, 63 MiB) instead of 0x84000000 (67108864, 64 MiB). A manual override as an optional configurable fallback will act as the Dolphin memory override does, fixing this issue for this edge case.

Further more,epending on Dolphin's INI structures is not reliable as Dolphin only writes to its INIs when it closes. If DME were to use INI settings to get the memory override set in Dolphin and the memory override is changed between game launches, DME cannot know of it until Dolphin closes and reopens.

In a case where the source of information for memory sizes is unreliable, a fallback (optional) slider is a good enough workaround. I admit, the previous slider is not as safe (it can, like bi2.bin and BAT, be manipulated to values that don't match), and I simply just brought it back with a toggable setting to toggle it (default to on/true so previously functionality is not interrupted) but there does not seem to be a way to safe guard these sliders. It simply is a fix to this edge case which I do not know of any other solution.

Finally, yes, the memory override technically is a fix for the ARAM detection problem on GameCube but that is not the intent. I have a separate fix for that. Yes, indeed, if memory reports as 83F00000 to DME but its actually 84000000 behind the scenes, then my ARAM fix (#280) will fail and this PR with a memory override of 64 MiB fixes this bug but again that is not a bug this PR is intended to fix.

I understand there may be a desire to keep the settings UI clean/simple and for DME functionality to continue to be reliable. I am open to any other ways this can be done or for this to be dropped and another path forward to fix this problem.