### PR TITLE
Use aqtinstall (Qt 6.11.1) for GitHub workflows on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,28 +124,25 @@ jobs:
           path: dolphin-memory-engine.AppImage
 
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     name: 🍎 macOS
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      # Current Runner has cmake we want by default; Omitting for now but restore if they stop bundling it
-      # - name: Install Dependencies
-      #   run: |
-      #     brew install --formula cmake
-      #   shell: bash
-
-      - name: Initialize submodules
-        run: git submodule update --init
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.1'
+          archives: 'qtbase qtsvg'
 
       - name: Build
         run: |
           mkdir Source/build
           cd Source/build
           cmake .. \
-            -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
+            -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -143,15 +143,18 @@ jobs:
             dolphin-memory-engine-${{ github.ref_name }}-linux-x86_64-binary.tar.gz
 
   build-macos:
-    runs-on: macos-15
+    runs-on: macos-26
     name: 🍎 macOS (TAG)
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Initialize submodules
-        run: git submodule update --init
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.11.1'
+          archives: 'qtbase qtsvg'
         
       - name: Set APP_VERSION for tags
         run: echo "APP_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
@@ -161,7 +164,7 @@ jobs:
           mkdir -p Source/build
           cd Source/build
           cmake .. \
-            -DCMAKE_PREFIX_PATH="$(realpath ../../Externals/Qt-macOS)" \
+            -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
             -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           make
           echo -e "\n" | ../../Tools/MacDeploy.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Externals/Qt-macOS"]
-	path = Externals/Qt-macOS
-	url = https://github.com/campital/ext-macos-qt-dme
 [submodule "Externals/Qt"]
 	path = Externals/Qt
 	url = https://github.com/dreamsyntax/dme-ext-win-qt.git

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(GCC_min_version 10)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0")
 project(dolphin-memory-engine)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/Tools/MacDeploy.sh
+++ b/Tools/MacDeploy.sh
@@ -7,4 +7,4 @@ read -r package_
 if [ ! -z "$package_" ]; then package="$package_"; fi
 
 cd "$package/.."
-"$project_root/Externals/Qt-macOS/bin/macdeployqt" "$(basename "$package")" -dmg -codesign=-
+"$QT_ROOT_DIR/bin/macdeployqt" "$(basename "$package")" -dmg -codesign=-


### PR DESCRIPTION
- Updated the workflow runner to macOS 26.
- Workflow now uses `aqtinstall` to install a stripped version of Qt 6.11.1 on Mac.
- Removed the `Qt-macOS` submodule.
- Now targets macOS 12.0.

In the future, we could use this approach to build on Windows and Linux as well. Held off on the other CMake changes I mentioned in https://github.com/aldelaro5/dolphin-memory-engine/pull/271#issuecomment-4777236968.