### PR TITLE
Qt6.8.3 for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.5.3\x64"
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.8.3\x64"
           cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
         shell: powershell
 

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.5.3\x64"
+          cmake Source -B .\Source\bin -A x64 "-DCMAKE_PREFIX_PATH=..\Externals\Qt\Qt6.8.3\x64"
           cmake --build .\Source\bin --config ${{ matrix.configuration }} --parallel
         shell: powershell
 

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -84,7 +84,7 @@ if (WIN32)
     find_package(Qt6Widgets QUIET)
 	  if (NOT Qt6Widgets_FOUND)
 		    message(STATUS "Qt package not found, using external lib")
-		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.5.3\\x64")
+		    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}\\..\\Externals\\Qt\\Qt6.8.3\\x64")
 		    find_package(Qt6Widgets REQUIRED)
 	  endif ()
 else ()
@@ -182,7 +182,7 @@ if(WIN32)
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
         TARGET dolphin-memory-engine POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:Qt6::QWindowsVistaStylePlugin>
+            $<TARGET_FILE:Qt6::QModernWindowsStylePlugin>
             $<TARGET_FILE_DIR:dolphin-memory-engine>/styles
     )
 endif(WIN32)


### PR DESCRIPTION
Dolphin is also migrating off Qt6.5.1 (we were on Qt6.5.3 for several years) - aligning and adding the ARM64 blobs as well thanks to AdmiralCurtiss.

Other than to align with Dolphin, our CI for windows recently started failing after windows-latest started failing building Qt6.5.3. It's time to migrate.